### PR TITLE
fix: store movie title and year from Radarr alongside dates

### DIFF
--- a/processors/movie_processor.py
+++ b/processors/movie_processor.py
@@ -255,12 +255,17 @@ class MovieProcessor:
         
         # TIER 2: Query external APIs directly (NFO layer removed in Phase 2)
         _log("INFO", f"🔍 TIER 2 - No database cache, querying external APIs")
-        
+
+        # Fetch title/year from Radarr now so we can store them alongside dates
+        radarr_meta = self.radarr.movie_by_imdb(imdb_id) if self.radarr else None
+        title = radarr_meta.get("title") if radarr_meta else None
+        year = radarr_meta.get("year") if radarr_meta else None
+
         # Check for shutdown signal before expensive API operations
         if shutdown_event and shutdown_event.is_set():
             _log("INFO", f"⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing before API calls: {movie_path.name}")
             return "shutdown"
-        
+
         # TIER 3: No cached data found - determine if we should query APIs
         if webhook_mode:
             _log("INFO", f"Webhook processing - no cached data found, using full date decision logic")
@@ -298,7 +303,7 @@ class MovieProcessor:
         # Skip remaining processing if no valid date found and file dates disabled
         if final_dateadded is None:
             _log("WARNING", f"Movie {movie_path.name} - no valid date source available, but NFO was still processed")
-            self.db.upsert_movie_dates(imdb_id, released, None, source, True)
+            self.db.upsert_movie_dates(imdb_id, released, None, source, True, title=title, year=year)
             return "processed"
             
         # Update dateadded and source for the rest of processing
@@ -316,7 +321,7 @@ class MovieProcessor:
         # Save to database
         _log("DEBUG", f"About to save to database: imdb_id={imdb_id}, dateadded={dateadded}")
         try:
-            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True)
+            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year)
             _log("DEBUG", f"Database save completed for {imdb_id}")
         except Exception as e:
             _log("ERROR", f"Database save failed for {imdb_id}: {e}")
@@ -385,8 +390,11 @@ class MovieProcessor:
         
         # Save to database only (NFO operations removed in Phase 1)
         if dateadded:
-            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True)
-            
+            radarr_meta = self.radarr.movie_by_imdb(imdb_id) if self.radarr else None
+            title = radarr_meta.get("title") if radarr_meta else None
+            year = radarr_meta.get("year") if radarr_meta else None
+            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year)
+
             _log("INFO", f"🔍 INCOMPLETE MODE COMPLETE: {movie_path.name} (source: {source})")
             return "processed"
         else:


### PR DESCRIPTION
When processing movies, Radarr metadata is already available — this stores the title and year into the database at the same time as the dates rather than leaving those fields empty.

Fixes both the scheduled task path and the incomplete-mode path in `movie_processor.py`.