### PR TITLE
Fix version fetch endpoint — use /health not /api/v1/health

### DIFF
--- a/chronarr-web/static/js/app.js
+++ b/chronarr-web/static/js/app.js
@@ -9,7 +9,7 @@ let dashboardData = null;
 // Initialize app
 document.addEventListener('DOMContentLoaded', function() {
     // Populate sidebar version from the backend — stays in sync with VERSION file
-    fetch('/api/v1/health')
+    fetch('/health')
         .then(function(r) { return r.json(); })
         .then(function(d) {
             var el = document.getElementById('app-version');


### PR DESCRIPTION
The web container (port 8081) exposes /health returning version from get_version(). The core container's /api/v1/health is unreachable from the browser. Changed fetch to /health which is on the same origin as the web UI.