### PR TITLE
Backend hardening: logging cleanup, rate limiting, webhook signatures

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -11,6 +11,55 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from starlette.middleware.base import BaseHTTPMiddleware
 
 
+class LoginRateLimiter:
+    """Per-IP brute force protection — lockout after N failures within a window."""
+
+    MAX_ATTEMPTS = 5
+    WINDOW_SECONDS = 900   # 15 minutes
+    LOCKOUT_SECONDS = 900  # 15-minute lockout
+
+    def __init__(self):
+        # {ip: {"count": int, "first_attempt": datetime, "locked_until": datetime|None}}
+        self._attempts: Dict[str, Dict] = {}
+
+    def _client_ip(self, request: Request) -> str:
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+        return request.client.host if request.client else "unknown"
+
+    def is_locked(self, request: Request) -> bool:
+        ip = self._client_ip(request)
+        record = self._attempts.get(ip)
+        if not record:
+            return False
+        if record.get("locked_until") and datetime.utcnow() < record["locked_until"]:
+            return True
+        # Expired lockout — clear it
+        if record.get("locked_until") and datetime.utcnow() >= record["locked_until"]:
+            del self._attempts[ip]
+        return False
+
+    def record_failure(self, request: Request) -> None:
+        ip = self._client_ip(request)
+        now = datetime.utcnow()
+        record = self._attempts.setdefault(ip, {"count": 0, "first_attempt": now, "locked_until": None})
+
+        # Reset window if it has expired
+        if (now - record["first_attempt"]).total_seconds() > self.WINDOW_SECONDS:
+            record["count"] = 0
+            record["first_attempt"] = now
+            record["locked_until"] = None
+
+        record["count"] += 1
+        if record["count"] >= self.MAX_ATTEMPTS:
+            record["locked_until"] = now + timedelta(seconds=self.LOCKOUT_SECONDS)
+
+    def record_success(self, request: Request) -> None:
+        ip = self._client_ip(request)
+        self._attempts.pop(ip, None)
+
+
 class AuthSession:
     """Simple session management for web interface"""
     
@@ -77,6 +126,7 @@ class SimpleAuthMiddleware(BaseHTTPMiddleware):
         self.config = config
         self.session_manager = session_manager or AuthSession(config.web_auth_session_timeout)
         self.security = HTTPBasic()
+        self.rate_limiter = LoginRateLimiter()
         
         # Routes that are always public — everything else requires auth when enabled.
         # Webhooks must be public so Radarr/Sonarr can call them without credentials.
@@ -116,9 +166,15 @@ class SimpleAuthMiddleware(BaseHTTPMiddleware):
         # Check for HTTP Basic Auth
         auth_header = request.headers.get("authorization")
         if auth_header and auth_header.startswith("Basic "):
+            if self.rate_limiter.is_locked(request):
+                return Response(
+                    content="Too many failed login attempts — try again later",
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    headers={"Retry-After": str(LoginRateLimiter.LOCKOUT_SECONDS)},
+                )
             credentials = self._parse_basic_auth(auth_header)
             if credentials and self._validate_credentials(credentials.username, credentials.password):
-                # Create session for successful login
+                self.rate_limiter.record_success(request)
                 session_token = self.session_manager.create_session(credentials.username)
                 response = await call_next(request)
                 response.set_cookie(
@@ -130,7 +186,9 @@ class SimpleAuthMiddleware(BaseHTTPMiddleware):
                     samesite="lax",
                 )
                 return response
-        
+            else:
+                self.rate_limiter.record_failure(request)
+
         # Authentication required
         return self._auth_required_response()
     

--- a/api/routes.py
+++ b/api/routes.py
@@ -2,6 +2,8 @@
 FastAPI routes for Chronarr - extracted from main chronarr.py for modular architecture
 """
 import os
+import hmac
+import hashlib
 import json
 import requests
 import asyncio
@@ -58,6 +60,22 @@ async def _read_payload(request: Request) -> dict:
 
 
 # ---------------------------
+# Webhook signature verification
+# ---------------------------
+
+async def _verify_webhook_signature(request: Request, body: bytes, secret: str, header_name: str) -> None:
+    """Verify HMAC-SHA256 webhook signature. Raises 403 if invalid, skips if no secret configured."""
+    if not secret:
+        return
+    sig_header = request.headers.get(header_name, "")
+    if not sig_header:
+        raise HTTPException(status_code=403, detail="Missing webhook signature")
+    expected = "sha256=" + hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, sig_header):
+        raise HTTPException(status_code=403, detail="Invalid webhook signature")
+
+
+# ---------------------------
 # Route Handlers
 # ---------------------------
 
@@ -66,8 +84,10 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
     tv_processor = dependencies["tv_processor"]
     batcher = dependencies["batcher"]
     config = dependencies["config"]
-    
+
     try:
+        body = await request.body()
+        await _verify_webhook_signature(request, body, config.sonarr_webhook_secret, "X-Sonarr-Signature")
         payload = await _read_payload(request)
         if not payload:
             raise HTTPException(status_code=422, detail="Empty Sonarr payload")
@@ -104,9 +124,9 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         
         # For all webhook events, if no episodes in webhook.episodes, try to extract from episodeFile
         # This ensures targeted processing for single episode operations (Download, Rename, Upgrade)
-        print(f"DEBUG: webhook.episodeFile present: {webhook.episodeFile is not None}")
+        _log("DEBUG", f"webhook.episodeFile present: {webhook.episodeFile is not None}")
         if webhook.episodeFile:
-            print(f"DEBUG: episodeFile content: {webhook.episodeFile}")
+            _log("DEBUG", f"episodeFile content: {webhook.episodeFile}")
         
         if not episodes_data and webhook.episodeFile:
             episode_file = webhook.episodeFile
@@ -120,17 +140,17 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                 
                 # Try relativePath first, then path
                 file_path = episode_file.get("relativePath") or episode_file.get("path", "")
-                print(f"DEBUG: Parsing episode info from path: {file_path}")
+                _log("DEBUG", f"Parsing episode info from path: {file_path}")
                 
                 episode_info = extract_episode_info_from_filename(file_path)
                 if episode_info:
                     season_num = episode_info["season"]
                     episode_num = episode_info["episode"]
-                    print(f"DEBUG: Extracted from filename - Season: {season_num}, Episode: {episode_num}")
+                    _log("DEBUG", f"Extracted from filename - Season: {season_num}, Episode: {episode_num}")
                 else:
-                    print(f"DEBUG: Could not extract season/episode from filename: {file_path}")
+                    _log("DEBUG", f"Could not extract season/episode from filename: {file_path}")
             
-            print(f"DEBUG: episodeFile seasonNumber: {season_num}, episodeNumber: {episode_num}")
+            _log("DEBUG", f"episodeFile seasonNumber: {season_num}, episodeNumber: {episode_num}")
             if season_num and episode_num:
                 # Create episode data structure that matches what process_webhook_episodes expects
                 episodes_data = [{
@@ -142,35 +162,35 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                 }]
                 _log("INFO", f"Extracted episode info from episodeFile for {webhook.eventType}: S{season_num:02d}E{episode_num:02d}")
             else:
-                print(f"DEBUG: Missing season/episode numbers in episodeFile for {webhook.eventType}")
+                _log("DEBUG", f"Missing season/episode numbers in episodeFile for {webhook.eventType}")
         
         # Special handling for Rename events - Sonarr doesn't include episodeFile for renames
         # Try to find recently renamed episodes using Sonarr history API
         if not episodes_data and webhook.eventType == "Rename":
-            print(f"DEBUG: Attempting to find recently renamed episode for series {imdb_id}")
+            _log("DEBUG", f"Attempting to find recently renamed episode for series {imdb_id}")
             try:
                 # Get series info from Sonarr to find series ID
                 series_lookup_url = f"{config.sonarr_url}/api/v3/series/lookup?term=imdbid:{imdb_id}"
-                print(f"DEBUG: Sonarr lookup for rename: {series_lookup_url}")
+                _log("DEBUG", f"Sonarr lookup for rename: {series_lookup_url}")
                 
                 response = requests.get(series_lookup_url, headers={"X-Api-Key": os.environ.get("SONARR_API_KEY", "")}, timeout=10)
                 if response.status_code == 200:
                     series_results = response.json()
                     if series_results:
                         series_id = series_results[0].get("id")
-                        print(f"DEBUG: Found series ID {series_id} for rename lookup")
+                        _log("DEBUG", f"Found series ID {series_id} for rename lookup")
                         
                         # Get recent history for the series and filter for rename events
                         from datetime import datetime, timedelta
                         since_date = (datetime.utcnow() - timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
                         history_url = f"{config.sonarr_url}/api/v3/history?seriesId={series_id}&sortKey=date&sortDir=desc&page=1&pageSize=50"
-                        print(f"DEBUG: Checking recent rename history: {history_url}")
+                        _log("DEBUG", f"Checking recent rename history: {history_url}")
                         
                         history_response = requests.get(history_url, headers={"X-Api-Key": os.environ.get("SONARR_API_KEY", "")}, timeout=10)
                         if history_response.status_code == 200:
                             history_data = history_response.json()
                             all_records = history_data.get("records", [])
-                            print(f"DEBUG: Got {len(all_records)} total history records")
+                            _log("DEBUG", f"Got {len(all_records)} total history records")
                             
                             # Filter for recent rename events
                             since_timestamp = datetime.utcnow() - timedelta(hours=1)
@@ -190,16 +210,16 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                                         # If datetime parsing fails, include it anyway
                                         recent_renames.append(record)
                             
-                            print(f"DEBUG: Found {len(recent_renames)} recent rename events")
+                            _log("DEBUG", f"Found {len(recent_renames)} recent rename events")
                             
                             if recent_renames:
                                 # Take the most recent rename event
                                 latest_rename = recent_renames[0]
-                                print(f"DEBUG: Processing latest rename event")
+                                _log("DEBUG", f"Processing latest rename event")
                                 
                                 # Extract episodeId directly from the rename event
                                 episode_id = latest_rename.get("episodeId")
-                                print(f"DEBUG: Found episodeId {episode_id} in rename event")
+                                _log("DEBUG", f"Found episodeId {episode_id} in rename event")
                                 
                                 if episode_id:
                                     # Fetch episode details using the episodeId
@@ -212,7 +232,7 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                                         episode_num = episode_detail.get("episodeNumber")
                                         episode_title = episode_detail.get("title")
                                         
-                                        print(f"DEBUG: Episode details - Season: {season_num}, Episode: {episode_num}, Title: {episode_title}")
+                                        _log("DEBUG", f"Episode details - Season: {season_num}, Episode: {episode_num}, Title: {episode_title}")
                                         
                                         if season_num is not None and episode_num is not None:
                                             episodes_data = [{
@@ -223,21 +243,21 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                                             }]
                                             print(f"INFO: Successfully identified renamed episode: S{season_num:02d}E{episode_num:02d} - {episode_title}")
                                         else:
-                                            print(f"DEBUG: Episode details missing season/episode numbers")
+                                            _log("DEBUG", f"Episode details missing season/episode numbers")
                                     else:
-                                        print(f"DEBUG: Failed to fetch episode details: {episode_response.status_code}")
+                                        _log("DEBUG", f"Failed to fetch episode details: {episode_response.status_code}")
                                 else:
-                                    print(f"DEBUG: No episodeId found in rename event")
+                                    _log("DEBUG", f"No episodeId found in rename event")
                             else:
-                                print(f"DEBUG: No recent rename events found in last hour")
+                                _log("DEBUG", f"No recent rename events found in last hour")
                         else:
-                            print(f"DEBUG: Failed to get rename history: {history_response.status_code}")
+                            _log("DEBUG", f"Failed to get rename history: {history_response.status_code}")
                     else:
-                        print(f"DEBUG: No series found for IMDb {imdb_id}")
+                        _log("DEBUG", f"No series found for IMDb {imdb_id}")
                 else:
-                    print(f"DEBUG: Series lookup failed: {response.status_code}")
+                    _log("DEBUG", f"Series lookup failed: {response.status_code}")
             except Exception as e:
-                print(f"DEBUG: Error finding renamed episode: {e}")
+                _log("DEBUG", f"Error finding renamed episode: {e}")
                 # Continue with series processing as fallback
         
         # Force targeted mode for single-episode webhooks to prevent full series processing
@@ -268,8 +288,11 @@ async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, de
     """Handle Radarr webhooks"""
     path_mapper = dependencies["path_mapper"]
     batcher = dependencies["batcher"]
-    
+    config = dependencies["config"]
+
     try:
+        body = await request.body()
+        await _verify_webhook_signature(request, body, config.radarr_webhook_secret, "X-Radarr-Signature")
         payload = await _read_payload(request)
         _log("INFO", f"Received Radarr webhook: {payload.get('eventType', 'Unknown')}")
         _log("DEBUG", f"Full Radarr webhook payload: {payload}")
@@ -545,7 +568,7 @@ async def health(dependencies: dict) -> HealthResponse:
                     overall_status = "degraded"
     except Exception as e:
         # If movie processor isn't available, skip database health check
-        print(f"DEBUG: Skipping Radarr database health check: {e}")
+        _log("DEBUG", f"Skipping Radarr database health check: {e}")
     
     return HealthResponse(
         status=overall_status,
@@ -579,7 +602,7 @@ async def debug_movie_import_date(imdb_id: str, dependencies: dict):
         if not imdb_id.startswith("tt"):
             imdb_id = f"tt{imdb_id}"
             
-        print(f"INFO: === DEBUG MOVIE IMPORT DATE: {imdb_id} ===")
+        _log("DEBUG", f"=== MOVIE IMPORT DATE: {imdb_id} ===")
         
         if not (os.environ.get("RADARR_URL") and os.environ.get("RADARR_API_KEY")):
             return {
@@ -795,12 +818,12 @@ async def manual_scan(background_tasks: BackgroundTasks, path: Optional[str] = N
             # Handle the common Docker volume mount: /mnt/unionfs/Media/ -> /media/
             if path_str.startswith('/mnt/unionfs/Media/'):
                 container_path = path_str.replace('/mnt/unionfs/Media/', '/media/')
-                print(f"DEBUG: Translated host path '{path_str}' to container path '{container_path}'")
+                _log("DEBUG", f"Translated host path '{path_str}' to container path '{container_path}'")
                 return container_path
             # Handle case where user enters /Media/ instead of /media/ (case sensitivity)
             elif path_str.startswith('/Media/'):
                 container_path = path_str.replace('/Media/', '/media/')
-                print(f"DEBUG: Fixed case sensitivity '{path_str}' to container path '{container_path}'")
+                _log("DEBUG", f"Fixed case sensitivity '{path_str}' to container path '{container_path}'")
                 return container_path
             return path_str
         
@@ -809,7 +832,7 @@ async def manual_scan(background_tasks: BackgroundTasks, path: Optional[str] = N
             # Translate the provided path from host format to container format
             translated_path = translate_host_path_to_container(path)
             paths_to_scan = [Path(translated_path)]
-            print(f"DEBUG: Manual scan with specific path: {path} -> {translated_path}")
+            _log("DEBUG", f"Manual scan with specific path: {path} -> {translated_path}")
         else:
             if scan_type in ["both", "tv"]:
                 paths_to_scan.extend(config.tv_paths)
@@ -817,17 +840,17 @@ async def manual_scan(background_tasks: BackgroundTasks, path: Optional[str] = N
                 paths_to_scan.extend(config.movie_paths)
         
         for scan_path in paths_to_scan:
-            print(f"DEBUG: Checking scan_path: {scan_path}, exists: {scan_path.exists()}")
+            _log("DEBUG", f"Checking scan_path: {scan_path}, exists: {scan_path.exists()}")
             if not scan_path.exists():
-                print(f"DEBUG: Path does not exist, skipping: {scan_path}")
+                _log("DEBUG", f"Path does not exist, skipping: {scan_path}")
                 continue
                 
-            print(f"DEBUG: scan_type={scan_type}, path={path}, scan_path in tv_paths: {scan_path in config.tv_paths}")
+            _log("DEBUG", f"scan_type={scan_type}, path={path}, scan_path in tv_paths: {scan_path in config.tv_paths}")
             if scan_type in ["both", "tv"] and (scan_path in config.tv_paths or path):
                 # Handle specific season/episode path
-                print(f"DEBUG: Entered TV processing branch")
+                _log("DEBUG", f"Entered TV processing branch")
                 if path and scan_path.name.lower().startswith('season'):
-                    print(f"DEBUG: Taking season processing path")
+                    _log("DEBUG", f"Taking season processing path")
                     # Single season processing
                     series_path = scan_path.parent
                     tv_processor_obj = dependencies.get("tv_processor")
@@ -840,7 +863,7 @@ async def manual_scan(background_tasks: BackgroundTasks, path: Optional[str] = N
                         except Exception as e:
                             print(f"ERROR: Failed processing season {scan_path}: {e}")
                 elif path and scan_path.is_file() and scan_path.suffix.lower() in ('.mkv', '.mp4', '.avi'):
-                    print(f"DEBUG: Taking single episode processing path")
+                    _log("DEBUG", f"Taking single episode processing path")
                     # Single episode processing
                     season_path = scan_path.parent
                     series_path = season_path.parent
@@ -854,18 +877,18 @@ async def manual_scan(background_tasks: BackgroundTasks, path: Optional[str] = N
                         except Exception as e:
                             print(f"ERROR: Failed processing episode {scan_path}: {e}")
                 else:
-                    print(f"DEBUG: Taking series processing path")
+                    _log("DEBUG", f"Taking series processing path")
                     # Check if this path itself is a series (has IMDb ID in directory name or NFO files)
                     tv_processor_obj = dependencies.get("tv_processor")
                     sonarr_client = tv_processor_obj.sonarr if tv_processor_obj and hasattr(tv_processor_obj, 'sonarr') else None
                     shutdown_event = dependencies.get("shutdown_event")
                     imdb_id = nfo_manager.parse_imdb_from_path_with_nfo_fallback(scan_path, sonarr_client, shutdown_event)
-                    print(f"DEBUG: Manual scan IMDb detection for {scan_path}: {imdb_id}")
+                    _log("DEBUG", f"Manual scan IMDb detection for {scan_path}: {imdb_id}")
                     if imdb_id:
                         try:
                             # Determine force_scan based on scan mode
                             force_scan = (scan_mode == "full")
-                            print(f"DEBUG: Processing series {scan_path} with force_scan={force_scan}, scan_mode={scan_mode}")
+                            _log("DEBUG", f"Processing series {scan_path} with force_scan={force_scan}, scan_mode={scan_mode}")
                             result = tv_processor.process_series(scan_path, force_scan=force_scan, scan_mode=scan_mode)
                             tv_series_total += 1
                             if result == "skipped":
@@ -1848,7 +1871,7 @@ async def verify_nfo_sync(dependencies: dict, media_type: str = "both"):
             "episodes": {"total": 0, "verified": 0, "missing_nfo": 0, "date_mismatch": 0, "empty_nfo": 0, "issues": []}
         }
         
-        print(f"🔍 NFO VERIFICATION STARTED: Checking {media_type}")
+        _log("DEBUG", f"NFO VERIFICATION STARTED: Checking {media_type}")
         
         # Verify Movies
         if media_type in ["both", "movies"]:
@@ -2283,7 +2306,7 @@ async def backfill_movie_release_dates(dependencies: dict):
             source = movie['source']
             
             try:
-                print(f"🔍 Processing {imdb_id} (source: {source})")
+                _log("DEBUG", f"Processing {imdb_id} (source: {source})")
                 
                 # Try to get release date based on the source
                 release_date = None
@@ -2515,7 +2538,7 @@ async def lookup_episode(imdb_id: str, season: int, episode: int, dependencies: 
     Used by Emby plugin to populate missing dateadded elements in NFO files.
     """
     try:
-        print(f"DEBUG: Episode lookup called for {imdb_id} S{season:02d}E{episode:02d}")
+        _log("DEBUG", f"Episode lookup called for {imdb_id} S{season:02d}E{episode:02d}")
         
         db = dependencies.get("db")
         if not db:
@@ -2526,12 +2549,12 @@ async def lookup_episode(imdb_id: str, season: int, episode: int, dependencies: 
         if not imdb_id.startswith('tt'):
             imdb_id = f"tt{imdb_id}"
         
-        print(f"DEBUG: Querying database for episode {imdb_id} S{season:02d}E{episode:02d}")
+        _log("DEBUG", f"Querying database for episode {imdb_id} S{season:02d}E{episode:02d}")
         
         # Query database for episode
         result = db.get_episode_date(imdb_id, season, episode)
         
-        print(f"DEBUG: Database query result: {result}")
+        _log("DEBUG", f"Database query result: {result}")
         
         if result and result.get('dateadded'):
             # Format response for Emby plugin
@@ -3194,7 +3217,7 @@ def register_routes(app, dependencies: dict):
             
             # Find all NFO files in TV directory
             if os.path.exists(tv_path):
-                print("🔍 Finding all TV NFO files...")
+                _log("DEBUG", "Finding all TV NFO files...")
                 try:
                     # Use find to get all NFO files
                     find_result = subprocess.run(
@@ -3233,9 +3256,9 @@ def register_routes(app, dependencies: dict):
                                     
                                     # Log specific files we're looking for
                                     if 'Hudson' in nfo_file and 'S08E05' in nfo_file:
-                                        print(f"🔍 FOUND MISSING: Hudson & Rex S08E05 at {nfo_file}")
+                                        _log("DEBUG", f"FOUND MISSING: Hudson & Rex S08E05 at {nfo_file}")
                                     if 'Star Trek' in nfo_file and 'S03E07' in nfo_file:
-                                        print(f"🔍 FOUND MISSING: Star Trek SNW S03E07 at {nfo_file}")
+                                        _log("DEBUG", f"FOUND MISSING: Star Trek SNW S03E07 at {nfo_file}")
                                         
                             except subprocess.TimeoutExpired:
                                 print(f"⏰ Timeout checking {nfo_file}")
@@ -3384,7 +3407,7 @@ def register_routes(app, dependencies: dict):
             
             # Find all NFO files in Movie directory
             if os.path.exists(movie_path):
-                print(f"🔍 Finding all Movie NFO files in {movie_path}...")
+                _log("DEBUG", f"Finding all Movie NFO files in {movie_path}...")
                 try:
                     # Use find to get all NFO files
                     find_result = subprocess.run(
@@ -3477,7 +3500,7 @@ def register_routes(app, dependencies: dict):
                     continue
             
             # Database lookup to get actual dateadded values for missing items
-            print("🔍 Looking up dateadded values from database for missing items...")
+            _log("DEBUG", "Looking up dateadded values from database for missing items...")
             
             # Enhance episodes with database data
             episodes_with_dates = 0
@@ -3591,7 +3614,7 @@ def register_routes(app, dependencies: dict):
             print(f"✅ NFO repair scan complete:")
             print(f"   📄 {total_nfo_files_missing} NFO files missing dateadded elements")
             print(f"   🎬 {len(missing_tv_nfo_files)} TV episodes, {len(missing_movie_nfo_files)} movies")
-            print(f"   🔍 {total_with_imdb_and_db} items with IMDb IDs found in database (can be fixed)")
+            _log("DEBUG", f"{total_with_imdb_and_db} items with IMDb IDs found in database (can be fixed)")
             
             return {
                 "status": "success",
@@ -3655,7 +3678,7 @@ def register_routes(app, dependencies: dict):
         total_episodes = len(missing_items["episodes"])
         total_movies = len(missing_items["movies"])
         
-        print(f"🔍 Found {total_episodes} episodes and {total_movies} movies to fix")
+        _log("DEBUG", f"Found {total_episodes} episodes and {total_movies} movies to fix")
         
         fixed_count = 0
         failed_count = 0

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException, Query, BackgroundTasks
 from pathlib import Path
 
 from api.models import *
+from utils.logging import _log
 
 
 # Status file for cross-process communication
@@ -569,7 +570,7 @@ async def update_movie_date(dependencies: dict, imdb_id: str, dateadded: Optiona
     db = dependencies["db"]
     
     # Debug logging to track the issue
-    print(f"🔍 UPDATE_MOVIE_DATE: imdb_id={imdb_id}, dateadded={dateadded}, source={source}")
+    _log("DEBUG", f"UPDATE_MOVIE_DATE: imdb_id={imdb_id}, dateadded={dateadded}, source={source}")
     print(f"   - dateadded type: {type(dateadded)}")
     print(f"   - dateadded repr: {repr(dateadded)}")
     
@@ -626,7 +627,7 @@ async def update_episode_date(dependencies: dict, imdb_id: str, season: int, epi
     """Update dateadded for a specific episode"""
     db = dependencies["db"]
     
-    print(f"🔍 DEBUG: update_episode_date called with dateadded={repr(dateadded)}, source={repr(source)}")
+    _log("DEBUG", f"update_episode_date called with dateadded={repr(dateadded)}, source={repr(source)}")
     
     # Get existing episode
     episode_data = db.get_episode_date(imdb_id, season, episode)
@@ -641,9 +642,9 @@ async def update_episode_date(dependencies: dict, imdb_id: str, season: int, epi
             dateadded = aired_date.isoformat() + "T20:00:00"  # Set to 8 PM on air date
         else:
             dateadded = str(aired_date) + "T20:00:00"
-        print(f"🔍 DEBUG: Using air date as dateadded: {dateadded}")
+        _log("DEBUG", f"Using air date as dateadded: {dateadded}")
     
-    print(f"🔍 DEBUG: Final dateadded value: {repr(dateadded)}")
+    _log("DEBUG", f"Final dateadded value: {repr(dateadded)}")
     
     # Update the date
     db.upsert_episode_date(
@@ -774,7 +775,7 @@ async def get_movie_date_options(dependencies: dict, imdb_id: str):
         raise HTTPException(status_code=404, detail="Movie not found")
     
     # Debug logging (can be removed once Smart Fix is working)
-    print(f"🔍 DEBUG: Movie data for {imdb_id}:")
+    _log("DEBUG", f"Movie data for {imdb_id}:")
     print(f"   - released: {repr(movie.get('released'))}")
     print(f"   - dateadded: {repr(movie.get('dateadded'))}")
     print(f"   - source: {repr(movie.get('source'))}")
@@ -929,7 +930,7 @@ async def get_movie_date_options(dependencies: dict, imdb_id: str):
     except Exception as e:
         print(f"⚠️ External source lookup failed for {imdb_id}: {e}")
     
-    print(f"🔍 DEBUG: Generated {len(options)} options for {imdb_id}:")
+    _log("DEBUG", f"Generated {len(options)} options for {imdb_id}:")
     for i, option in enumerate(options):
         print(f"   Option {i}: {option}")
     
@@ -942,7 +943,7 @@ async def get_movie_date_options(dependencies: dict, imdb_id: str):
 
 async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int, episode: int):
     """Get available date options for an episode"""
-    print(f"🔍 DEBUG: get_episode_date_options called with imdb_id={imdb_id}, season={season}, episode={episode}")
+    _log("DEBUG", f"get_episode_date_options called with imdb_id={imdb_id}, season={season}, episode={episode}")
     db = dependencies["db"]
     
     # Validate parameters with enhanced checking
@@ -968,7 +969,7 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
     
     # Get current episode data
     episode_data = db.get_episode_date(imdb_id, season, episode)
-    print(f"🔍 DEBUG: Episode data from DB: {episode_data}")
+    _log("DEBUG", f"Episode data from DB: {episode_data}")
     if not episode_data:
         print(f"❌ Episode not found in database: {imdb_id} S{season:02d}E{episode:02d}")
         raise HTTPException(status_code=404, detail="Episode not found")
@@ -999,35 +1000,35 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
     try:
         # Get TV processor and clients from dependencies
         tv_processor = dependencies.get("tv_processor")
-        print(f"🔍 DEBUG: tv_processor available: {tv_processor is not None}")
+        _log("DEBUG", f"tv_processor available: {tv_processor is not None}")
         if tv_processor:
-            print(f"🔍 DEBUG: tv_processor has external_clients: {hasattr(tv_processor, 'external_clients')}")
-            print(f"🔍 DEBUG: tv_processor has sonarr: {hasattr(tv_processor, 'sonarr')}")
+            _log("DEBUG", f"tv_processor has external_clients: {hasattr(tv_processor, 'external_clients')}")
+            _log("DEBUG", f"tv_processor has sonarr: {hasattr(tv_processor, 'sonarr')}")
         
         if tv_processor and hasattr(tv_processor, 'external_clients'):
             external_clients = tv_processor.external_clients
-            print(f"🔍 DEBUG: external_clients available: {external_clients is not None}")
+            _log("DEBUG", f"external_clients available: {external_clients is not None}")
             if external_clients:
-                print(f"🔍 DEBUG: TMDB enabled: {external_clients.tmdb.enabled if hasattr(external_clients, 'tmdb') else 'No TMDB client'}")
+                _log("DEBUG", f"TMDB enabled: {external_clients.tmdb.enabled if hasattr(external_clients, 'tmdb') else 'No TMDB client'}")
             
             # Check Sonarr for import dates
             if tv_processor.sonarr and tv_processor.sonarr.enabled:
                 try:
-                    print(f"🔍 DEBUG: Attempting Sonarr lookup for {imdb_id}")
+                    _log("DEBUG", f"Attempting Sonarr lookup for {imdb_id}")
                     # Look up the series and episode in Sonarr
                     series_data = tv_processor.sonarr.series_by_imdb(imdb_id)
                     
                     # If IMDb lookup fails, try direct series lookup as fallback
                     if not series_data:
-                        print(f"🔍 DEBUG: IMDb lookup failed, trying direct series lookup")
+                        _log("DEBUG", f"IMDb lookup failed, trying direct series lookup")
                         try:
                             # Let's also debug what series are available
                             all_series = tv_processor.sonarr.get_all_series()
-                            print(f"🔍 DEBUG: Found {len(all_series)} total series in Sonarr")
+                            _log("DEBUG", f"Found {len(all_series)} total series in Sonarr")
                             
                             # Look for Lincoln Lawyer specifically
                             lincoln_series = [s for s in all_series if 'lincoln' in s.get('title', '').lower()]
-                            print(f"🔍 DEBUG: Lincoln Lawyer series found: {len(lincoln_series)}")
+                            _log("DEBUG", f"Lincoln Lawyer series found: {len(lincoln_series)}")
                             for ls in lincoln_series:
                                 print(f"   - Title: '{ls.get('title')}', IMDb: '{ls.get('imdbId')}', ID: {ls.get('id')}")
                             
@@ -1037,7 +1038,7 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
                             # If still no match but we found Lincoln Lawyer series, try fuzzy matching
                             if not series_data and lincoln_series:
                                 target_imdb_num = imdb_id.replace('tt', '').lower()
-                                print(f"🔍 DEBUG: Trying fuzzy match for IMDb number: {target_imdb_num}")
+                                _log("DEBUG", f"Trying fuzzy match for IMDb number: {target_imdb_num}")
                                 
                                 for ls in lincoln_series:
                                     ls_imdb = ls.get('imdbId', '')
@@ -1063,17 +1064,17 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
                             import traceback
                             print(f"   Traceback: {traceback.format_exc()}")
                     
-                    print(f"🔍 DEBUG: Series data found: {series_data is not None}")
+                    _log("DEBUG", f"Series data found: {series_data is not None}")
                     if series_data:
                         series_id = series_data.get('id')
                         series_title = series_data.get('title', 'Unknown')
-                        print(f"🔍 DEBUG: Found series '{series_title}' with ID {series_id}")
+                        _log("DEBUG", f"Found series '{series_title}' with ID {series_id}")
                         
                         if series_id:
                             # Get episodes for the series
-                            print(f"🔍 DEBUG: Getting episodes for series {series_id}")
+                            _log("DEBUG", f"Getting episodes for series {series_id}")
                             episodes = tv_processor.sonarr.episodes_for_series(series_id)
-                            print(f"🔍 DEBUG: Found {len(episodes)} episodes")
+                            _log("DEBUG", f"Found {len(episodes)} episodes")
                             
                             for ep in episodes:
                                 ep_season = ep.get('seasonNumber')
@@ -1089,13 +1090,13 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
                                     episode_id = ep.get('id')
                                     ep_title = ep.get('title', 'Unknown')
                                     ep_air_date = ep.get('airDate')  # Get air date from Sonarr
-                                    print(f"🔍 DEBUG: Found target episode '{ep_title}' with ID {episode_id}, airDate: {ep_air_date}")
+                                    _log("DEBUG", f"Found target episode '{ep_title}' with ID {episode_id}, airDate: {ep_air_date}")
                                     
                                     if episode_id:
                                         # Get import history for this specific episode
-                                        print(f"🔍 DEBUG: Getting import history for episode {episode_id}")
+                                        _log("DEBUG", f"Getting import history for episode {episode_id}")
                                         import_date = tv_processor.get_episode_import_history(episode_id)
-                                        print(f"🔍 DEBUG: Import date found: {import_date}")
+                                        _log("DEBUG", f"Import date found: {import_date}")
                                         
                                         if import_date:
                                             # Check if this is different from current date
@@ -1149,11 +1150,11 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
             # Check TMDB for episode air dates
             if external_clients.tmdb.enabled:
                 try:
-                    print(f"🔍 DEBUG: Attempting TMDB lookup for {imdb_id}")
+                    _log("DEBUG", f"Attempting TMDB lookup for {imdb_id}")
                     # Get TMDB TV series ID from IMDb ID using find endpoint
                     tv_find_result = external_clients.tmdb._get(f"/find/{imdb_id}", {"external_source": "imdb_id"})
-                    print(f"🔍 DEBUG: TMDB find result: {tv_find_result is not None}")
-                    print(f"🔍 DEBUG: TMDB raw response: {tv_find_result}")
+                    _log("DEBUG", f"TMDB find result: {tv_find_result is not None}")
+                    _log("DEBUG", f"TMDB raw response: {tv_find_result}")
                     
                     # Check both tv_results and tv_episode_results
                     tmdb_id = None
@@ -1161,36 +1162,36 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
                     
                     if tv_find_result and tv_find_result.get("tv_results"):
                         tv_results = tv_find_result.get("tv_results", [])
-                        print(f"🔍 DEBUG: Found {len(tv_results)} TV results")
+                        _log("DEBUG", f"Found {len(tv_results)} TV results")
                         
                         if tv_results:
                             tv_show = tv_results[0]
                             tmdb_id = tv_show.get("id")
                             tv_title = tv_show.get("name", "Unknown")
-                            print(f"🔍 DEBUG: Found TMDB series '{tv_title}' with ID {tmdb_id}")
+                            _log("DEBUG", f"Found TMDB series '{tv_title}' with ID {tmdb_id}")
                     
                     # Fallback: Check tv_episode_results for show_id
                     elif tv_find_result and tv_find_result.get("tv_episode_results"):
                         episode_results = tv_find_result.get("tv_episode_results", [])
-                        print(f"🔍 DEBUG: Found {len(episode_results)} TV episode results")
+                        _log("DEBUG", f"Found {len(episode_results)} TV episode results")
                         
                         if episode_results:
                             tmdb_episode_data = episode_results[0]
                             tmdb_id = tmdb_episode_data.get("show_id")
                             episode_name = tmdb_episode_data.get("name", "Unknown")
-                            print(f"🔍 DEBUG: Found TMDB series via episode '{episode_name}' with show_id {tmdb_id}")
+                            _log("DEBUG", f"Found TMDB series via episode '{episode_name}' with show_id {tmdb_id}")
                     
                     if tmdb_id:
-                        print(f"🔍 DEBUG: Using TMDB ID {tmdb_id} for series lookup")
+                        _log("DEBUG", f"Using TMDB ID {tmdb_id} for series lookup")
                         
                         # Get episode air date from TMDB
-                        print(f"🔍 DEBUG: Getting TMDB season {season} episodes for series {tmdb_id}")
+                        _log("DEBUG", f"Getting TMDB season {season} episodes for series {tmdb_id}")
                         episodes = external_clients.tmdb.get_tv_season_episodes(tmdb_id, season)
-                        print(f"🔍 DEBUG: TMDB episodes found: {episodes}")
+                        _log("DEBUG", f"TMDB episodes found: {episodes}")
                         
                         if episode in episodes:
                             air_date = episodes[episode]
-                            print(f"🔍 DEBUG: TMDB air date for S{season:02d}E{episode:02d}: {air_date}")
+                            _log("DEBUG", f"TMDB air date for S{season:02d}E{episode:02d}: {air_date}")
                             
                             if air_date:
                                 # Check if this is different from current aired date
@@ -1264,11 +1265,11 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
         "description": "Enter custom date and time"
     })
     
-    print(f"🔍 DEBUG: Generated {len(options)} options for {imdb_id} S{season:02d}E{episode:02d}:")
+    _log("DEBUG", f"Generated {len(options)} options for {imdb_id} S{season:02d}E{episode:02d}:")
     for i, option in enumerate(options):
         print(f"   Option {i}: {option}")
     
-    print(f"🔍 DEBUG: Returning result with {len(options)} options")
+    _log("DEBUG", f"Returning result with {len(options)} options")
     return {
         "imdb_id": imdb_id,
         "season": season,
@@ -1425,11 +1426,11 @@ async def populate_database(background_tasks: BackgroundTasks, media_type: str =
     )
     _populate_process.start()
 
-    print(f"INFO: Database population process started (PID: {_populate_process.pid}) for: {media_type}")
+    _log("INFO", f"Database population process started for: {media_type}")
     return {
         "status": "started",
         "media_type": media_type,
-        "message": f"Database population started for {media_type} in separate process (PID: {_populate_process.pid})"
+        "message": f"Database population started for {media_type}"
     }
 
 
@@ -1499,7 +1500,7 @@ def register_web_routes(app, dependencies):
             dateadded = data.get('dateadded')
             source = data.get('source', 'manual')
 
-            print(f"🔍 API PUT /api/movies/{imdb_id} - Received JSON:")
+            _log("DEBUG", f"API PUT /api/movies/{imdb_id} - Received JSON:")
             print(f"   - Raw data: {data}")
             print(f"   - dateadded: {dateadded}")
             print(f"   - source: {source}")
@@ -2002,7 +2003,7 @@ async def get_episodes_missing_nfo_dateadded(dependencies: dict):
         import asyncio
         
         core_url = f"http://chronarr:{config.core_api_port}/admin/nfo-repair-scan"
-        print(f"🔍 DEBUG: Calling core container at: {core_url}")
+        _log("DEBUG", f"Calling core container at: {core_url}")
         
         timeout = aiohttp.ClientTimeout(total=300.0)  # 5 minute timeout for filesystem scan
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -2096,7 +2097,7 @@ async def fix_nfo_missing_dateadded(dependencies: dict):
         import asyncio
         
         core_url = f"http://chronarr:{config.core_api_port}/admin/nfo-repair-fix"
-        print(f"🔍 DEBUG: Calling core container at: {core_url}")
+        _log("DEBUG", f"Calling core container at: {core_url}")
         
         timeout = aiohttp.ClientTimeout(total=600.0)  # 10 minute timeout for fix operation
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -2145,7 +2146,7 @@ async def get_missing_imdb_items(dependencies: dict):
         import asyncio
         
         core_url = f"http://chronarr:{config.core_api_port}/admin/missing-imdb"
-        print(f"🔍 DEBUG: Calling core container at: {core_url}")
+        _log("DEBUG", f"Calling core container at: {core_url}")
         
         timeout = aiohttp.ClientTimeout(total=60.0)  # 1 minute timeout
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -2391,12 +2392,12 @@ def register_database_admin_routes(app, dependencies):
         return await get_schedule_executions(dependencies, schedule_id)
 
     # Database population endpoints
-    print("🔧 DEBUG: Registering /admin/populate-database endpoint...")
+    _log("DEBUG", "Registering /admin/populate-database endpoint...")
 
     @app.post("/admin/populate-database")
     async def api_populate_database(request: Request, background_tasks: BackgroundTasks):
         """Populate database from Radarr/Sonarr"""
-        print(f"🔥 DEBUG: populate-database endpoint called!")
+        _log("DEBUG", "populate-database endpoint called!")
         try:
             data = await request.json()
             media_type = data.get("media_type", "both")
@@ -2405,7 +2406,7 @@ def register_database_admin_routes(app, dependencies):
             media_type = request.query_params.get("media_type", "both")
         return await populate_database(background_tasks, media_type, dependencies)
 
-    print("✅ DEBUG: /admin/populate-database registered")
+    _log("DEBUG", "/admin/populate-database registered")
 
     @app.get("/api/populate/status")
     async def api_populate_status():

--- a/config/settings.py
+++ b/config/settings.py
@@ -186,6 +186,8 @@ class ChronarrConfig:
         self.web_auth_password = os.environ.get("WEB_AUTH_PASSWORD", "")
         self.web_auth_session_timeout = self._get_int_env("WEB_AUTH_SESSION_TIMEOUT", 3600, 300, 86400)  # 1 hour default, 5min-24h range
         self.web_auth_secure_cookie = _bool_env("WEB_AUTH_SECURE_COOKIE", False)  # Set True when serving over HTTPS
+        self.radarr_webhook_secret = os.environ.get("RADARR_WEBHOOK_SECRET", "")
+        self.sonarr_webhook_secret = os.environ.get("SONARR_WEBHOOK_SECRET", "")
     
     def _get_int_env(self, name: str, default: int, min_val: int, max_val: int) -> int:
         """Get integer environment variable with validation"""

--- a/main.py
+++ b/main.py
@@ -40,40 +40,11 @@ from webhooks.webhook_batcher import WebhookBatcher
 # Import API routes
 from api.routes import register_routes
 
+# Version — single source of truth
+from version_utils import get_version
+
 # Global shutdown event for graceful shutdown coordination
 shutdown_event = asyncio.Event()
-
-def get_version() -> str:
-    """Get application version"""
-    try:
-        version = (Path(__file__).parent / "VERSION").read_text().strip()
-    except:
-        version = "0.1.0"
-
-    # Check if running from dev branch (detect at runtime)
-    try:
-        # Try to read git branch from .git/HEAD
-        git_head_path = Path(__file__).parent / ".git" / "HEAD"
-        if git_head_path.exists():
-            head_content = git_head_path.read_text().strip()
-            if "ref: refs/heads/dev" in head_content:
-                version = f"{version}-dev"
-            elif head_content.startswith("ref: refs/heads/"):
-                # Extract branch name for other branches
-                branch = head_content.split("refs/heads/")[-1]
-                if branch != "main":
-                    version = f"{version}-{branch}"
-    except Exception:
-        # If git detection fails, that's fine - use base version
-        pass
-
-    # Check for build source (only add -gitea for local Gitea builds)
-    build_source = os.environ.get("BUILD_SOURCE", "")
-    if build_source == "gitea":
-        if "gitea" not in version:  # Don't double-add gitea suffix
-            version = f"{version}-gitea"
-
-    return version
 
 
 def create_app() -> FastAPI:


### PR DESCRIPTION
Logging cleanup:
- Remove duplicate get_version() from main.py; import from version_utils (single source of truth)
- Add _log import to web_routes.py; replace all DEBUG print() calls with _log('DEBUG', ...) in both web_routes.py and routes.py
- Remove OS process PID from populate-database API response

Rate limiting:
- Add LoginRateLimiter to auth.py — tracks failed Basic Auth attempts per client IP; locks out for 15 min after 5 failures within 15 min
- Returns 429 with Retry-After header during lockout
- Resets on successful login; no new dependencies required

Webhook signature verification:
- Add RADARR_WEBHOOK_SECRET and SONARR_WEBHOOK_SECRET env vars to config/settings.py
- Add _verify_webhook_signature() helper in routes.py using HMAC-SHA256 and timing-safe hmac.compare_digest()
- Wire into sonarr_webhook and radarr_webhook handlers; verification is skipped when no secret is configured (backwards compatible)