### PR TITLE
Remove PostgreSQL host port exposure from docker-compose

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -36,8 +36,6 @@ services:
       - TZ=${TZ:-UTC}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "${DB_EXTERNAL_PORT:-5432}:5432"  # Optional external access
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-chronarr} -d ${DB_NAME:-chronarr}"]
       interval: 10s
@@ -169,7 +167,7 @@ networks:
 # Port Configuration:
 # - Core API: ${CORE_API_PORT:-8080} (webhooks, processing)
 # - Web Interface: ${WEB_API_PORT:-8081} (dashboard)
-# - Database: ${DB_EXTERNAL_PORT:-5432} (optional external access)
+# - Database: internal only (not exposed to host — use docker exec or a tunnel if direct access needed)
 #
 # Media Path Configuration:
 # - Update the volume mounts under chronarr: section


### PR DESCRIPTION
The chronarr-db service had ports: - "${DB_EXTERNAL_PORT:-5432}:5432" which defaulted to binding PostgreSQL to all host interfaces on port
5432. The database is only needed by the other containers on the internal chronarr-network — no host port mapping is required.

If direct DB access is genuinely needed, use docker exec or an SSH tunnel rather than exposing the port to the network.