### PR TITLE
Fetch sidebar version from API — always matches running VERSION file

### DIFF
--- a/chronarr-web/static/index.html
+++ b/chronarr-web/static/index.html
@@ -17,7 +17,7 @@
                 <img src="/static/chronarr.jpg" alt="Chronarr">
                 <div class="sidebar-brand-text">
                     <h1>Chronarr</h1>
-                    <small id="app-version">v2.0.10</small>
+                    <small id="app-version">…</small>
                 </div>
             </div>
 

--- a/chronarr-web/static/js/app.js
+++ b/chronarr-web/static/js/app.js
@@ -8,6 +8,15 @@ let dashboardData = null;
 
 // Initialize app
 document.addEventListener('DOMContentLoaded', function() {
+    // Populate sidebar version from the backend — stays in sync with VERSION file
+    fetch('/api/v1/health')
+        .then(function(r) { return r.json(); })
+        .then(function(d) {
+            var el = document.getElementById('app-version');
+            if (el && d.version) el.textContent = 'v' + d.version;
+        })
+        .catch(function() { /* leave as-is on failure */ });
+
     try {
         initializeTabs();
     } catch (error) {


### PR DESCRIPTION
Replaces hardcoded 'v2.0.10' in index.html with a fetch to /api/v1/health on DOMContentLoaded. The health endpoint is already unauthenticated and returns the version string from version_utils.py (which reads VERSION file and appends branch suffix). Version shown in sidebar now stays in sync with what the backend logs at startup.