### PR TITLE
Note early-adopter perk in Emby plugin licensing section

### DIFF
--- a/Emby-DLL/README.md
+++ b/Emby-DLL/README.md
@@ -17,3 +17,7 @@ terms from the rest of this repository — see [LICENSE](LICENSE).
 It is currently free to use during the preview/trial period. Paid licensing
 details will be announced here and on the plugin's configuration page before
 any change takes effect.
+
+If you register a license before that change goes live, you'll get a full
+year of paid use for free — our way of saying thanks for trying this out
+while it was still being built.


### PR DESCRIPTION
The plugin is free during the preview period, with paid licensing planned for later. Anyone who registers a license before that switch flips gets a full year of paid use free — this documents that commitment so it isn't a surprise when pricing details land.