### PR TITLE
fix: reconnect on stale database connection

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -36,8 +36,9 @@ class ChronarrDatabase:
     
     
     def _get_connection(self) -> 'psycopg2.extensions.connection':
-        """Get thread-local PostgreSQL database connection"""
-        if not hasattr(self._local, 'connection'):
+        """Get thread-local PostgreSQL database connection, reconnecting if closed"""
+        conn = getattr(self._local, 'connection', None)
+        if conn is None or conn.closed:
             self._local.connection = psycopg2.connect(
                 host=self.db_host,
                 port=self.db_port,
@@ -60,9 +61,14 @@ class ChronarrDatabase:
         conn = self._get_connection()
         try:
             yield conn
-            # PostgreSQL uses autocommit - no manual commit needed
-        except Exception:
-            # PostgreSQL uses autocommit - no manual rollback needed
+        except (psycopg2.OperationalError, psycopg2.InterfaceError):
+            # Connection died mid-use — discard it so the next caller reconnects
+            if hasattr(self._local, 'connection'):
+                try:
+                    self._local.connection.close()
+                except Exception:
+                    pass
+                delattr(self._local, 'connection')
             raise
     
     def _init_database(self):


### PR DESCRIPTION
All movie and episode lookups were returning 500 with "connection already closed" after any PostgreSQL connectivity blip (container restart, idle timeout, network drop).

_get_connection() only created a new connection when the thread-local had no connection stored at all. Once psycopg2 marked a connection as closed (conn.closed = 2), the attribute still existed so every subsequent call got back the dead connection and failed immediately.

Two changes:
- _get_connection() now checks conn.closed in addition to existence, so a known-dead connection is replaced before use
- get_connection() context manager clears the dead connection on OperationalError/InterfaceError, so the next request reconnects cleanly instead of hitting the same dead connection again
