### PR TITLE
docs: add Emby plugin download page, SignPath mention, and privacy policy

### DIFF
--- a/Emby-DLL/README.md
+++ b/Emby-DLL/README.md
@@ -1,23 +1,30 @@
 # Chronarr Emby Plugin
 
-This directory contains the compiled Emby plugin binary
-(`Chronarr.Emby.Plugin.dll`) bundled with the Chronarr application.
+The Chronarr Emby plugin syncs accurate import dates from the Chronarr database back to your Emby library, so your media sorts by when you actually added it — not when Emby last scanned the file.
 
-**Bundled plugin version:** 2.0.13
+## Auto-Deploy (Recommended)
 
-The plugin syncs media "date added" metadata between Chronarr and your
-Emby server. Drop the DLL into your Emby `plugins` folder to install it —
-see the main project documentation for setup instructions.
+Chronarr ships the plugin DLL inside the Docker image and deploys it automatically on startup. Mount your Emby plugins directory in `docker-compose.yml`:
 
-## Licensing
+```yaml
+volumes:
+  - /path/to/emby/plugins:/emby-plugins
+```
 
-This is closed-source software distributed in binary form under separate
-terms from the rest of this repository — see [LICENSE](LICENSE).
+Or set `EMBY_PLUGINS_PATH` in your `.env` to the Emby plugins folder on the host. On startup you'll see:
 
-It is currently free to use during the preview/trial period. Paid licensing
-details will be announced here and on the plugin's configuration page before
-any change takes effect.
+```
+✅ Plugin deployed successfully! (257536 bytes)
+```
 
-If you register a license before that change goes live, you'll get a full
-year of paid use for free — our way of saying thanks for trying this out
-while it was still being built.
+## Manual Install
+
+If you prefer to install manually, download `Chronarr.Emby.Plugin.dll` from this directory and place it in your Emby plugins folder. Restart Emby.
+
+## Code Signing
+
+This project uses [SignPath Foundation](https://signpath.org) for code signing.
+
+## Changelog
+
+The plugin changelog is visible in the Emby configuration page under **Dashboard → Plugins → Chronarr → Version & Changelog**.

--- a/README.md
+++ b/README.md
@@ -501,6 +501,20 @@ A: **Radarr requires direct database access** (PostgreSQL or SQLite) - the Radar
 **Q: Does this work with SQLite Radarr/Sonarr databases?**
 A: Yes, Chronarr can read from both SQLite and PostgreSQL databases for both Radarr and Sonarr. **Important for Docker users**: You must mount the directory containing the SQLite database file(s) as a read-only volume in your `docker-compose.yml`. See the Quick Start guide for configuration details.
 
+## Privacy Policy
+
+Chronarr's core application does not collect personal data. It reads only from your local Radarr and Sonarr databases and stores date information in your own PostgreSQL instance.
+
+The **Emby plugin** collects the following information during license registration:
+
+- **Name** — used to identify your license
+- **Email address** — used to deliver your license key and send license status notifications
+- **Server name** — used to associate a license with a specific Emby installation
+
+This data is transmitted to the Chronarr license server and is used solely for license management. It is never sold, shared with third parties, or used for any purpose other than validating and managing your license.
+
+To request removal of your data, open an issue at [github.com/sbcrumb/chronarr/issues](https://github.com/sbcrumb/chronarr/issues).
+
 ## Contributing
 
 Contributions welcome! Please:


### PR DESCRIPTION
Adds two docs required for the SignPath Foundation code signing application:

- **`Emby-DLL/README.md`** — download and install instructions for the Emby plugin, with the required SignPath Foundation mention
- **Privacy Policy section in README** — covers what data the Emby plugin collects during license registration (name, email, server name), how it's used, and how to request removal

No code changes.