### PR TITLE
Clarify licensing for bundled Emby plugin binary

### DIFF
--- a/Emby-DLL/LICENSE
+++ b/Emby-DLL/LICENSE
@@ -1,0 +1,21 @@
+Chronarr Emby Plugin — Binary Distribution License
+==================================================
+
+Chronarr.Emby.Plugin.dll is distributed here in compiled (binary) form only.
+Its source code is closed and is not part of this repository.
+
+Copyright (c) 2025-2026 Chronarr. All rights reserved.
+
+This binary is NOT covered by the MIT license that applies to the rest of
+this repository (see the top-level LICENSE file). It is provided under the
+following terms:
+
+- You may use this plugin with a valid Chronarr Emby Plugin license
+  (including the free trial period offered at first run).
+- You may NOT redistribute, resell, sublicense, decompile, reverse engineer,
+  or modify this binary without prior written permission.
+- This software is provided "AS IS", without warranty of any kind, express
+  or implied, including but not limited to the warranties of merchantability,
+  fitness for a particular purpose, and noninfringement.
+
+For licensing questions or commercial terms, contact Chronarr support.

--- a/Emby-DLL/README.md
+++ b/Emby-DLL/README.md
@@ -1,0 +1,17 @@
+# Chronarr Emby Plugin
+
+This directory contains the compiled Emby plugin binary
+(`Chronarr.Emby.Plugin.dll`) bundled with the Chronarr application.
+
+The plugin syncs media "date added" metadata between Chronarr and your
+Emby server. Drop the DLL into your Emby `plugins` folder to install it —
+see the main project documentation for setup instructions.
+
+## Licensing
+
+This is closed-source software distributed in binary form under separate
+terms from the rest of this repository — see [LICENSE](LICENSE).
+
+It is currently free to use during the preview/trial period. Paid licensing
+details will be announced here and on the plugin's configuration page before
+any change takes effect.

--- a/LICENSE
+++ b/LICENSE
@@ -24,11 +24,15 @@ SOFTWARE.
 
 ## Commercial Licensing
 
-For commercial use, enterprise features, or if the MIT license doesn't meet your needs, 
+For commercial use, enterprise features, or if the MIT license doesn't meet your needs,
 commercial licenses are available. Contact us for more information.
 
-Future premium features (such as web UI, advanced analytics, enterprise support) 
+Future premium features (such as web UI, advanced analytics, enterprise support)
 may be offered under separate commercial licensing terms.
+
+The MIT license above covers the Chronarr application source code. Bundled
+binary plugins (e.g. `Emby-DLL/`) are distributed under separate proprietary
+terms — see their respective LICENSE files.
 
 ## Third-Party Licenses
 


### PR DESCRIPTION
The Emby-DLL/ binary is closed-source and distributed under separate proprietary terms, not the repo's MIT license. Add a scoped LICENSE and README to that directory and note the carve-out in the top-level LICENSE so the terms are unambiguous before paid licensing begins.