### PR TITLE
Pin GitHub Actions to SHA hashes, add dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ghcr-dev.yml
+++ b/.github/workflows/ghcr-dev.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read VERSION and compute DEV tags
         run: |
@@ -28,10 +28,10 @@ jobs:
           if [[ -z "$RAW" ]]; then echo "VERSION empty"; exit 1; fi
           # Remove 'v' prefix if present for version number
           if [[ "$RAW" =~ ^v ]]; then NUM="${RAW#v}"; else NUM="$RAW"; fi
-          
+
           # Get repository name (assumes format: owner/repo)
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
-          
+
           echo "VERSION_NUM=$NUM" >> $GITHUB_ENV
           echo "DEV_VERSION=${NUM}-dev" >> $GITHUB_ENV
           echo "DOCKER_REPO=${{ secrets.DOCKER_HUB_USERNAME }}/${REPO_NAME}" >> $GITHUB_ENV
@@ -40,20 +40,20 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ env.PLATFORMS == 'linux/amd64,linux/arm64' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build & (maybe) push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ghcr-main.yml
+++ b/.github/workflows/ghcr-main.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Read VERSION
         id: ver
@@ -28,10 +28,10 @@ jobs:
           RAW=$(tr -d ' \n' < VERSION)
           if [[ -z "$RAW" ]]; then echo "VERSION empty"; exit 1; fi
           if [[ "$RAW" =~ ^v ]]; then TAG="$RAW"; NUM="${RAW#v}"; else TAG="v${RAW}"; NUM="$RAW"; fi
-          
+
           # Get repository name for DockerHub
           REPO_NAME=$(echo "${GITHUB_REPOSITORY}" | cut -d'/' -f2)
-          
+
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "NUM=$NUM" >> $GITHUB_ENV
           echo "DOCKER_REPO=${{ secrets.DOCKER_HUB_USERNAME }}/${REPO_NAME}" >> $GITHUB_ENV
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create tag (if missing)
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             const tag = process.env.TAG;
@@ -59,7 +59,7 @@ jobs:
       - name: Update draft release notes
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         id: drafter
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@da8b9b696abad2ad997580e49f4c1c2e03cc2bd2 # v7.3.0
         with:
           config-name: release-drafter.yml
           publish: false
@@ -68,7 +68,7 @@ jobs:
 
       - name: Publish GitHub Release
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ env.TAG }}
           name: Chronarr ${{ env.TAG }}
@@ -80,20 +80,20 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ env.PLATFORMS == 'linux/amd64,linux/arm64' }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build & Push (main)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
All actions updated to Node.js 24 compatible versions — deadline June 2nd 2026:

ghcr-dev.yml + ghcr-main.yml:
  actions/checkout        @v4     → @de0fac2...  (v6.0.2)
  docker/setup-qemu-action @v3   → @ce360397... (v4.0.0)
  docker/setup-buildx-action @v3 → @d7f5e7f5... (v4.1.0)
  docker/login-action     @v3    → @650006c6... (v4.2.0)
  docker/build-push-action @v5   → @f9f3042f... (v7.2.0)

ghcr-main.yml only:
  actions/github-script       @v7 → @d746ffe3... (v9.0.0)
  release-drafter/release-drafter @v6 → @da8b9b69... (v7.3.0)
  softprops/action-gh-release @v2 → @b4309332... (v3.0.0)

.github/dependabot.yml (new):
  Weekly automated PRs to keep action SHAs current going forward