### PR TITLE
Move auto-purge settings to web UI — no env vars needed

### DIFF
--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -1931,6 +1931,36 @@ def register_web_routes(app, dependencies):
             _log("ERROR", f"Library sync failed: {e}")
             raise HTTPException(status_code=500, detail=str(e))
 
+    @app.get("/api/settings/library-sync")
+    async def get_library_sync_settings():
+        """Return current auto-purge settings."""
+        from utils.source_sync import load_sync_settings
+        return load_sync_settings()
+
+    @app.put("/api/settings/library-sync")
+    async def put_library_sync_settings(request: Request):
+        """Save auto-purge settings."""
+        from utils.source_sync import save_sync_settings, load_sync_settings
+        try:
+            body = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid JSON")
+
+        current = load_sync_settings()
+        movie_days = body.get("purge_missing_movies_days", current.get("purge_missing_movies_days", 0))
+        tv_days    = body.get("purge_missing_tv_days",    current.get("purge_missing_tv_days", 0))
+
+        try:
+            movie_days = max(0, int(movie_days))
+            tv_days    = max(0, int(tv_days))
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=400, detail="Days values must be non-negative integers")
+
+        settings = {"purge_missing_movies_days": movie_days, "purge_missing_tv_days": tv_days}
+        save_sync_settings(settings)
+        _log("INFO", f"Library sync settings updated: movies={movie_days}d, tv={tv_days}d")
+        return {"success": True, **settings}
+
     # Simple scan tracking (since we can't reliably access docker logs from container)
     scan_tracking = {"last_scan_time": None, "scanning": False}
     

--- a/chronarr-web/static/index.html
+++ b/chronarr-web/static/index.html
@@ -660,6 +660,26 @@
                                 <i class="fas fa-times"></i> Hide Results
                             </button>
                         </div>
+
+                        <hr style="margin:1.25rem 0;border:none;border-top:1px solid var(--border-color,#e2e8f0)">
+                        <h4 style="margin-bottom:0.5rem"><i class="fas fa-clock"></i> Auto-Purge Settings</h4>
+                        <p style="font-size:0.85em;color:var(--text-muted,#718096);margin-bottom:0.75rem">
+                            Items missing from Radarr/Sonarr for longer than the configured days will be automatically removed. Set to <strong>0</strong> to disable.
+                        </p>
+                        <div class="form-group" style="display:flex;gap:1rem;flex-wrap:wrap;align-items:flex-end">
+                            <label style="flex:1;min-width:160px">
+                                <span style="font-size:0.85em;display:block;margin-bottom:0.25rem">Movies — purge after (days)</span>
+                                <input type="number" id="sync-purge-movies-days" min="0" max="3650" value="0" style="width:100%">
+                            </label>
+                            <label style="flex:1;min-width:160px">
+                                <span style="font-size:0.85em;display:block;margin-bottom:0.25rem">TV Series — purge after (days)</span>
+                                <input type="number" id="sync-purge-tv-days" min="0" max="3650" value="0" style="width:100%">
+                            </label>
+                            <button type="button" class="btn btn-secondary" onclick="saveSyncSettings()" style="flex-shrink:0">
+                                <i class="fas fa-save"></i> Save
+                            </button>
+                        </div>
+                        <p id="sync-settings-status" style="font-size:0.8em;margin-top:0.4rem;min-height:1.2em"></p>
                     </div>
 
                     <div class="tool-card">

--- a/chronarr-web/static/js/app.js
+++ b/chronarr-web/static/js/app.js
@@ -140,6 +140,7 @@ function initializeEventListeners() {
                 immediateGroup.style.display = dryRunCb.checked ? 'none' : 'block';
             });
         }
+        loadSyncSettings();
     }
 }
 
@@ -2028,105 +2029,84 @@ function hideCleanupStatus() {
 
 function displayCleanupResults(report, dryRun) {
     const cleanupResults = document.getElementById('cleanup-results');
+    const accentColor = dryRun ? 'var(--warning-color,#d69e2e)' : 'var(--danger,#e53e3e)';
 
-    const mode = dryRun ? 'Would be removed' : 'Removed';
-    const modeClass = dryRun ? 'warning' : 'danger';
+    function statRow(label, value, highlight) {
+        const style = highlight ? `font-weight:700;color:${accentColor}` : 'color:var(--text-muted,#718096)';
+        return `<div style="display:flex;justify-content:space-between;padding:4px 0;border-bottom:1px solid var(--border-color,#e2e8f0);font-size:0.875em">
+            <span>${label}</span><span style="${style}">${value}</span>
+        </div>`;
+    }
 
-    let html = `
-        <div style="background: #f8f9fa; padding: 15px; border-radius: 8px; margin-top: 10px;">
-            <h4 style="margin-top: 0; color: #333;">
-                <i class="fas fa-${dryRun ? 'eye' : 'check-circle'}"></i>
-                ${dryRun ? 'Preview Results' : 'Cleanup Results'}
-            </h4>
-    `;
+    // titles = removed_titles array from backend
+    function itemList(titles, label) {
+        if (!titles || titles.length === 0) return '';
+        return `<details style="margin-top:8px">
+            <summary style="cursor:pointer;font-size:0.82em;color:var(--accent,#0096c7)">
+                <i class="fas fa-list" style="margin-right:4px"></i>${label} (${titles.length})
+            </summary>
+            <ul style="margin:6px 0 0 16px;max-height:220px;overflow-y:auto;font-size:0.8em;padding-right:4px">
+                ${titles.map(t => `<li style="padding:2px 0">${escapeHtml(t)}</li>`).join('')}
+            </ul>
+        </details>`;
+    }
 
-    // Movies section
+    const moviesRemoved  = report.movies?.removed || 0;
+    const seriesRemoved  = report.series?.removed || 0;
+    const episodesRemoved = report.series?.removed_episodes || 0;
+
+    let html = `<div style="margin-top:10px">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
+            <i class="fas fa-${dryRun ? 'eye' : 'check-circle'}" style="color:${accentColor}"></i>
+            <strong>${dryRun ? 'Preview Results' : 'Cleanup Results'}</strong>
+        </div>`;
+
     if (report.movies) {
-        html += `
-            <div style="margin-bottom: 15px;">
-                <h5 style="color: #666; margin-bottom: 8px;">
-                    <i class="fas fa-film"></i> Movies
-                </h5>
-                <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; padding-left: 20px;">
-                    <div>Total checked: <strong>${report.movies.total_checked || 0}</strong></div>
-                    <div class="badge badge-${modeClass}">${mode}: <strong>${report.movies.removed || 0}</strong></div>
-                    <div>Missing from filesystem: ${report.movies.missing_filesystem || 0}</div>
-                    <div>Missing from database: ${report.movies.missing_database || 0}</div>
-                </div>
-        `;
-
-        if (report.movies.removed_items && report.movies.removed_items.length > 0) {
-            html += `
-                <details style="margin-top: 10px;">
-                    <summary style="cursor: pointer; color: #007bff;">View ${mode} items (${report.movies.removed_items.length})</summary>
-                    <ul style="margin-top: 10px; padding-left: 20px; max-height: 200px; overflow-y: auto;">
-            `;
-            report.movies.removed_items.forEach(item => {
-                html += `<li style="font-size: 0.9em; margin-bottom: 5px;">${escapeHtml(item)}</li>`;
-            });
-            html += `
-                    </ul>
-                </details>
-            `;
-        }
-
-        html += `</div>`;
-    }
-
-    // TV Series section
-    if (report.series) {
-        html += `
-            <div style="margin-bottom: 15px;">
-                <h5 style="color: #666; margin-bottom: 8px;">
-                    <i class="fas fa-tv"></i> TV Series
-                </h5>
-                <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; padding-left: 20px;">
-                    <div>Total checked: <strong>${report.series.total_checked || 0}</strong></div>
-                    <div class="badge badge-${modeClass}">${mode}: <strong>${report.series.removed || 0}</strong></div>
-                    <div>Episodes removed: <strong>${report.series.removed_episodes || 0}</strong></div>
-                    <div>Missing from database: ${report.series.missing_database || 0}</div>
-                </div>
-        `;
-
-        if (report.series.removed_items && report.series.removed_items.length > 0) {
-            html += `
-                <details style="margin-top: 10px;">
-                    <summary style="cursor: pointer; color: #007bff;">View ${mode} series (${report.series.removed_items.length})</summary>
-                    <ul style="margin-top: 10px; padding-left: 20px; max-height: 200px; overflow-y: auto;">
-            `;
-            report.series.removed_items.forEach(item => {
-                html += `<li style="font-size: 0.9em; margin-bottom: 5px;">${escapeHtml(item)}</li>`;
-            });
-            html += `
-                    </ul>
-                </details>
-            `;
-        }
-
-        html += `</div>`;
-    }
-
-    // Summary
-    const totalRemoved = (report.movies?.removed || 0) + (report.series?.removed || 0) + (report.series?.removed_episodes || 0);
-    html += `
-        <div style="margin-top: 15px; padding-top: 15px; border-top: 2px solid #dee2e6;">
-            <strong>Total ${mode}:</strong>
-            <span style="color: ${dryRun ? '#ff9800' : '#dc3545'}; font-size: 1.2em;">
-                ${totalRemoved} items
-            </span>
-        </div>
-    `;
-
-    if (dryRun) {
-        html += `
-            <div style="margin-top: 10px; padding: 10px; background: #fff3cd; border-left: 4px solid #ffc107; border-radius: 4px;">
-                <i class="fas fa-info-circle"></i> This was a <strong>dry run</strong>. No changes were made. Uncheck "Dry Run" to perform actual cleanup.
+        html += `<div style="margin-bottom:14px">
+            <div style="font-size:0.78em;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted,#718096);margin-bottom:4px">
+                <i class="fas fa-film"></i> Movies
             </div>
-        `;
+            ${statRow('Orphaned found', report.movies.orphaned || 0)}
+            ${statRow(dryRun ? 'Would be removed' : 'Removed', moviesRemoved, moviesRemoved > 0)}
+            ${itemList(report.movies.removed_titles, dryRun ? 'View movies to remove' : 'View removed movies')}
+        </div>`;
+    }
+
+    if (report.series) {
+        html += `<div style="margin-bottom:14px">
+            <div style="font-size:0.78em;font-weight:700;text-transform:uppercase;letter-spacing:.06em;color:var(--text-muted,#718096);margin-bottom:4px">
+                <i class="fas fa-tv"></i> TV Series
+            </div>
+            ${statRow('Orphaned found', report.series.orphaned || 0)}
+            ${statRow(dryRun ? 'Series would be removed' : 'Series removed', seriesRemoved, seriesRemoved > 0)}
+            ${episodesRemoved > 0 ? statRow(dryRun ? 'Episodes would be removed' : 'Episodes removed', episodesRemoved, true) : ''}
+            ${itemList(report.series.removed_titles, dryRun ? 'View series to remove' : 'View removed series')}
+        </div>`;
+    }
+
+    const totalItems = moviesRemoved + seriesRemoved;
+    const summaryParts = [];
+    if (moviesRemoved  > 0) summaryParts.push(`${moviesRemoved} movie${moviesRemoved !== 1 ? 's' : ''}`);
+    if (seriesRemoved  > 0) summaryParts.push(`${seriesRemoved} series`);
+    if (episodesRemoved > 0) summaryParts.push(`${episodesRemoved} episode${episodesRemoved !== 1 ? 's' : ''}`);
+    const summaryText = summaryParts.length ? summaryParts.join(', ') : 'nothing';
+
+    html += `<div style="padding:8px 0;border-top:1px solid var(--border-color,#e2e8f0);font-size:0.875em">
+        <strong>${dryRun ? 'Would remove' : 'Removed'}:</strong>
+        <span style="color:${accentColor};font-weight:700;margin-left:4px">${summaryText}</span>
+    </div>`;
+
+    if (dryRun && totalItems > 0) {
+        html += `<div style="margin-top:8px;padding:8px 12px;background:var(--badge-warning-bg,#fefcbf);border-left:3px solid var(--warning-color,#d69e2e);border-radius:4px;font-size:0.82em">
+            <i class="fas fa-info-circle"></i> Dry run — no changes made. Uncheck <strong>Dry Run</strong> to apply.
+        </div>`;
+    } else if (!dryRun && totalItems === 0) {
+        html += `<div style="margin-top:8px;padding:8px 12px;background:var(--badge-success-bg,#c6f6d5);border-left:3px solid var(--success,#38a169);border-radius:4px;font-size:0.82em">
+            <i class="fas fa-check-circle"></i> Nothing to remove — database is clean.
+        </div>`;
     }
 
     html += `</div>`;
-
     cleanupResults.innerHTML = html;
 }
 
@@ -2244,6 +2224,45 @@ function renderSyncResults(data, dryRun) {
 
 function hideSyncStatus() {
     document.getElementById('sync-status').style.display = 'none';
+}
+
+async function loadSyncSettings() {
+    try {
+        const res = await fetch('/api/settings/library-sync');
+        if (!res.ok) return;
+        const s = await res.json();
+        const movieEl = document.getElementById('sync-purge-movies-days');
+        const tvEl    = document.getElementById('sync-purge-tv-days');
+        if (movieEl) movieEl.value = s.purge_missing_movies_days ?? 0;
+        if (tvEl)    tvEl.value    = s.purge_missing_tv_days ?? 0;
+    } catch (_) {}
+}
+
+async function saveSyncSettings() {
+    const movieDays = parseInt(document.getElementById('sync-purge-movies-days')?.value || '0', 10);
+    const tvDays    = parseInt(document.getElementById('sync-purge-tv-days')?.value || '0', 10);
+    const statusEl  = document.getElementById('sync-settings-status');
+
+    try {
+        const res = await fetch('/api/settings/library-sync', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ purge_missing_movies_days: movieDays, purge_missing_tv_days: tvDays })
+        });
+        if (!res.ok) throw new Error('Save failed');
+        if (statusEl) {
+            statusEl.style.color = 'var(--success)';
+            statusEl.textContent = movieDays === 0 && tvDays === 0
+                ? '✓ Auto-purge disabled'
+                : `✓ Saved — movies: ${movieDays === 0 ? 'never' : movieDays + 'd'}, TV: ${tvDays === 0 ? 'never' : tvDays + 'd'}`;
+            setTimeout(() => { statusEl.textContent = ''; }, 4000);
+        }
+    } catch (err) {
+        if (statusEl) {
+            statusEl.style.color = 'var(--danger)';
+            statusEl.textContent = '✗ Failed to save settings';
+        }
+    }
 }
 
 // ── End Library Sync ──────────────────────────────────────────────────────────

--- a/utils/source_sync.py
+++ b/utils/source_sync.py
@@ -4,10 +4,34 @@ Library sync — compare Chronarr DB against current Radarr/Sonarr libraries.
 Identifies movies/series that Radarr/Sonarr no longer manages and optionally
 removes them from the Chronarr DB after a configurable grace period.
 """
+import json
 import os
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 from utils.logging import _log
+
+SETTINGS_FILE = "/app/data/chronarr_sync_settings.json"
+
+
+def load_sync_settings() -> dict:
+    """Load auto-purge settings from the settings file, falling back to env vars."""
+    try:
+        if os.path.exists(SETTINGS_FILE):
+            with open(SETTINGS_FILE) as f:
+                return json.load(f)
+    except Exception:
+        pass
+    return {
+        "purge_missing_movies_days": int(os.environ.get("PURGE_MISSING_MOVIES_DAYS", "0") or 0),
+        "purge_missing_tv_days": int(os.environ.get("PURGE_MISSING_TV_DAYS", "0") or 0),
+    }
+
+
+def save_sync_settings(settings: dict) -> None:
+    """Persist auto-purge settings to the settings file."""
+    os.makedirs(os.path.dirname(SETTINGS_FILE), exist_ok=True)
+    with open(SETTINGS_FILE, "w") as f:
+        json.dump(settings, f, indent=2)
 
 
 def _radarr_imdb_ids() -> Optional[set]:
@@ -181,14 +205,15 @@ def run_sync(db, media_type: str = "both", dry_run: bool = True,
 
 def run_auto_purge(db) -> dict:
     """
-    Run the auto-purge pass. Reads PURGE_MISSING_MOVIES_DAYS and
-    PURGE_MISSING_TV_DAYS from environment (0 or unset = disabled).
+    Run the auto-purge pass. Reads days thresholds from the settings file
+    (saved via the web UI) with env var fallback. 0 = disabled.
 
     First updates missing_from_source_since by comparing against Radarr/Sonarr,
     then deletes items that have been missing longer than the configured threshold.
     """
-    movie_days = int(os.environ.get("PURGE_MISSING_MOVIES_DAYS", "0") or 0)
-    tv_days = int(os.environ.get("PURGE_MISSING_TV_DAYS", "0") or 0)
+    settings = load_sync_settings()
+    movie_days = int(settings.get("purge_missing_movies_days", 0) or 0)
+    tv_days = int(settings.get("purge_missing_tv_days", 0) or 0)
 
     if movie_days == 0 and tv_days == 0:
         return {"skipped": True, "reason": "auto-purge disabled (PURGE_MISSING_*_DAYS=0)"}


### PR DESCRIPTION
Settings saved to /app/data/chronarr_sync_settings.json via two new endpoints:
  GET  /api/settings/library-sync  — returns current days thresholds
  PUT  /api/settings/library-sync  — saves purge_missing_movies_days and
                                      purge_missing_tv_days (0 = disabled)

Library Sync tool card now shows an Auto-Purge Settings section with two number inputs (Movies days, TV days) and a Save button. Values load from the API on page open and save instantly. Feedback shown inline.

source_sync.run_auto_purge() reads from the settings file first, falling back to PURGE_MISSING_MOVIES_DAYS/PURGE_MISSING_TV_DAYS env vars if the file does not exist (preserves backwards compatibility for existing setups).