### PR TITLE
Fix critical SQL injection and two high-severity path issues

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -829,10 +829,14 @@ async def manual_scan(background_tasks: BackgroundTasks, path: Optional[str] = N
         
         paths_to_scan = []
         if path:
-            # Translate the provided path from host format to container format
             translated_path = translate_host_path_to_container(path)
-            paths_to_scan = [Path(translated_path)]
-            _log("DEBUG", f"Manual scan with specific path: {path} -> {translated_path}")
+            resolved = Path(translated_path).resolve()
+            allowed = [p.resolve() for p in config.tv_paths + config.movie_paths]
+            if not any(str(resolved).startswith(str(a)) for a in allowed):
+                _log("WARNING", f"Manual scan rejected — path not in allowed directories: {resolved}")
+                return
+            paths_to_scan = [resolved]
+            _log("DEBUG", f"Manual scan with specific path: {path} -> {resolved}")
         else:
             if scan_type in ["both", "tv"]:
                 paths_to_scan.extend(config.tv_paths)

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -17,7 +17,7 @@ from utils.logging import _log
 
 # Status file for cross-process communication
 # Use /tmp which is writable in both core and web containers
-POPULATE_STATUS_FILE = "/tmp/chronarr_populate_status.json"
+POPULATE_STATUS_FILE = "/app/data/chronarr_populate_status.json"
 
 # Process tracking
 _populate_process = None
@@ -1947,49 +1947,6 @@ def register_web_routes(app, dependencies):
 # DATABASE ADMIN INTERFACE
 # =============================================================================
 
-async def execute_database_query(dependencies: dict, query: str, limit: int = 100):
-    """Execute a database query and return results"""
-    db = dependencies["db"]
-    
-    try:
-        with db.get_connection() as conn:
-            cursor = conn.cursor()
-            
-            # Add LIMIT if not already present in query
-            if "LIMIT" not in query.upper() and not query.strip().endswith(";"):
-                query += f" LIMIT {limit}"
-            elif query.strip().endswith(";"):
-                query = query.strip()[:-1] + f" LIMIT {limit};"
-            
-            cursor.execute(query)
-            
-            if query.strip().upper().startswith("SELECT"):
-                results = cursor.fetchall()
-                columns = [desc[0] for desc in cursor.description] if cursor.description else []
-                return {
-                    "success": True,
-                    "query": query,
-                    "columns": columns,
-                    "rows": [dict(zip(columns, row)) for row in results],
-                    "row_count": len(results)
-                }
-            else:
-                conn.commit()
-                return {
-                    "success": True,
-                    "query": query,
-                    "message": f"Query executed successfully. Rows affected: {cursor.rowcount}",
-                    "rows_affected": cursor.rowcount
-                }
-                
-    except Exception as e:
-        return {
-            "success": False,
-            "query": query,
-            "error": str(e),
-            "message": f"Database query failed: {str(e)}"
-        }
-
 
 async def get_episodes_missing_nfo_dateadded(dependencies: dict):
     """Find episodes and movies missing dateadded elements in NFO files via core container"""
@@ -2295,11 +2252,6 @@ def register_database_admin_routes(app, dependencies):
     """Register database admin routes"""
     from fastapi import Request, Response
 
-    @app.post("/api/admin/database/query")
-    async def api_database_query(query: str, limit: int = 100):
-        """Execute a database query"""
-        return await execute_database_query(dependencies, query, limit)
-    
     @app.get("/api/admin/nfo/missing-dateadded")
     async def api_episodes_missing_nfo_dateadded():
         """Get episodes missing dateadded in NFO files"""


### PR DESCRIPTION
Critical:
- Remove /api/admin/database/query endpoint and execute_database_query() entirely; accepted arbitrary SQL strings and executed them directly against the database including non-SELECT statements with commit — no safe way to make this endpoint secure, deletion is the fix

High:
- Path traversal in manual_scan: resolve user-supplied path and validate it falls under a configured tv_path or movie_path before use; previously any filesystem path could be scanned
- Move populate status file from /tmp (world-writable) to /app/data which is the app's own volume; eliminates the race condition where another process on the host could inject arbitrary JSON that was read back and returned directly to clients