### PR TITLE
fix: webhook processing fails for standard Radarr/Sonarr folder naming

### DIFF
--- a/processors/movie_processor.py
+++ b/processors/movie_processor.py
@@ -171,9 +171,13 @@ class MovieProcessor:
             _log("ERROR", f"Error checking movie completion for {imdb_id}: {e}")
             return False, f"Error checking completion: {e}"
     
-    def process_movie(self, movie_path: Path, webhook_mode: bool = False, force_scan: bool = False, scan_mode: str = "smart", shutdown_event=None) -> str:
+    def process_movie(self, movie_path: Path, webhook_mode: bool = False, force_scan: bool = False, scan_mode: str = "smart", shutdown_event=None, imdb_id: str = None) -> str:
         """Process a movie directory"""
-        imdb_id = find_imdb_in_directory(movie_path)  # Phase 3: Using imdb_utils instead of NFOManager
+        # Prefer the IMDb ID passed in (e.g. from webhook payload) over filesystem detection.
+        # Filesystem detection only works when the ID is embedded in the folder/file name,
+        # which standard Radarr naming doesn't do.
+        if not imdb_id:
+            imdb_id = find_imdb_in_directory(movie_path)
         if not imdb_id:
             _log("ERROR", f"No IMDb ID found in movie directory, filenames, or NFO file: {movie_path}")
             return "error"

--- a/processors/tv_processor.py
+++ b/processors/tv_processor.py
@@ -178,9 +178,10 @@ class TVProcessor:
             _log("ERROR", f"Error checking series completion for {imdb_id}: {e}")
             return False, f"Error checking completion: {e}"
     
-    def process_series(self, series_path: Path, force_scan: bool = False, scan_mode: str = "smart") -> str:
+    def process_series(self, series_path: Path, force_scan: bool = False, scan_mode: str = "smart", imdb_id: str = None) -> str:
         """Process a TV series directory"""
-        imdb_id = parse_imdb_from_path(series_path)  # Phase 3: Using imdb_utils
+        if not imdb_id:
+            imdb_id = parse_imdb_from_path(series_path)
         if not imdb_id:
             _log("ERROR", f"No IMDb ID found in series path: {series_path}")
             return "error"
@@ -779,9 +780,10 @@ class TVProcessor:
         
         return processed_results
     
-    def process_webhook_episodes(self, series_path: Path, webhook_episodes: List[Dict[str, Any]]) -> None:
+    def process_webhook_episodes(self, series_path: Path, webhook_episodes: List[Dict[str, Any]], imdb_id: str = None) -> None:
         """Process only the specific episodes mentioned in a webhook (targeted mode)"""
-        imdb_id = parse_imdb_from_path(series_path)  # Phase 3: Using imdb_utils
+        if not imdb_id:
+            imdb_id = parse_imdb_from_path(series_path)
         if not imdb_id:
             _log("ERROR", f"No IMDb ID found in series path: {series_path}")
             return

--- a/webhooks/webhook_batcher.py
+++ b/webhooks/webhook_batcher.py
@@ -162,7 +162,7 @@ class WebhookBatcher:
                     _log("ERROR", "Movie processor not available")
                     return
                     
-                self.movie_processor.process_movie(path_obj, webhook_mode=True)
+                self.movie_processor.process_movie(path_obj, webhook_mode=True, imdb_id=expected_imdb)
             else:
                 _log("ERROR", f"Unknown media type: {media_type}")
         

--- a/webhooks/webhook_batcher.py
+++ b/webhooks/webhook_batcher.py
@@ -152,10 +152,10 @@ class WebhookBatcher:
                         _log("INFO", f"Processing {len(episodes_data)} episodes sequentially with {config.sequential_delay}s delay")
                         self._process_episodes_sequentially(path_obj, episodes_data)
                     else:
-                        self.tv_processor.process_webhook_episodes(path_obj, episodes_data)
+                        self.tv_processor.process_webhook_episodes(path_obj, episodes_data, imdb_id=expected_imdb)
                 else:
                     _log("INFO", f"Using series processing mode (fallback or configured)")
-                    self.tv_processor.process_series(path_obj)
+                    self.tv_processor.process_series(path_obj, imdb_id=expected_imdb)
                     
             elif media_type == 'movie':
                 if not self.movie_processor:


### PR DESCRIPTION
Webhook processing assumed an IMDb ID would be embedded in the movie folder or TV series folder name. Standard Radarr/Sonarr naming (Movie Title (Year), Series Title (Year)) never includes one, so detection always returned nothing and processing was rejected.

Fixed by passing the IMDb ID from the webhook payload directly into the movie and TV processors. Filesystem detection is kept as a fallback for manual scans where no webhook ID is available.

Also tightened the batch validator — previously rejected any entry where no IMDb was found in the folder name. Now only rejects if a conflicting ID is detected, which is the actual corruption case worth catching.