### PR TITLE
Pin remaining GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create / Update GitHub Release notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           body: ${{ steps.build.outputs.changelog }}

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -47,7 +47,7 @@ jobs:
           echo "Building branch: $BRANCH_NAME as tag: $SAFE_BRANCH"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/ghcr-main.yml
+++ b/.github/workflows/ghcr-main.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create tag (if missing)
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const tag = process.env.TAG;


### PR DESCRIPTION
feature-branch.yml and changelog.yml were still referencing actions by floating version tag instead of the SHA-pinned convention used in ghcr-dev.yml/ghcr-main.yml. Pin docker/setup-buildx-action, docker/login-action, docker/build-push-action, and softprops/action-gh-release to the same commit SHAs already verified working there (picking up the v3->v4, v3->v4, v5->v7, and v2->v3 bumps dependabot proposed).

Also sync ghcr-main.yml's actions/github-script pin with the fix merged to main in #41 — the old pin used the v9.0.0 tag object's SHA instead of the commit it points to, which confused dependabot's version tracking.