### PR TITLE
Bust app.js and CSS cache — force browser to load updated files

### DIFF
--- a/chronarr-web/static/index.html
+++ b/chronarr-web/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chronarr - Database Management</title>
-    <link rel="stylesheet" href="/static/css/styles.css?v=2.0.10-charts">
+    <link rel="stylesheet" href="/static/css/styles.css?v=2.0.15-library-sync">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 </head>
@@ -1015,8 +1015,8 @@
     <!-- Toast Notifications -->
     <div class="toast-container" id="toast-container"></div>
 
-    <script src="/static/js/app.js?v=2.0.10-ui-redesign"></script>
-    <script src="/static/js/cleanup-schedule.js?v=2.0.10-ui-redesign"></script>
+    <script src="/static/js/app.js?v=2.0.15-library-sync"></script>
+    <script src="/static/js/cleanup-schedule.js?v=2.0.15-library-sync"></script>
     <script>
         // Mobile sidebar toggle
         function openSidebar() {


### PR DESCRIPTION
Version string on static assets was still 2.0.10-ui-redesign so browsers served old app.js from cache even after container was updated. Bumped to 2.0.15-library-sync to force fresh load.