### PR TITLE
fix: batch IMDb validation rejects standard Radarr folder naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,11 @@ Chronarr works with standard Radarr/Sonarr folder naming out of the box — no c
 /tv/Breaking Bad (2008) [imdb-tt0903747]/
 ```
 
-When an IMDb ID is present in the folder name, Chronarr cross-checks it against the webhook payload as an extra validation step — useful if you want to catch mismatches between your folder names and what Radarr/Sonarr reports. Without it, the webhook payload is used as the authoritative source, which is correct in all normal setups.
+When an IMDb ID is present in the folder or file name, Chronarr cross-checks it against the webhook payload as an extra validation step. If a conflicting ID is found, the webhook is rejected to prevent processing the wrong media. If no ID is present, the webhook payload is trusted as the authoritative source — which is correct for all standard naming setups.
+
+**Radarr** — if your movie file naming includes `[{ImdbId}]`, Chronarr detects it from the filename inside the folder even when the folder name itself is standard.
+
+**Sonarr** — the series folder name is checked. If your series folder format includes `[imdb-{ImdbId}]`, Chronarr will cross-check on every TV webhook.
 
 Supported IMDb formats in folder/file names: `[imdb-tt1234567]`, `[tt1234567]`, `{imdb-tt1234567}`, `(imdb-tt1234567)`.
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,26 @@ Watch as Chronarr imports all your media with proper dates!
 
 > **📖 For detailed setup instructions, see [QUICKSTART.md](QUICKSTART.md)**
 
+## Folder Naming
+
+Chronarr works with standard Radarr/Sonarr folder naming out of the box — no changes required.
+
+**Standard naming (always works):**
+```
+/movies/Selena (1997)/
+/tv/Breaking Bad (2008)/
+```
+
+**Optional — embed IMDb ID in folder name:**
+```
+/movies/Selena (1997) [imdb-tt0120094]/
+/tv/Breaking Bad (2008) [imdb-tt0903747]/
+```
+
+When an IMDb ID is present in the folder name, Chronarr cross-checks it against the webhook payload as an extra validation step — useful if you want to catch mismatches between your folder names and what Radarr/Sonarr reports. Without it, the webhook payload is used as the authoritative source, which is correct in all normal setups.
+
+Supported IMDb formats in folder/file names: `[imdb-tt1234567]`, `[tt1234567]`, `{imdb-tt1234567}`, `(imdb-tt1234567)`.
+
 ## Architecture
 
 Chronarr uses a 3-container Docker Compose architecture:

--- a/api/routes.py
+++ b/api/routes.py
@@ -331,9 +331,7 @@ async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, de
             _log("ERROR", "This prevents processing wrong movies due to path mapping issues")
             return {"status": "error", "message": f"Mapped movie path does not exist: {container_path}"}
         
-        # Verify the path contains the expected IMDb ID
-        if imdb_id not in container_path.lower():
-            print(f"WARNING: IMDb ID {imdb_id} not found in container path {container_path}")
+        # IMDb ID won't be in the path for standard Radarr folder naming — omit the check
         
         # Create movie-specific webhook data with proper path validation
         movie_webhook_data = {

--- a/webhooks/webhook_batcher.py
+++ b/webhooks/webhook_batcher.py
@@ -102,43 +102,39 @@ class WebhookBatcher:
                 _log("ERROR", f"This indicates a path mapping issue - webhook rejected to prevent wrong processing")
                 return
             
-            # CRITICAL: Validate that the path contains the expected IMDb ID for movies
+            # Validate IMDb ID for movies — only reject if a conflicting ID is found.
+            # Standard Radarr folder naming (Movie Title (Year)) doesn't embed IMDb IDs,
+            # so no detection is normal and not a reason to reject.
             if media_type == 'movie':
                 expected_imdb = key.replace('movie:', '') if key.startswith('movie:') else key
 
-                # Use imdb_utils for IMDb detection (Phase 3: no NFO reading)
                 detected_imdb = find_imdb_in_directory(path_obj)
-                imdb_match = False
                 if detected_imdb:
-                    # Compare with and without 'tt' prefix for flexibility
+                    # An ID was found — check it matches
                     if detected_imdb == expected_imdb or detected_imdb.replace('tt', '') == expected_imdb.replace('tt', ''):
-                        imdb_match = True
+                        _log("DEBUG", f"Batch validation passed: IMDb {expected_imdb} confirmed in folder name")
+                    else:
+                        _log("ERROR", f"BATCH VALIDATION FAILED: folder contains {detected_imdb} but webhook expected {expected_imdb} in {path_str}")
+                        _log("ERROR", f"This prevents processing the wrong movie due to a mismatched batch entry")
+                        return
+                else:
+                    # No IMDb ID in folder/file names — standard naming, trust the webhook
+                    _log("DEBUG", f"Batch validation: no IMDb in folder name for {path_str}, trusting webhook ID {expected_imdb}")
 
-                if not imdb_match:
-                    _log("ERROR", f"BATCH VALIDATION FAILED: Expected IMDb {expected_imdb} but found {detected_imdb} in {path_str}")
-                    _log("ERROR", f"Detected IMDb: {detected_imdb}, Expected: {expected_imdb}")
-                    _log("ERROR", f"This prevents processing wrong movies due to batch corruption")
-                    return
-                _log("DEBUG", f"Batch validation passed: IMDb {expected_imdb} matches detected {detected_imdb}")
-            
-            # CRITICAL: Validate that the path contains the expected IMDb ID for TV shows
+            # Validate IMDb ID for TV shows — same logic: conflict = reject, absent = proceed.
             if media_type == 'tv':
                 expected_imdb = key.replace('tv:', '') if key.startswith('tv:') else key
 
-                # Use imdb_utils for IMDb detection (Phase 3: no NFO reading)
                 detected_imdb = parse_imdb_from_path(path_obj)
-                imdb_match = False
                 if detected_imdb:
-                    # Compare with and without 'tt' prefix for flexibility
                     if detected_imdb == expected_imdb or detected_imdb.replace('tt', '') == expected_imdb.replace('tt', ''):
-                        imdb_match = True
-
-                if not imdb_match:
-                    _log("ERROR", f"BATCH VALIDATION FAILED: Expected IMDb {expected_imdb} but found {detected_imdb} in TV {path_str}")
-                    _log("ERROR", f"Detected TV IMDb: {detected_imdb}, Expected: {expected_imdb}")
-                    _log("ERROR", f"This prevents processing wrong TV series due to batch corruption")
-                    return
-                _log("DEBUG", f"TV batch validation passed: IMDb {expected_imdb} matches detected {detected_imdb}")
+                        _log("DEBUG", f"TV batch validation passed: IMDb {expected_imdb} confirmed in folder name")
+                    else:
+                        _log("ERROR", f"BATCH VALIDATION FAILED: folder contains {detected_imdb} but webhook expected {expected_imdb} in TV {path_str}")
+                        _log("ERROR", f"This prevents processing the wrong series due to a mismatched batch entry")
+                        return
+                else:
+                    _log("DEBUG", f"TV batch validation: no IMDb in folder name for {path_str}, trusting webhook ID {expected_imdb}")
                 
                 if not self.tv_processor:
                     _log("ERROR", "TV processor not available")


### PR DESCRIPTION
The batch validator required an IMDb ID embedded in the folder or file name to proceed. Standard Radarr naming (Movie Title (Year)) never includes one, so every webhook was failing validation after path mapping.

Changed the logic: only reject if a conflicting ID is found in the folder name. No ID in the name means standard naming — the webhook payload is already the authoritative source for the IMDb ID. The protection against real batch corruption (mismatched ID) is still fully intact.