### PR TITLE
Feature/v3 phase2

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -80,8 +80,8 @@ async def _verify_webhook_signature(request: Request, body: bytes, secret: str, 
 # Route Handlers
 # ---------------------------
 
-async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, dependencies: dict):
-    """Handle Sonarr webhooks"""
+async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, dependencies: dict, instance: str = "sonarr"):
+    """Handle Sonarr webhooks — instance name comes from the URL path."""
     tv_processor = dependencies["tv_processor"]
     batcher = dependencies["batcher"]
     config = dependencies["config"]
@@ -267,14 +267,14 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
             processing_mode = "targeted"
             _log("INFO", f"Forcing targeted mode for {len(episodes_data)} episode(s)")
         
-        # Add to batch queue with TV-prefixed key to avoid movie conflicts
         tv_batch_key = f"tv:{imdb_id}"
         webhook_dict = {
             'path': str(series_path),
             'series_info': series_info,
             'event_type': webhook.eventType,
-            'episodes': episodes_data,  # Include enhanced episode data for targeted processing
-            'processing_mode': processing_mode  # Use forced targeted mode when appropriate
+            'episodes': episodes_data,
+            'processing_mode': processing_mode,
+            'instance': instance,
         }
         batcher.add_webhook(tv_batch_key, webhook_dict, 'tv')
         
@@ -285,9 +285,10 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         raise HTTPException(status_code=422, detail=f"Invalid webhook: {e}")
 
 
-async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, dependencies: dict):
-    """Handle Radarr webhooks"""
-    path_mapper = dependencies["path_mapper"]
+async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, dependencies: dict, instance: str = "radarr"):
+    """Handle Radarr webhooks — instance name comes from the URL path."""
+    registry = dependencies.get("registry")
+    path_mapper = registry.radarr_mapper(instance) if registry else dependencies.get("path_mapper")
     batcher = dependencies["batcher"]
     config = dependencies["config"]
 
@@ -333,17 +334,16 @@ async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         
         # IMDb ID won't be in the path for standard Radarr folder naming — omit the check
         
-        # Create movie-specific webhook data with proper path validation
         movie_webhook_data = {
-            'path': container_path,  # Use verified container path
+            'path': container_path,
             'movie_info': movie_data,
             'event_type': payload.get('eventType'),
-            'original_payload': payload
+            'original_payload': payload,
+            'instance': instance,
         }
-        
-        # Add to batch queue with movie-prefixed key to avoid TV conflicts
+
         movie_batch_key = f"movie:{imdb_id}"
-        _log("DEBUG", f"Adding Radarr webhook to batch: key={movie_batch_key}, movie_title={movie_data.get('title', 'Unknown')}")
+        _log("DEBUG", f"Adding Radarr webhook to batch: key={movie_batch_key}, movie_title={movie_data.get('title', 'Unknown')}, instance={instance}")
         batcher.add_webhook(movie_batch_key, movie_webhook_data, "movie")
         
         return {"status": "success", "message": f"Radarr webhook queued for {movie_batch_key}"}
@@ -2990,30 +2990,47 @@ _populate_status = {"running": False, "completed": False}
 
 
 def register_routes(app, dependencies: dict):
-    """
-    Register all routes with the FastAPI app
-    
-    Args:
-        app: FastAPI application instance
-        dependencies: Dictionary containing:
-            - db: ChronarrDatabase instance
-            - nfo_manager: NFOManager instance
-            - path_mapper: PathMapper instance
-            - tv_processor: TVProcessor instance
-            - movie_processor: MovieProcessor instance
-            - batcher: WebhookBatcher instance
-            - start_time: Application start time
-            - config: ChronarrConfig instance
-            - version: Application version string
-    """
-    
-    @app.post("/webhook/sonarr")
-    async def _sonarr_webhook(request: Request, background_tasks: BackgroundTasks):
-        return await sonarr_webhook(request, background_tasks, dependencies)
+    """Register all routes. Webhook routes are registered per-instance dynamically."""
 
-    @app.post("/webhook/radarr") 
-    async def _radarr_webhook(request: Request, background_tasks: BackgroundTasks):
-        return await radarr_webhook(request, background_tasks, dependencies)
+    # Backward-compat aliases for single-instance users: /webhook/sonarr, /webhook/radarr
+    @app.post("/webhook/sonarr")
+    async def _sonarr_webhook_default(request: Request, background_tasks: BackgroundTasks):
+        return await sonarr_webhook(request, background_tasks, dependencies, instance="sonarr")
+
+    @app.post("/webhook/radarr")
+    async def _radarr_webhook_default(request: Request, background_tasks: BackgroundTasks):
+        return await radarr_webhook(request, background_tasks, dependencies, instance="radarr")
+
+    # Per-instance webhook routes derived from discovered instance names.
+    # Each instance named "radarr_4k" gets /radarr_4k/webhook; the default "radarr"
+    # instance gets /radarr/webhook in addition to the /webhook/radarr alias above.
+    registry = dependencies.get("registry")
+    if registry:
+        for name in registry.radarr_names:
+            _inst = name  # capture for closure
+
+            async def _radarr_instance_handler(request: Request, background_tasks: BackgroundTasks, _n=_inst):
+                return await radarr_webhook(request, background_tasks, dependencies, instance=_n)
+
+            app.add_api_route(
+                f"/{name}/webhook",
+                _radarr_instance_handler,
+                methods=["POST"],
+                name=f"radarr_webhook_{name}",
+            )
+
+        for name in registry.sonarr_names:
+            _inst = name
+
+            async def _sonarr_instance_handler(request: Request, background_tasks: BackgroundTasks, _n=_inst):
+                return await sonarr_webhook(request, background_tasks, dependencies, instance=_n)
+
+            app.add_api_route(
+                f"/{name}/webhook",
+                _sonarr_instance_handler,
+                methods=["POST"],
+                name=f"sonarr_webhook_{name}",
+            )
 
     @app.post("/webhook/maintainarr")
     async def _maintainarr_webhook(request: Request, background_tasks: BackgroundTasks):

--- a/core/database.py
+++ b/core/database.py
@@ -4,6 +4,7 @@ PostgreSQL database management for Chronarr
 Handles database operations for tracking media dates and processing history
 """
 import json
+import os
 import threading
 from datetime import datetime
 from typing import Optional, Dict, List, Any
@@ -16,12 +17,6 @@ class ChronarrDatabase:
     """PostgreSQL database manager for Chronarr media tracking and processing history"""
     
     def __init__(self, config):
-        """
-        Initialize PostgreSQL database connection
-        
-        Args:
-            config: Configuration object with database settings
-        """
         if not config:
             raise ValueError("PostgreSQL configuration is required")
         self.db_host = config.db_host
@@ -72,32 +67,29 @@ class ChronarrDatabase:
             raise
     
     def _init_database(self):
-        """Initialize PostgreSQL database tables"""
         with self.get_connection() as conn:
             cursor = conn.cursor()
             self._init_postgresql_tables(cursor)
-            
-            # Test the connection works and verify autocommit
-            cursor.execute("SELECT 1")
-            print(f"✅ PostgreSQL database initialized and connection verified")
-            print(f"🔍 Autocommit status: {conn.autocommit}")
     
     def _init_postgresql_tables(self, cursor):
-        """Initialize database tables"""
-        # Series table
+        # Series — instance is part of the PK so two different Sonarr instances
+        # can track the same show independently.
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS series (
-                imdb_id VARCHAR(20) PRIMARY KEY,
+                imdb_id VARCHAR(20) NOT NULL,
+                instance VARCHAR(100) NOT NULL DEFAULT 'sonarr',
                 path TEXT NOT NULL,
                 last_updated TIMESTAMP NOT NULL,
-                metadata JSONB
+                metadata JSONB,
+                missing_from_source_since TIMESTAMP DEFAULT NULL,
+                PRIMARY KEY (imdb_id, instance)
             )
         """)
-        
-        # Episodes table
+
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS episodes (
                 imdb_id VARCHAR(20) NOT NULL,
+                instance VARCHAR(100) NOT NULL DEFAULT 'sonarr',
                 season INTEGER NOT NULL,
                 episode INTEGER NOT NULL,
                 aired DATE,
@@ -105,69 +97,70 @@ class ChronarrDatabase:
                 source VARCHAR(100),
                 last_updated TIMESTAMP NOT NULL,
                 has_video_file BOOLEAN DEFAULT FALSE,
-                PRIMARY KEY (imdb_id, season, episode),
-                FOREIGN KEY (imdb_id) REFERENCES series(imdb_id)
+                skipped BOOLEAN DEFAULT FALSE,
+                skip_reason TEXT,
+                PRIMARY KEY (imdb_id, season, episode, instance),
+                FOREIGN KEY (imdb_id, instance) REFERENCES series(imdb_id, instance)
             )
         """)
-        
-        # Movies table
+
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS movies (
-                imdb_id VARCHAR(20) PRIMARY KEY,
+                imdb_id VARCHAR(20) NOT NULL,
+                instance VARCHAR(100) NOT NULL DEFAULT 'radarr',
                 title TEXT,
                 year INTEGER,
-                path TEXT NOT NULL,
+                path TEXT NOT NULL DEFAULT 'unknown',
                 released DATE,
                 dateadded TIMESTAMP,
                 source VARCHAR(100),
                 last_updated TIMESTAMP NOT NULL,
-                has_video_file BOOLEAN DEFAULT FALSE
+                has_video_file BOOLEAN DEFAULT FALSE,
+                skipped BOOLEAN DEFAULT FALSE,
+                skip_reason TEXT,
+                missing_from_source_since TIMESTAMP DEFAULT NULL,
+                PRIMARY KEY (imdb_id, instance)
             )
         """)
 
-        # Add title and year columns if they don't exist (migration for existing databases)
+        # Migrate existing single-instance databases to the composite-PK schema.
+        # Runs only when the instance column is absent (first upgrade to v3).
         cursor.execute("""
             DO $$
             BEGIN
+                -- Series: drop the old FK from episodes before touching the series PK.
                 IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='movies' AND column_name='title') THEN
-                    ALTER TABLE movies ADD COLUMN title TEXT;
+                               WHERE table_name='series' AND column_name='instance') THEN
+                    ALTER TABLE episodes DROP CONSTRAINT IF EXISTS episodes_imdb_id_fkey;
+                    ALTER TABLE series ADD COLUMN instance VARCHAR(100) NOT NULL DEFAULT 'sonarr';
+                    ALTER TABLE series ADD COLUMN IF NOT EXISTS missing_from_source_since TIMESTAMP DEFAULT NULL;
+                    ALTER TABLE series DROP CONSTRAINT series_pkey;
+                    ALTER TABLE series ADD PRIMARY KEY (imdb_id, instance);
                 END IF;
-                IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='movies' AND column_name='year') THEN
-                    ALTER TABLE movies ADD COLUMN year INTEGER;
-                END IF;
-            END $$;
-        """)
 
-        # Add skipped and skip_reason columns if they don't exist (migration for skip tracking)
-        cursor.execute("""
-            DO $$
-            BEGIN
+                -- Movies: independent of series.
                 IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='movies' AND column_name='skipped') THEN
-                    ALTER TABLE movies ADD COLUMN skipped BOOLEAN DEFAULT FALSE;
+                               WHERE table_name='movies' AND column_name='instance') THEN
+                    ALTER TABLE movies ADD COLUMN instance VARCHAR(100) NOT NULL DEFAULT 'radarr';
+                    ALTER TABLE movies ADD COLUMN IF NOT EXISTS title TEXT;
+                    ALTER TABLE movies ADD COLUMN IF NOT EXISTS year INTEGER;
+                    ALTER TABLE movies ADD COLUMN IF NOT EXISTS skipped BOOLEAN DEFAULT FALSE;
+                    ALTER TABLE movies ADD COLUMN IF NOT EXISTS skip_reason TEXT;
+                    ALTER TABLE movies ADD COLUMN IF NOT EXISTS missing_from_source_since TIMESTAMP DEFAULT NULL;
+                    ALTER TABLE movies DROP CONSTRAINT movies_pkey;
+                    ALTER TABLE movies ADD PRIMARY KEY (imdb_id, instance);
                 END IF;
+
+                -- Episodes: needs series to have its composite PK in place first.
                 IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='movies' AND column_name='skip_reason') THEN
-                    ALTER TABLE movies ADD COLUMN skip_reason TEXT;
-                END IF;
-                IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='episodes' AND column_name='skipped') THEN
-                    ALTER TABLE episodes ADD COLUMN skipped BOOLEAN DEFAULT FALSE;
-                END IF;
-                IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='episodes' AND column_name='skip_reason') THEN
-                    ALTER TABLE episodes ADD COLUMN skip_reason TEXT;
-                END IF;
-                -- Library sync: track when items were first noticed missing from Radarr/Sonarr
-                IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='movies' AND column_name='missing_from_source_since') THEN
-                    ALTER TABLE movies ADD COLUMN missing_from_source_since TIMESTAMP DEFAULT NULL;
-                END IF;
-                IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                              WHERE table_name='series' AND column_name='missing_from_source_since') THEN
-                    ALTER TABLE series ADD COLUMN missing_from_source_since TIMESTAMP DEFAULT NULL;
+                               WHERE table_name='episodes' AND column_name='instance') THEN
+                    ALTER TABLE episodes ADD COLUMN instance VARCHAR(100) NOT NULL DEFAULT 'sonarr';
+                    ALTER TABLE episodes ADD COLUMN IF NOT EXISTS skipped BOOLEAN DEFAULT FALSE;
+                    ALTER TABLE episodes ADD COLUMN IF NOT EXISTS skip_reason TEXT;
+                    ALTER TABLE episodes DROP CONSTRAINT episodes_pkey;
+                    ALTER TABLE episodes ADD PRIMARY KEY (imdb_id, season, episode, instance);
+                    ALTER TABLE episodes ADD CONSTRAINT episodes_series_fk
+                        FOREIGN KEY (imdb_id, instance) REFERENCES series(imdb_id, instance);
                 END IF;
             END $$;
         """)
@@ -303,73 +296,62 @@ class ChronarrDatabase:
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_cleanup_executions_schedule ON cleanup_executions(schedule_id)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_cleanup_executions_status ON cleanup_executions(status)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_cleanup_executions_started ON cleanup_executions(started_at)")
-    def upsert_series(self, imdb_id: str, path: str, metadata: Optional[Dict] = None):
-        """Insert or update series record"""
+    def upsert_series(self, imdb_id: str, path: str, instance: str = 'sonarr', metadata: Optional[Dict] = None):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             timestamp = datetime.utcnow()
-            
             cursor.execute("""
-                INSERT INTO series (imdb_id, path, last_updated, metadata)
-                VALUES (%s, %s, %s, %s)
-                ON CONFLICT (imdb_id) DO UPDATE SET
+                INSERT INTO series (imdb_id, instance, path, last_updated, metadata)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (imdb_id, instance) DO UPDATE SET
                     path = EXCLUDED.path,
                     last_updated = EXCLUDED.last_updated,
                     metadata = EXCLUDED.metadata
-            """, (imdb_id, path, timestamp, json.dumps(metadata) if metadata else None))
+            """, (imdb_id, instance, path, timestamp, json.dumps(metadata) if metadata else None))
     
-    def upsert_episode_date(self, imdb_id: str, season: int, episode: int, 
-                           aired: Optional[str], dateadded: Optional[str], 
-                           source: str, has_video_file: bool = False):
-        """Insert or update episode date record"""
+    def upsert_episode_date(self, imdb_id: str, season: int, episode: int,
+                           aired: Optional[str], dateadded: Optional[str],
+                           source: str, has_video_file: bool = False, instance: str = 'sonarr'):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             timestamp = datetime.utcnow()
-            
             cursor.execute("""
-                INSERT INTO episodes 
-                (imdb_id, season, episode, aired, dateadded, source, has_video_file, last_updated)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (imdb_id, season, episode) DO UPDATE SET
+                INSERT INTO episodes
+                (imdb_id, instance, season, episode, aired, dateadded, source, has_video_file, last_updated)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (imdb_id, season, episode, instance) DO UPDATE SET
                     aired = COALESCE(EXCLUDED.aired, episodes.aired),
                     dateadded = COALESCE(EXCLUDED.dateadded, episodes.dateadded),
                     source = COALESCE(EXCLUDED.source, episodes.source),
                     has_video_file = EXCLUDED.has_video_file,
                     last_updated = EXCLUDED.last_updated
-            """, (imdb_id, season, episode, aired, dateadded, source, has_video_file, timestamp))
-            import os
-            if os.environ.get("DEBUG", "false").lower() == "true":
-                print(f"🔍 DEBUG: PostgreSQL upsert executed for {imdb_id} S{season:02d}E{episode:02d}, rows affected: {cursor.rowcount}")
+            """, (imdb_id, instance, season, episode, aired, dateadded, source, has_video_file, timestamp))
     
-    def upsert_movie(self, imdb_id: str, path: str):
-        """Insert or update movie record"""
+    def upsert_movie(self, imdb_id: str, path: str, instance: str = 'radarr'):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             timestamp = datetime.utcnow()
-            
             cursor.execute("""
-                INSERT INTO movies (imdb_id, path, last_updated)
-                VALUES (%s, %s, %s)
-                ON CONFLICT (imdb_id) DO UPDATE SET
+                INSERT INTO movies (imdb_id, instance, path, last_updated)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (imdb_id, instance) DO UPDATE SET
                     path = EXCLUDED.path,
                     last_updated = EXCLUDED.last_updated
-            """, (imdb_id, path, timestamp))
+            """, (imdb_id, instance, path, timestamp))
     
     def upsert_movie_dates(self, imdb_id: str, released: Optional[str],
                           dateadded: Optional[str], source: str, has_video_file: bool = False,
-                          title: Optional[str] = None, year: Optional[int] = None):
-        """Insert or update movie date record"""
-        import os
-        if os.environ.get("DEBUG", "false").lower() == "true":
-            print(f"🔍 DATABASE UPSERT: imdb_id={imdb_id}, title={title}, dateadded={dateadded}, source={source}")
+                          title: Optional[str] = None, year: Optional[int] = None,
+                          instance: str = 'radarr'):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             timestamp = datetime.utcnow()
-
             cursor.execute("""
-                INSERT INTO movies (imdb_id, title, year, path, released, dateadded, source, has_video_file, last_updated)
-                VALUES (%s, %s, %s, COALESCE((SELECT path FROM movies WHERE imdb_id = %s), 'unknown'), %s, %s, %s, %s, %s)
-                ON CONFLICT (imdb_id) DO UPDATE SET
+                INSERT INTO movies (imdb_id, instance, title, year, path, released, dateadded, source, has_video_file, last_updated)
+                VALUES (%s, %s, %s, %s,
+                        COALESCE((SELECT path FROM movies WHERE imdb_id = %s AND instance = %s), 'unknown'),
+                        %s, %s, %s, %s, %s)
+                ON CONFLICT (imdb_id, instance) DO UPDATE SET
                     title = COALESCE(EXCLUDED.title, movies.title),
                     year = COALESCE(EXCLUDED.year, movies.year),
                     released = COALESCE(EXCLUDED.released, movies.released),
@@ -377,114 +359,91 @@ class ChronarrDatabase:
                     source = COALESCE(EXCLUDED.source, movies.source),
                     has_video_file = EXCLUDED.has_video_file,
                     last_updated = EXCLUDED.last_updated
-            """, (imdb_id, title, year, imdb_id, released, dateadded, source, has_video_file, timestamp))
-            
-            # Debug: Check what was actually saved
-            cursor.execute("SELECT dateadded, source FROM movies WHERE imdb_id = %s", (imdb_id,))
-            result = cursor.fetchone()
-            import os
-            if os.environ.get("DEBUG", "false").lower() == "true":
-                print(f"🔍 DATABASE VERIFY: After upsert, found dateadded={result['dateadded'] if result else 'NOT_FOUND'}, source={result['source'] if result else 'NOT_FOUND'}")
+            """, (imdb_id, instance, title, year, imdb_id, instance, released, dateadded, source, has_video_file, timestamp))
 
-    def mark_movie_skipped(self, imdb_id: str, title: str, year: int, path: str, reason: str):
-        """Mark a movie as skipped with reason"""
+    def mark_movie_skipped(self, imdb_id: str, title: str, year: int, path: str, reason: str, instance: str = 'radarr'):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             timestamp = datetime.utcnow()
             cursor.execute("""
-                INSERT INTO movies (imdb_id, title, year, path, skipped, skip_reason, has_video_file, last_updated)
-                VALUES (%s, %s, %s, %s, TRUE, %s, FALSE, %s)
-                ON CONFLICT (imdb_id) DO UPDATE SET
+                INSERT INTO movies (imdb_id, instance, title, year, path, skipped, skip_reason, has_video_file, last_updated)
+                VALUES (%s, %s, %s, %s, %s, TRUE, %s, FALSE, %s)
+                ON CONFLICT (imdb_id, instance) DO UPDATE SET
                     title = EXCLUDED.title,
                     year = EXCLUDED.year,
                     path = EXCLUDED.path,
                     skipped = TRUE,
                     skip_reason = EXCLUDED.skip_reason,
                     last_updated = EXCLUDED.last_updated
-            """, (imdb_id, title, year, path, reason, timestamp))
+            """, (imdb_id, instance, title, year, path, reason, timestamp))
 
-    def mark_episode_skipped(self, imdb_id: str, season: int, episode: int, reason: str):
-        """Mark an episode as skipped with reason"""
+    def mark_episode_skipped(self, imdb_id: str, season: int, episode: int, reason: str, instance: str = 'sonarr'):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             timestamp = datetime.utcnow()
             cursor.execute("""
-                INSERT INTO episodes (imdb_id, season, episode, skipped, skip_reason, has_video_file, last_updated)
-                VALUES (%s, %s, %s, TRUE, %s, FALSE, %s)
-                ON CONFLICT (imdb_id, season, episode) DO UPDATE SET
+                INSERT INTO episodes (imdb_id, instance, season, episode, skipped, skip_reason, has_video_file, last_updated)
+                VALUES (%s, %s, %s, %s, TRUE, %s, FALSE, %s)
+                ON CONFLICT (imdb_id, season, episode, instance) DO UPDATE SET
                     skipped = TRUE,
                     skip_reason = EXCLUDED.skip_reason,
                     last_updated = EXCLUDED.last_updated
-            """, (imdb_id, season, episode, reason, timestamp))
+            """, (imdb_id, instance, season, episode, reason, timestamp))
 
-    def clear_movie_skipped(self, imdb_id: str):
-        """Clear skipped flag for a movie"""
+    def clear_movie_skipped(self, imdb_id: str, instance: str = 'radarr'):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
                 UPDATE movies SET skipped = FALSE, skip_reason = NULL
-                WHERE imdb_id = %s
-            """, (imdb_id,))
+                WHERE imdb_id = %s AND instance = %s
+            """, (imdb_id, instance))
 
-    def clear_episode_skipped(self, imdb_id: str, season: int, episode: int):
-        """Clear skipped flag for an episode"""
+    def clear_episode_skipped(self, imdb_id: str, season: int, episode: int, instance: str = 'sonarr'):
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
                 UPDATE episodes SET skipped = FALSE, skip_reason = NULL
-                WHERE imdb_id = %s AND season = %s AND episode = %s
-            """, (imdb_id, season, episode))
+                WHERE imdb_id = %s AND season = %s AND episode = %s AND instance = %s
+            """, (imdb_id, season, episode, instance))
 
     def get_skipped_counts(self) -> Dict:
-        """Get counts of skipped movies and episodes"""
+        """Total skipped counts across all instances — for dashboard summary."""
         with self.get_connection() as conn:
             cursor = conn.cursor()
-
-            # Count skipped movies
             cursor.execute("SELECT COUNT(*) as count FROM movies WHERE skipped = TRUE")
             skipped_movies = cursor.fetchone()['count']
-
-            # Count skipped episodes
             cursor.execute("SELECT COUNT(*) as count FROM episodes WHERE skipped = TRUE")
             skipped_episodes = cursor.fetchone()['count']
-
             return {
                 'movies': skipped_movies,
                 'episodes': skipped_episodes,
                 'total': skipped_movies + skipped_episodes
             }
 
-    def get_series_episodes(self, imdb_id: str, has_video_file_only: bool = False) -> List[Dict]:
-        """Get all episodes for a series"""
+    def get_series_episodes(self, imdb_id: str, instance: str = 'sonarr', has_video_file_only: bool = False) -> List[Dict]:
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
-            query = "SELECT * FROM episodes WHERE imdb_id = %s"
-            params = [imdb_id]
+            query = "SELECT * FROM episodes WHERE imdb_id = %s AND instance = %s"
+            params = [imdb_id, instance]
             if has_video_file_only:
                 query += " AND has_video_file = TRUE"
-            
             cursor.execute(query, params)
             return [dict(row) for row in cursor.fetchall()]
-    
-    def get_episode_date(self, imdb_id: str, season: int, episode: int) -> Optional[Dict]:
-        """Get episode date record"""
+
+    def get_episode_date(self, imdb_id: str, season: int, episode: int, instance: str = 'sonarr') -> Optional[Dict]:
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
-                SELECT * FROM episodes 
-                WHERE imdb_id = %s AND season = %s AND episode = %s
-            """, (imdb_id, season, episode))
-            
+                SELECT * FROM episodes
+                WHERE imdb_id = %s AND season = %s AND episode = %s AND instance = %s
+            """, (imdb_id, season, episode, instance))
             row = cursor.fetchone()
             return dict(row) if row else None
-    
-    def get_movie_dates(self, imdb_id: str) -> Optional[Dict]:
-        """Get movie date record"""
+
+    def get_movie_dates(self, imdb_id: str, instance: str = 'radarr') -> Optional[Dict]:
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT * FROM movies WHERE imdb_id = %s", (imdb_id,))
-            
+            cursor.execute("SELECT * FROM movies WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
             row = cursor.fetchone()
             return dict(row) if row else None
     
@@ -498,79 +457,65 @@ class ChronarrDatabase:
             """, (imdb_id, media_type, event_type, datetime.utcnow().isoformat(), 
                   json.dumps(details) if details else None))
     
-    def migrate_movie_imdb_id(self, old_imdb_id: str, new_imdb_id: str) -> bool:
-        """Migrate a movie from placeholder IMDb ID to real IMDb ID"""
+    def migrate_movie_imdb_id(self, old_imdb_id: str, new_imdb_id: str, instance: str = 'radarr') -> bool:
+        """Replace a placeholder IMDb ID with the real one, preserving all other data."""
         with self.get_connection() as conn:
             cursor = conn.cursor()
 
-            # Check if old record exists
-            cursor.execute("SELECT * FROM movies WHERE imdb_id = %s", (old_imdb_id,))
+            cursor.execute("SELECT * FROM movies WHERE imdb_id = %s AND instance = %s", (old_imdb_id, instance))
             old_record = cursor.fetchone()
             if not old_record:
                 return False
 
             old_data = dict(old_record)
 
-            # Check if new IMDb ID already exists
-            cursor.execute("SELECT * FROM movies WHERE imdb_id = %s", (new_imdb_id,))
+            cursor.execute("SELECT * FROM movies WHERE imdb_id = %s AND instance = %s", (new_imdb_id, instance))
             if cursor.fetchone():
-                # New IMDb ID already exists, just delete the old one
-                cursor.execute("DELETE FROM movies WHERE imdb_id = %s", (old_imdb_id,))
+                cursor.execute("DELETE FROM movies WHERE imdb_id = %s AND instance = %s", (old_imdb_id, instance))
                 return True
 
-            # Create new record with correct IMDb ID
             cursor.execute("""
-                INSERT INTO movies (imdb_id, title, year, path, released, dateadded, source,
+                INSERT INTO movies (imdb_id, instance, title, year, path, released, dateadded, source,
                                    has_video_file, last_updated, skipped, skip_reason)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-            """, (new_imdb_id, old_data.get('title'), old_data.get('year'),
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE, NULL)
+            """, (new_imdb_id, instance, old_data.get('title'), old_data.get('year'),
                   old_data.get('path'), old_data.get('released'), old_data.get('dateadded'),
-                  old_data.get('source'), old_data.get('has_video_file'),
-                  datetime.utcnow(), False, None))  # Clear skipped status
+                  old_data.get('source'), old_data.get('has_video_file'), datetime.utcnow()))
 
-            # Delete old placeholder record
-            cursor.execute("DELETE FROM movies WHERE imdb_id = %s", (old_imdb_id,))
+            cursor.execute("DELETE FROM movies WHERE imdb_id = %s AND instance = %s", (old_imdb_id, instance))
             return True
 
-    def migrate_series_imdb_id(self, old_imdb_id: str, new_imdb_id: str) -> bool:
-        """Migrate a series and all its episodes from placeholder IMDb ID to real IMDb ID"""
+    def migrate_series_imdb_id(self, old_imdb_id: str, new_imdb_id: str, instance: str = 'sonarr') -> bool:
+        """Replace a placeholder series IMDb ID with the real one, migrating all episodes."""
         with self.get_connection() as conn:
             cursor = conn.cursor()
 
-            # Check if old series exists
-            cursor.execute("SELECT * FROM series WHERE imdb_id = %s", (old_imdb_id,))
+            cursor.execute("SELECT * FROM series WHERE imdb_id = %s AND instance = %s", (old_imdb_id, instance))
             old_series = cursor.fetchone()
             if not old_series:
                 return False
 
             old_series_data = dict(old_series)
 
-            # Check if new series IMDb ID already exists
-            cursor.execute("SELECT * FROM series WHERE imdb_id = %s", (new_imdb_id,))
+            cursor.execute("SELECT * FROM series WHERE imdb_id = %s AND instance = %s", (new_imdb_id, instance))
             if cursor.fetchone():
-                # New series already exists, migrate episodes and delete old series
-                cursor.execute("""
-                    UPDATE episodes SET imdb_id = %s WHERE imdb_id = %s
-                """, (new_imdb_id, old_imdb_id))
-                cursor.execute("DELETE FROM series WHERE imdb_id = %s", (old_imdb_id,))
+                cursor.execute("UPDATE episodes SET imdb_id = %s WHERE imdb_id = %s AND instance = %s",
+                               (new_imdb_id, old_imdb_id, instance))
+                cursor.execute("DELETE FROM series WHERE imdb_id = %s AND instance = %s", (old_imdb_id, instance))
                 return True
 
-            # Create new series record
             cursor.execute("""
-                INSERT INTO series (imdb_id, path, last_updated, metadata)
-                VALUES (%s, %s, %s, %s)
-            """, (new_imdb_id, old_series_data.get('path'),
+                INSERT INTO series (imdb_id, instance, path, last_updated, metadata)
+                VALUES (%s, %s, %s, %s, %s)
+            """, (new_imdb_id, instance, old_series_data.get('path'),
                   datetime.utcnow(), old_series_data.get('metadata')))
 
-            # Migrate all episodes to new series IMDb ID and clear skipped status
             cursor.execute("""
-                UPDATE episodes
-                SET imdb_id = %s, skipped = FALSE, skip_reason = NULL
-                WHERE imdb_id = %s
-            """, (new_imdb_id, old_imdb_id))
+                UPDATE episodes SET imdb_id = %s, skipped = FALSE, skip_reason = NULL
+                WHERE imdb_id = %s AND instance = %s
+            """, (new_imdb_id, old_imdb_id, instance))
 
-            # Delete old placeholder series
-            cursor.execute("DELETE FROM series WHERE imdb_id = %s", (old_imdb_id,))
+            cursor.execute("DELETE FROM series WHERE imdb_id = %s AND instance = %s", (old_imdb_id, instance))
             return True
 
     def get_stats(self) -> Dict[str, Any]:
@@ -616,62 +561,27 @@ class ChronarrDatabase:
                 "database_type": "postgresql"
             }
     
-    def delete_episode(self, imdb_id: str, season: int, episode: int) -> bool:
-        """
-        Delete a specific episode from the database
-        
-        Args:
-            imdb_id: Series IMDb ID
-            season: Season number
-            episode: Episode number
-            
-        Returns:
-            True if episode was deleted, False if not found
-        """
+    def delete_episode(self, imdb_id: str, season: int, episode: int, instance: str = 'sonarr') -> bool:
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
             cursor.execute("""
-                DELETE FROM episodes 
-                WHERE imdb_id = %s AND season = %s AND episode = %s
-            """, (imdb_id, season, episode))
-            
+                DELETE FROM episodes
+                WHERE imdb_id = %s AND season = %s AND episode = %s AND instance = %s
+            """, (imdb_id, season, episode, instance))
             deleted_count = cursor.rowcount
             conn.commit()
-            
             return deleted_count > 0
-    
-    def delete_series_episodes(self, imdb_id: str) -> int:
-        """
-        Delete all episodes for a series from the database
-        
-        Args:
-            imdb_id: Series IMDb ID
-            
-        Returns:
-            Number of episodes deleted
-        """
+
+    def delete_series_episodes(self, imdb_id: str, instance: str = 'sonarr') -> int:
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
-            cursor.execute("""
-                DELETE FROM episodes 
-                WHERE imdb_id = %s
-            """, (imdb_id,))
-            
+            cursor.execute("DELETE FROM episodes WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
             deleted_count = cursor.rowcount
             conn.commit()
-            
             return deleted_count
     
     def delete_orphaned_episodes(self) -> List[Dict]:
-        """
-        Find and delete episodes that don't have corresponding video files on disk
-        This requires checking filesystem for each episode, so use carefully
-        
-        Returns:
-            List of deleted episodes with their details
-        """
+        """Delete DB episode rows that have no matching file on disk. Checks filesystem."""
         from utils.file_utils import find_episodes_on_disk
         from pathlib import Path
         
@@ -679,119 +589,60 @@ class ChronarrDatabase:
         
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
-            # Get all series with their paths
-            cursor.execute("""
-                SELECT DISTINCT imdb_id, path FROM series
-            """)
-            
+            cursor.execute("SELECT DISTINCT imdb_id, path FROM series")
             series_list = cursor.fetchall()
-            
+
             for series in series_list:
                 imdb_id = series['imdb_id']
                 series_path = Path(series['path'])
-                
                 if not series_path.exists():
                     continue
-                
-                # Get episodes on disk
+
                 disk_episodes = find_episodes_on_disk(series_path)
                 disk_episode_keys = set(disk_episodes.keys())
-                
-                # Get episodes in database
-                cursor.execute("""
-                    SELECT season, episode, dateadded, source 
-                    FROM episodes 
-                    WHERE imdb_id = %s
-                """, (imdb_id,))
-                
-                db_episodes = cursor.fetchall()
-                
-                # Find orphaned episodes (in DB but not on disk)
-                for db_episode in db_episodes:
-                    season = db_episode['season']
-                    episode = db_episode['episode']
-                    episode_key = (season, episode)
-                    
-                    if episode_key not in disk_episode_keys:
-                        # Episode is orphaned - delete it
-                        cursor.execute("""
-                            DELETE FROM episodes 
-                            WHERE imdb_id = %s AND season = %s AND episode = %s
-                        """, (imdb_id, season, episode))
-                        
+
+                cursor.execute(
+                    "SELECT season, episode, dateadded, source FROM episodes WHERE imdb_id = %s",
+                    (imdb_id,)
+                )
+                for ep in cursor.fetchall():
+                    season, episode = ep['season'], ep['episode']
+                    if (season, episode) not in disk_episode_keys:
+                        cursor.execute(
+                            "DELETE FROM episodes WHERE imdb_id = %s AND season = %s AND episode = %s",
+                            (imdb_id, season, episode)
+                        )
                         deleted_episodes.append({
                             'imdb_id': imdb_id,
                             'season': season,
                             'episode': episode,
-                            'dateadded': db_episode['dateadded'],
-                            'source': db_episode['source'],
+                            'dateadded': ep['dateadded'],
+                            'source': ep['source'],
                             'series_path': str(series_path)
                         })
-            
+
             conn.commit()
-            
+
         return deleted_episodes
     
-    def delete_movie(self, imdb_id: str) -> bool:
-        """
-        Delete a specific movie from the database
-        
-        Args:
-            imdb_id: Movie IMDb ID
-            
-        Returns:
-            True if movie was deleted, False if not found
-        """
+    def delete_movie(self, imdb_id: str, instance: str = 'radarr') -> bool:
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
-            cursor.execute("""
-                DELETE FROM movies 
-                WHERE imdb_id = %s
-            """, (imdb_id,))
-            
+            cursor.execute("DELETE FROM movies WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
             deleted_count = cursor.rowcount
             conn.commit()
-            
             return deleted_count > 0
-    
-    def delete_series(self, imdb_id: str) -> bool:
-        """
-        Delete a specific series from the database
-        
-        Args:
-            imdb_id: Series IMDb ID
-            
-        Returns:
-            True if series was deleted, False if not found
-        """
+
+    def delete_series(self, imdb_id: str, instance: str = 'sonarr') -> bool:
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
-            cursor.execute("""
-                DELETE FROM series 
-                WHERE imdb_id = %s
-            """, (imdb_id,))
-            
+            cursor.execute("DELETE FROM series WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
             deleted_count = cursor.rowcount
             conn.commit()
-            
             return deleted_count > 0
 
     def update_movie_file_info(self, imdb_id: str, path: str, has_video_file: bool = True) -> bool:
-        """
-        Update path and video file status for an existing movie
-        Used when population finds a video file for a manually-added movie
-
-        Args:
-            imdb_id: Movie IMDb ID
-            path: File path to the video file
-            has_video_file: Whether a video file exists (default True)
-
-        Returns:
-            True if movie was updated, False if not found
-        """
+        """Update path and file status — used when a population scan finds a video for a queued movie."""
         with self.get_connection() as conn:
             cursor = conn.cursor()
 
@@ -842,24 +693,22 @@ class ChronarrDatabase:
     # ── Library sync helpers ──────────────────────────────────────────────────
 
     def get_all_movie_records(self) -> List[Dict]:
-        """Return all movies with id, title, path, and missing_from_source_since."""
+        """Return all movie records including instance — used by library sync."""
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT imdb_id, title, path, missing_from_source_since FROM movies"
+                "SELECT imdb_id, instance, title, path, missing_from_source_since FROM movies"
             )
-            rows = cursor.fetchall()
-            return [dict(r) for r in rows]
+            return [dict(r) for r in cursor.fetchall()]
 
     def get_all_series_records(self) -> List[Dict]:
-        """Return all series with imdb_id, path, metadata, and missing_from_source_since."""
+        """Return all series records including instance — used by library sync."""
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT imdb_id, path, metadata, missing_from_source_since FROM series"
+                "SELECT imdb_id, instance, path, metadata, missing_from_source_since FROM series"
             )
-            rows = cursor.fetchall()
-            return [dict(r) for r in rows]
+            return [dict(r) for r in cursor.fetchall()]
 
     def mark_movies_missing_from_source(self, imdb_ids: List[str], timestamp) -> None:
         """Set missing_from_source_since for movies not yet marked."""
@@ -938,112 +787,63 @@ class ChronarrDatabase:
             return [dict(r) for r in cursor.fetchall()]
 
     def delete_orphaned_movies(self) -> List[Dict]:
-        """
-        Find and delete movies that don't have corresponding video files on disk
-        This requires checking filesystem for each movie, so use carefully
-        
-        Returns:
-            List of deleted movies with their details
-        """
+        """Delete DB movie rows whose directory or video files no longer exist on disk."""
         from pathlib import Path
-        
+
         deleted_movies = []
-        
+        video_exts = (".mkv", ".mp4", ".avi", ".mov", ".m4v")
+
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
-            # Get all movies with their paths
-            cursor.execute("""
-                SELECT imdb_id, path, dateadded, source 
-                FROM movies
-            """)
-            
-            movies_list = cursor.fetchall()
-            
-            for movie in movies_list:
+            cursor.execute("SELECT imdb_id, path, dateadded, source FROM movies")
+
+            for movie in cursor.fetchall():
                 imdb_id = movie['imdb_id']
                 movie_path = Path(movie['path'])
-                
+
                 if not movie_path.exists():
-                    # Movie directory doesn't exist - delete it
-                    cursor.execute("""
-                        DELETE FROM movies 
-                        WHERE imdb_id = %s
-                    """, (imdb_id,))
-                    
+                    cursor.execute("DELETE FROM movies WHERE imdb_id = %s", (imdb_id,))
                     deleted_movies.append({
-                        'imdb_id': imdb_id,
-                        'reason': 'directory_not_found',
-                        'path': str(movie_path),
-                        'dateadded': movie['dateadded'],
+                        'imdb_id': imdb_id, 'reason': 'directory_not_found',
+                        'path': str(movie_path), 'dateadded': movie['dateadded'],
                         'source': movie['source']
                     })
                     continue
-                
-                # Check for video files
-                video_exts = (".mkv", ".mp4", ".avi", ".mov", ".m4v")
-                has_video = any(f.is_file() and f.suffix.lower() in video_exts 
-                              for f in movie_path.iterdir() if f.is_file())
-                
+
+                has_video = any(
+                    f.is_file() and f.suffix.lower() in video_exts
+                    for f in movie_path.iterdir() if f.is_file()
+                )
                 if not has_video:
-                    # No video files found - delete this movie
-                    cursor.execute("""
-                        DELETE FROM movies 
-                        WHERE imdb_id = %s
-                    """, (imdb_id,))
-                    
+                    cursor.execute("DELETE FROM movies WHERE imdb_id = %s", (imdb_id,))
                     deleted_movies.append({
-                        'imdb_id': imdb_id,
-                        'reason': 'no_video_files',
-                        'path': str(movie_path),
-                        'dateadded': movie['dateadded'],
+                        'imdb_id': imdb_id, 'reason': 'no_video_files',
+                        'path': str(movie_path), 'dateadded': movie['dateadded'],
                         'source': movie['source']
                     })
-            
+
             conn.commit()
-            
+
         return deleted_movies
     
     def delete_orphaned_series(self) -> List[Dict]:
-        """
-        Find and delete TV series that don't have corresponding directories on disk
-        This requires checking filesystem for each series, so use carefully
-        
-        Returns:
-            List of deleted series with their details
-        """
+        """Delete DB series (and all their episodes) whose directory no longer exists on disk."""
         from pathlib import Path
-        
+
         deleted_series = []
-        
+
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            
-            # Get all series with their paths
-            cursor.execute("""
-                SELECT imdb_id, path, last_updated, metadata 
-                FROM series
-            """)
-            
-            series_list = cursor.fetchall()
-            
-            for series in series_list:
+            cursor.execute("SELECT imdb_id, path, last_updated, metadata FROM series")
+
+            for series in cursor.fetchall():
                 imdb_id = series['imdb_id']
                 series_path = Path(series['path'])
-                
+
                 if not series_path.exists():
-                    # Series directory doesn't exist - delete the series and all its episodes
-                    cursor.execute("""
-                        DELETE FROM episodes 
-                        WHERE imdb_id = %s
-                    """, (imdb_id,))
+                    cursor.execute("DELETE FROM episodes WHERE imdb_id = %s", (imdb_id,))
                     episodes_deleted = cursor.rowcount
-                    
-                    cursor.execute("""
-                        DELETE FROM series 
-                        WHERE imdb_id = %s
-                    """, (imdb_id,))
-                    
+                    cursor.execute("DELETE FROM series WHERE imdb_id = %s", (imdb_id,))
                     deleted_series.append({
                         'imdb_id': imdb_id,
                         'reason': 'directory_not_found',
@@ -1051,9 +851,9 @@ class ChronarrDatabase:
                         'last_updated': series['last_updated'],
                         'episodes_deleted': episodes_deleted
                     })
-            
+
             conn.commit()
-            
+
         return deleted_series
     
     def add_missing_imdb(self, file_path: str, media_type: str, folder_name: str = None, filename: str = None, notes: str = None):

--- a/core/instance_registry.py
+++ b/core/instance_registry.py
@@ -1,9 +1,9 @@
 """
 Instance registry for Radarr and Sonarr clients.
 
-Builds one client per configured instance at startup and provides a central
-lookup by instance name. Processors and webhook handlers resolve the right
-client from here rather than each constructing their own from env vars.
+Builds one client and one PathMapper per configured instance at startup.
+Processors and webhook handlers resolve the right client/mapper from here
+rather than each constructing their own from env vars.
 """
 from typing import Dict, Optional, Union
 
@@ -13,6 +13,7 @@ from clients.sonarr_client import SonarrClient
 from clients.sonarr_db_client import SonarrDbClient
 from config.settings import RadarrInstance, SonarrInstance
 from core.logging import _log
+from core.path_mapper import PathMapper
 
 # Type aliases
 AnyRadarrClient = Union[RadarrClient, RadarrDbClient]
@@ -92,21 +93,31 @@ def _build_sonarr_client(instance: SonarrInstance) -> Optional[AnySonarrClient]:
 
 
 class InstanceRegistry:
-    """Central store of all Radarr and Sonarr clients, keyed by instance name."""
+    """Central store of all Radarr and Sonarr clients and path mappers, keyed by instance name."""
 
     def __init__(self, radarr_instances, sonarr_instances):
         self._radarr: Dict[str, AnyRadarrClient] = {}
         self._sonarr: Dict[str, AnySonarrClient] = {}
+        self._radarr_mappers: Dict[str, PathMapper] = {}
+        self._sonarr_mappers: Dict[str, PathMapper] = {}
 
         for inst in radarr_instances:
             client = _build_radarr_client(inst)
             if client:
                 self._radarr[inst.name] = client
+            self._radarr_mappers[inst.name] = PathMapper(
+                root_folders=inst.root_folders,
+                container_paths=inst.movie_paths,
+            )
 
         for inst in sonarr_instances:
             client = _build_sonarr_client(inst)
             if client:
                 self._sonarr[inst.name] = client
+            self._sonarr_mappers[inst.name] = PathMapper(
+                root_folders=inst.root_folders,
+                container_paths=inst.tv_paths,
+            )
 
         _log("INFO", f"Instance registry: {len(self._radarr)} Radarr, {len(self._sonarr)} Sonarr")
 
@@ -117,6 +128,14 @@ class InstanceRegistry:
     def sonarr(self, name: str = "sonarr") -> Optional[AnySonarrClient]:
         """Look up a Sonarr client by instance name."""
         return self._sonarr.get(name)
+
+    def radarr_mapper(self, name: str = "radarr") -> Optional[PathMapper]:
+        """Look up the PathMapper for a Radarr instance."""
+        return self._radarr_mappers.get(name)
+
+    def sonarr_mapper(self, name: str = "sonarr") -> Optional[PathMapper]:
+        """Look up the PathMapper for a Sonarr instance."""
+        return self._sonarr_mappers.get(name)
 
     def all_radarr(self) -> Dict[str, AnyRadarrClient]:
         return dict(self._radarr)

--- a/core/path_mapper.py
+++ b/core/path_mapper.py
@@ -1,120 +1,49 @@
-#!/usr/bin/env python3
-"""
-Path mapping utilities for Chronarr
-Handles conversion between external service paths and container paths
-"""
-import os
-import re
 from pathlib import Path
 
+
 class PathMapper:
-    """Handles path mapping between different environments"""
-    
-    def __init__(self, config):
-        """Initialize path mapper with configuration"""
-        # Use environment variables directly since config attribute names are unclear
-        import os
-        
-        radarr_roots_str = os.getenv('RADARR_ROOT_FOLDERS', '')
-        sonarr_roots_str = os.getenv('SONARR_ROOT_FOLDERS', '')
-        movie_paths_str = os.getenv('MOVIE_PATHS', '')
-        tv_paths_str = os.getenv('TV_PATHS', '')
-        
-        self.radarr_roots = [path.strip() for path in radarr_roots_str.split(',') if path.strip()]
-        self.sonarr_roots = [path.strip() for path in sonarr_roots_str.split(',') if path.strip()]
-        self.movie_paths = [path.strip() for path in movie_paths_str.split(',') if path.strip()]
-        self.tv_paths = [path.strip() for path in tv_paths_str.split(',') if path.strip()]
-        
-        # Check if path debugging is enabled
-        self.path_debug = os.getenv('PATH_DEBUG', 'false').lower() == 'true'
-        
-        if self.path_debug:
-            print(f"PATH_DEBUG: PathMapper initialized with:")
-            print(f"PATH_DEBUG: radarr_roots: {self.radarr_roots}")
-            print(f"PATH_DEBUG: sonarr_roots: {self.sonarr_roots}")
-            print(f"PATH_DEBUG: movie_paths: {self.movie_paths}")
-            print(f"PATH_DEBUG: tv_paths: {self.tv_paths}")
+    """Maps filesystem paths between what Radarr/Sonarr report and what the container sees.
+
+    One PathMapper is created per configured instance at startup, built from
+    that instance's root_folders and container_paths. The mapping logic is
+    identical for Radarr and Sonarr — only the data differs.
+    """
+
+    def __init__(self, root_folders: list, container_paths: list, debug: bool = False):
+        self.root_folders = root_folders
+        self.container_paths = container_paths
+        self.debug = debug
 
     @staticmethod
-    def _normalize_separators(path: str) -> str:
-        """Normalize path separators to forward slashes — handles UNC paths from Windows/Radarr"""
+    def _normalize(path: str) -> str:
+        """Backslash to forward slash — handles UNC paths from Windows/Radarr."""
         return path.replace('\\', '/')
 
-    def sonarr_path_to_container_path(self, sonarr_path: str) -> str:
-        """Convert Sonarr path to container path using environment mappings"""
-        # Normalize separators so UNC paths (\\server\share\...) match correctly
-        normalized_path = self._normalize_separators(sonarr_path)
+    def map(self, path: str) -> str:
+        """Translate an external path to its container equivalent.
 
-        if self.path_debug:
-            print(f"PATH_DEBUG: sonarr_path_to_container_path input: {sonarr_path}")
-            print(f"PATH_DEBUG: normalized input: {normalized_path}")
-            print(f"PATH_DEBUG: sonarr_roots: {self.sonarr_roots}")
-            print(f"PATH_DEBUG: tv_paths: {self.tv_paths}")
-
-        # Sort roots by length (longest first) to avoid substring matching issues
-        indexed_roots = [(i, root) for i, root in enumerate(self.sonarr_roots)]
-        indexed_roots.sort(key=lambda x: len(x[1]), reverse=True)
-
-        # Try to match against configured Sonarr root folders (longest first)
-        for original_index, sonarr_root in indexed_roots:
-            normalized_root = self._normalize_separators(sonarr_root)
-            if self.path_debug:
-                print(f"PATH_DEBUG: Checking sonarr_root[{original_index}]: {normalized_root}")
-            if normalized_path.startswith(normalized_root + '/') or normalized_path == normalized_root:
-                if self.path_debug:
-                    print(f"PATH_DEBUG: Match found! Index {original_index}")
-                # Map to corresponding TV path
-                if original_index < len(self.tv_paths):
-                    container_root = self.tv_paths[original_index]
-                    relative_path = normalized_path[len(normalized_root):].lstrip('/')
-                    result = str(Path(container_root) / relative_path) if relative_path else container_root
-                    if self.path_debug:
-                        print(f"PATH_DEBUG: Mapped to: {result}")
+        Tries each configured root folder longest-first to avoid prefix collisions
+        (e.g. /movies matching before /movies/4k). Returns the original path
+        unchanged if nothing matches — let the caller decide what to do.
+        """
+        normalized = self._normalize(path)
+        roots = sorted(enumerate(self.root_folders), key=lambda x: len(x[1]), reverse=True)
+        for idx, root in roots:
+            norm_root = self._normalize(root)
+            if normalized.startswith(norm_root + '/') or normalized == norm_root:
+                if idx < len(self.container_paths):
+                    rel = normalized[len(norm_root):].lstrip('/')
+                    result = str(Path(self.container_paths[idx]) / rel) if rel else self.container_paths[idx]
+                    if self.debug:
+                        print(f"[path_mapper] {path!r} -> {result!r}")
                     return result
+        if self.debug:
+            print(f"[path_mapper] no match for {path!r}, returning as-is")
+        return path
 
-        if self.path_debug:
-            print(f"PATH_DEBUG: No match found, returning original: {sonarr_path}")
-        # No fallback - if path mapping fails, return original and let validation catch it
-        return sonarr_path
+    # Backward-compat aliases — existing call sites use these names.
+    def radarr_path_to_container_path(self, path: str) -> str:
+        return self.map(path)
 
-    def radarr_path_to_container_path(self, radarr_path: str) -> str:
-        """Convert Radarr path to container path using environment mappings"""
-        # Normalize separators so UNC paths (\\server\share\...) match correctly
-        normalized_path = self._normalize_separators(radarr_path)
-
-        if self.path_debug:
-            print(f"PATH_DEBUG: radarr_path_to_container_path input: {radarr_path}")
-            print(f"PATH_DEBUG: normalized input: {normalized_path}")
-            print(f"PATH_DEBUG: radarr_roots: {self.radarr_roots}")
-            print(f"PATH_DEBUG: movie_paths: {self.movie_paths}")
-
-        # Sort roots by length (longest first) to avoid substring matching issues
-        indexed_roots = [(i, root) for i, root in enumerate(self.radarr_roots)]
-        indexed_roots.sort(key=lambda x: len(x[1]), reverse=True)
-
-        # Try to match against configured Radarr root folders (longest first)
-        for original_index, radarr_root in indexed_roots:
-            normalized_root = self._normalize_separators(radarr_root)
-            if self.path_debug:
-                print(f"PATH_DEBUG: Checking radarr_root[{original_index}]: {normalized_root}")
-            if normalized_path.startswith(normalized_root + '/') or normalized_path == normalized_root:
-                if self.path_debug:
-                    print(f"PATH_DEBUG: Match found! Index {original_index}")
-                # Map to corresponding movie path
-                if original_index < len(self.movie_paths):
-                    container_root = self.movie_paths[original_index]
-                    relative_path = normalized_path[len(normalized_root):].lstrip('/')
-                    result = str(Path(container_root) / relative_path) if relative_path else container_root
-                    if self.path_debug:
-                        print(f"PATH_DEBUG: Mapped to: {result}")
-                    return result
-
-        if self.path_debug:
-            print(f"PATH_DEBUG: No match found, returning original: {radarr_path}")
-        # No fallback - if path mapping fails, return original and let validation catch it
-        return radarr_path
-    
-    def container_path_to_host_path(self, container_path: str) -> str:
-        """Convert container path back to host path if needed"""
-        # This might be needed for file operations
-        return container_path
+    def sonarr_path_to_container_path(self, path: str) -> str:
+        return self.map(path)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""
-Chronarr Core - Automated NFO file management and processing engine
-Core processing container with webhooks, scanning, and database management
-Web interface separated to chronarr-web container
-"""
+"""Chronarr core — webhook processor, scanner, and scheduling engine."""
 import os
 import sys
 import signal
@@ -22,13 +18,9 @@ from utils.logging import _log
 
 # Import core components
 from core.database import ChronarrDatabase
-# from core.nfo_manager import NFOManager  # Phase 3: Removed - no longer needed
-from core.path_mapper import PathMapper
+from core.instance_registry import build_registry
 
-# Import clients
-from clients.external_clients import ExternalClientManager
-from clients.radarr_db_client import RadarrDbClient
-from clients.sonarr_db_client import SonarrDbClient
+from core.path_mapper import PathMapper
 
 # Import processors
 from processors.tv_processor import TVProcessor
@@ -87,45 +79,43 @@ def create_app() -> FastAPI:
     return app
 
 
+def _noop_mapper() -> PathMapper:
+    """Return an empty PathMapper — used when a default instance isn't configured."""
+    return PathMapper(root_folders=[], container_paths=[])
+
+
 def initialize_components():
-    """Initialize all application components"""
     start_time = datetime.now(timezone.utc)
 
-    # Initialize core components
     db = ChronarrDatabase(config=config)
-    # nfo_manager = NFOManager(config.manager_brand, config.debug)  # Phase 3: Removed
-    path_mapper = PathMapper(config)
 
-    # Initialize processors (nfo_manager=None for backward compatibility)
-    tv_processor = TVProcessor(db, None, path_mapper)
-    movie_processor = MovieProcessor(db, None, path_mapper)
+    # Build the instance registry — one client + one path mapper per configured
+    # Radarr/Sonarr instance, derived from env vars at startup.
+    registry = build_registry(config)
 
-    # Initialize webhook batcher (no longer needs nfo_manager - Phase 3)
+    # Processors get the default instance's client and mapper. Multi-instance
+    # requests pass instance name explicitly at process time; the processors look
+    # up the right client from the registry during their DB writes.
+    default_radarr_mapper = registry.radarr_mapper("radarr")
+    default_sonarr_mapper = registry.sonarr_mapper("sonarr")
+
+    tv_processor = TVProcessor(
+        db, None,
+        default_sonarr_mapper or _noop_mapper(),
+        sonarr_client=registry.sonarr("sonarr"),
+    )
+    movie_processor = MovieProcessor(
+        db, None,
+        default_radarr_mapper or _noop_mapper(),
+        radarr_client=registry.radarr("radarr"),
+    )
+
     batcher = WebhookBatcher(nfo_manager=None)
     batcher.set_processors(tv_processor, movie_processor)
 
-    # Initialize optional Radarr/Sonarr database clients for orphaned record cleanup
-    radarr_db_client = None
-    sonarr_db_client = None
-
-    try:
-        radarr_db_client = RadarrDbClient.from_env()
-        if radarr_db_client:
-            _log("INFO", "Radarr database client initialized for orphaned record cleanup")
-    except Exception as e:
-        _log("WARNING", f"Could not initialize Radarr database client: {e}")
-
-    try:
-        sonarr_db_client = SonarrDbClient.from_env()
-        if sonarr_db_client:
-            _log("INFO", "Sonarr database client initialized for orphaned record cleanup")
-    except Exception as e:
-        _log("WARNING", f"Could not initialize Sonarr database client: {e}")
-
     return {
         "db": db,
-        # "nfo_manager": nfo_manager,  # Phase 3: Removed
-        "path_mapper": path_mapper,
+        "registry": registry,
         "tv_processor": tv_processor,
         "movie_processor": movie_processor,
         "batcher": batcher,
@@ -133,8 +123,6 @@ def initialize_components():
         "config": config,
         "version": get_version(),
         "shutdown_event": shutdown_event,
-        "radarr_db_client": radarr_db_client,
-        "sonarr_db_client": sonarr_db_client
     }
 
 

--- a/processors/movie_processor.py
+++ b/processors/movie_processor.py
@@ -1,7 +1,4 @@
-"""
-Movie Processor for Chronarr
-Handles movie processing and metadata management
-"""
+"""Movie processing — date discovery and DB writes for Radarr-managed movies."""
 import os
 import re
 import xml.etree.ElementTree as ET
@@ -67,34 +64,31 @@ def convert_utc_to_local(utc_iso_string: str) -> str:
 
 
 class MovieProcessor:
-    """Handles movie processing"""
 
-    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper):
-        # nfo_manager parameter kept for backward compatibility but no longer used (Phase 3)
+    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper, radarr_client=None):
+        # nfo_manager kept for call-site compat but is unused
         self.db = db
         self.path_mapper = path_mapper
 
-        # Try database client first, fall back to API client
-        self.radarr_db = None
-        self.radarr_api = None
-        self.using_db = False
-
-        try:
-            self.radarr_db = RadarrDbClient.from_env()
-            if self.radarr_db:
-                _log("INFO", "Using Radarr direct database access")
-                self.radarr = self.radarr_db  # Primary client
+        if radarr_client:
+            # Pre-built client from InstanceRegistry (preferred path)
+            self.radarr = radarr_client
+            self.using_db = isinstance(radarr_client, RadarrDbClient)
+        else:
+            # Fallback: construct from env vars (single-instance legacy path)
+            try:
+                self.radarr = RadarrDbClient.from_env()
+                if not self.radarr:
+                    raise Exception("Database not configured")
                 self.using_db = True
-            else:
-                raise Exception("Database not configured")
-        except Exception:
-            # Fall back to API client
-            self.radarr_api = RadarrClient(
-                os.environ.get("RADARR_URL", ""),
-                os.environ.get("RADARR_API_KEY", "")
-            )
-            self.radarr = self.radarr_api  # Primary client
-            _log("INFO", "Using Radarr API client (database not configured)")
+                _log("INFO", "Using Radarr direct database access")
+            except Exception:
+                self.radarr = RadarrClient(
+                    os.environ.get("RADARR_URL", ""),
+                    os.environ.get("RADARR_API_KEY", "")
+                )
+                self.using_db = False
+                _log("INFO", "Using Radarr API client (database not configured)")
 
         self.external_clients = ExternalClientManager()
     
@@ -108,70 +102,32 @@ class MovieProcessor:
             path_mapper=self.path_mapper
         )
     
-    def should_skip_movie(self, imdb_id: str, movie_name: str = "") -> Tuple[bool, str]:
-        """
-        Determine if we should skip processing this movie based on completion status
-        
-        Args:
-            imdb_id: Movie IMDb ID  
-            movie_name: Movie name for logging
-            
-        Returns:
-            (should_skip: bool, reason: str)
-        """
+    def should_skip_movie(self, imdb_id: str, movie_name: str = "", instance: str = 'radarr') -> Tuple[bool, str]:
+        """Return (should_skip, reason) — skip when date, source, and video file are all present."""
         try:
-            with self.db.get_connection() as conn:
-                cursor = conn.cursor()
-                
-                if self.db.db_type == "postgresql":
-                    cursor.execute("""
-                        SELECT dateadded, source, has_video_file
-                        FROM movies 
-                        WHERE imdb_id = %s
-                    """, (imdb_id,))
-                else:
-                    cursor.execute("""
-                        SELECT dateadded, source, has_video_file
-                        FROM movies 
-                        WHERE imdb_id = ?
-                    """, (imdb_id,))
-                
-                result = cursor.fetchone()
-                if not result:
-                    return False, "No database record found"
-                
-                if self.db.db_type == "postgresql":
-                    dateadded = result['dateadded']
-                    source = result['source']
-                    has_video_file = result['has_video_file']
-                else:
-                    dateadded = result[0] if result[0] else None
-                    source = result[1] if result[1] else None  
-                    has_video_file = result[2] if result[2] else False
-                
-                # Skip if:
-                # 1. Movie has a valid dateadded timestamp
-                # 2. Source is valid (not 'unknown' or 'no_valid_date_source')  
-                # 3. Has video file on disk
-                if (dateadded and 
-                    source and 
-                    source not in ['unknown', 'no_valid_date_source'] and
-                    has_video_file):
-                    return True, f"Complete: Has valid date '{dateadded}' from source '{source}'"
-                elif not dateadded:
-                    return False, "Missing dateadded"
-                elif not source or source in ['unknown', 'no_valid_date_source']:
-                    return False, f"Invalid source: '{source}'"
-                elif not has_video_file:
-                    return False, "No video file detected"
-                else:
-                    return False, "Incomplete movie data"
-                    
+            result = self.db.get_movie_dates(imdb_id, instance)
+            if not result:
+                return False, "No database record found"
+
+            dateadded = result.get('dateadded')
+            source = result.get('source')
+            has_video_file = result.get('has_video_file', False)
+
+            if dateadded and source and source not in ('unknown', 'no_valid_date_source') and has_video_file:
+                return True, f"Complete: Has valid date '{dateadded}' from source '{source}'"
+            if not dateadded:
+                return False, "Missing dateadded"
+            if not source or source in ('unknown', 'no_valid_date_source'):
+                return False, f"Invalid source: '{source}'"
+            if not has_video_file:
+                return False, "No video file detected"
+            return False, "Incomplete movie data"
+
         except Exception as e:
             _log("ERROR", f"Error checking movie completion for {imdb_id}: {e}")
             return False, f"Error checking completion: {e}"
     
-    def process_movie(self, movie_path: Path, webhook_mode: bool = False, force_scan: bool = False, scan_mode: str = "smart", shutdown_event=None, imdb_id: str = None) -> str:
+    def process_movie(self, movie_path: Path, webhook_mode: bool = False, force_scan: bool = False, scan_mode: str = "smart", shutdown_event=None, imdb_id: str = None, instance: str = 'radarr') -> str:
         """Process a movie directory"""
         # Prefer the IMDb ID passed in (e.g. from webhook payload) over filesystem detection.
         # Filesystem detection only works when the ID is embedded in the folder/file name,
@@ -192,11 +148,10 @@ class MovieProcessor:
         # Check if we should skip this movie (unless forced, webhook mode, or incomplete mode)
         # Skip database optimization for incomplete mode since we need to check NFO files first
         if not force_scan and not webhook_mode and scan_mode != "incomplete":
-            should_skip, reason = self.should_skip_movie(imdb_id, movie_path.name)
+            should_skip, reason = self.should_skip_movie(imdb_id, movie_path.name, instance=instance)
             if should_skip:
                 _log("INFO", f"⏭️ SKIPPING MOVIE: {movie_path.name} [{imdb_id}] - {reason}")
-                # Still update the movie record to track that we've seen it
-                self.db.upsert_movie(imdb_id, str(movie_path))
+                self.db.upsert_movie(imdb_id, str(movie_path), instance=instance)
                 return "skipped"
             else:
                 _log("INFO", f"🎬 PROCESSING MOVIE: {movie_path.name} [{imdb_id}] - {reason}")
@@ -211,7 +166,7 @@ class MovieProcessor:
             return "shutdown"
         
         # Update database
-        self.db.upsert_movie(imdb_id, str(movie_path))
+        self.db.upsert_movie(imdb_id, str(movie_path), instance=instance)
         
         # Check for video files
         video_exts = (".mkv", ".mp4", ".avi", ".mov", ".m4v")
@@ -221,13 +176,12 @@ class MovieProcessor:
             _log("WARNING", f"No video files found in: {movie_path} - skipping database entry")
             return "no_video_files"
         
-        # For incomplete mode: Start with NFO check to find missing dateadded elements
         if scan_mode == "incomplete":
-            return self._process_movie_nfo_first(movie_path, imdb_id, shutdown_event)
+            return self._process_movie_nfo_first(movie_path, imdb_id, shutdown_event, instance=instance)
         
         # For smart/full modes: Use database-first optimization
         # TIER 1: Check database first (fastest - local lookup)
-        existing = self.db.get_movie_dates(imdb_id)
+        existing = self.db.get_movie_dates(imdb_id, instance)
         _log("DEBUG", f"Database lookup for {imdb_id}: {existing}")
         
         # Enhanced debug for database state
@@ -307,7 +261,7 @@ class MovieProcessor:
         # Skip remaining processing if no valid date found and file dates disabled
         if final_dateadded is None:
             _log("WARNING", f"Movie {movie_path.name} - no valid date source available, but NFO was still processed")
-            self.db.upsert_movie_dates(imdb_id, released, None, source, True, title=title, year=year)
+            self.db.upsert_movie_dates(imdb_id, released, None, source, True, title=title, year=year, instance=instance)
             return "processed"
             
         # Update dateadded and source for the rest of processing
@@ -325,7 +279,7 @@ class MovieProcessor:
         # Save to database
         _log("DEBUG", f"About to save to database: imdb_id={imdb_id}, dateadded={dateadded}")
         try:
-            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year)
+            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year, instance=instance)
             _log("DEBUG", f"Database save completed for {imdb_id}")
         except Exception as e:
             _log("ERROR", f"Database save failed for {imdb_id}: {e}")
@@ -334,18 +288,15 @@ class MovieProcessor:
         _log("INFO", f"Completed processing movie: {movie_path.name} (source: {source})")
         return "processed"
     
-    def _process_movie_nfo_first(self, movie_path: Path, imdb_id: str, shutdown_event=None) -> str:
+    def _process_movie_nfo_first(self, movie_path: Path, imdb_id: str, shutdown_event=None, instance: str = 'radarr') -> str:
         """Process movie for incomplete mode: Database-first then API (NFO checks removed in Phase 2)"""
         _log("INFO", f"🔍 INCOMPLETE MODE: Checking movie for missing data: {movie_path.name}")
 
-        # Check for shutdown signal
         if shutdown_event and shutdown_event.is_set():
             _log("INFO", f"⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing: {movie_path.name}")
             return "shutdown"
 
-        # STEP 1: Check database for existing data (Phase 2: NFO check removed)
-        _log("DEBUG", f"STEP 1 - Checking database for existing data")
-        existing = self.db.get_movie_dates(imdb_id)
+        existing = self.db.get_movie_dates(imdb_id, instance)
 
         if existing and existing.get("dateadded") and existing.get("source") != "no_valid_date_source":
             # Found in database - data is complete
@@ -392,12 +343,11 @@ class MovieProcessor:
                 dateadded, source, released = self._get_file_mtime_date(movie_path)
                 _log("INFO", f"Using file mtime as fallback: {dateadded}")
         
-        # Save to database only (NFO operations removed in Phase 1)
         if dateadded:
             radarr_meta = self.radarr.movie_by_imdb(imdb_id) if self.radarr else None
             title = radarr_meta.get("title") if radarr_meta else None
             year = radarr_meta.get("year") if radarr_meta else None
-            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year)
+            self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year, instance=instance)
 
             _log("INFO", f"🔍 INCOMPLETE MODE COMPLETE: {movie_path.name} (source: {source})")
             return "processed"

--- a/processors/tv_processor.py
+++ b/processors/tv_processor.py
@@ -1,7 +1,4 @@
-"""
-TV Series Processor for Chronarr
-Handles TV series processing and episode management with async I/O support
-"""
+"""TV series processing — episode date discovery and DB writes for Sonarr-managed series."""
 import os
 import re
 import time
@@ -30,34 +27,37 @@ from utils.async_file_utils import (
 
 
 class TVProcessor:
-    """Handles TV series processing"""
 
-    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper):
-        # nfo_manager parameter kept for backward compatibility but no longer used (Phase 3)
+    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper, sonarr_client=None):
+        # nfo_manager kept for call-site compat but is unused
         self.db = db
         self.path_mapper = path_mapper
 
-        # Try database client first, fall back to API client
-        self.sonarr_db = None
-        self.sonarr_api = None
-        self.using_db = False
-
-        try:
-            self.sonarr_db = SonarrDbClient.from_env()
-            if self.sonarr_db:
-                _log("INFO", "Using Sonarr direct database access")
-                self.sonarr = self.sonarr_db  # Primary client
+        if sonarr_client:
+            # Pre-built client from InstanceRegistry (preferred path)
+            self.sonarr = sonarr_client
+            self.sonarr_db = sonarr_client if isinstance(sonarr_client, SonarrDbClient) else None
+            self.sonarr_api = sonarr_client if isinstance(sonarr_client, SonarrClient) else None
+            self.using_db = isinstance(sonarr_client, SonarrDbClient)
+        else:
+            # Fallback: construct from env vars (single-instance legacy path)
+            self.sonarr_db = None
+            self.sonarr_api = None
+            self.using_db = False
+            try:
+                self.sonarr_db = SonarrDbClient.from_env()
+                if not self.sonarr_db:
+                    raise Exception("Database not configured")
+                self.sonarr = self.sonarr_db
                 self.using_db = True
-            else:
-                raise Exception("Database not configured")
-        except Exception:
-            # Fall back to API client
-            self.sonarr_api = SonarrClient(
-                os.environ.get("SONARR_URL", ""),
-                os.environ.get("SONARR_API_KEY", "")
-            )
-            self.sonarr = self.sonarr_api  # Primary client
-            _log("INFO", "Using Sonarr API client (database not configured)")
+                _log("INFO", "Using Sonarr direct database access")
+            except Exception:
+                self.sonarr_api = SonarrClient(
+                    os.environ.get("SONARR_URL", ""),
+                    os.environ.get("SONARR_API_KEY", "")
+                )
+                self.sonarr = self.sonarr_api
+                _log("INFO", "Using Sonarr API client (database not configured)")
 
         self.external_clients = ExternalClientManager()
 
@@ -86,99 +86,50 @@ class TVProcessor:
             path_mapper=self.path_mapper
         )
     
-    def should_skip_series_fast(self, imdb_id: str, series_name: str = "") -> Tuple[bool, str, int]:
-        """
-        Fast preliminary check to skip series without filesystem scan
-        
-        Args:
-            imdb_id: Series IMDb ID
-            series_name: Series name for logging
-            
-        Returns:
-            (should_skip: bool, reason: str, episodes_in_db: int)
-        """
+    def _episode_completion_counts(self, imdb_id: str, instance: str) -> Tuple[int, int]:
+        """Return (total_in_db, complete_episodes) for an (imdb_id, instance) pair."""
+        with self.db.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT
+                    COUNT(*) AS total_in_db,
+                    COUNT(CASE WHEN dateadded IS NOT NULL AND source IS NOT NULL
+                               AND source NOT IN ('unknown', 'no_valid_date_source') THEN 1 END) AS complete_episodes
+                FROM episodes
+                WHERE imdb_id = %s AND instance = %s
+            """, (imdb_id, instance))
+            row = cursor.fetchone()
+            if not row:
+                return 0, 0
+            return row['total_in_db'], row['complete_episodes']
+
+    def should_skip_series_fast(self, imdb_id: str, series_name: str = "", instance: str = 'sonarr') -> Tuple[bool, str, int]:
+        """Prelim skip check without a filesystem scan — returns (skip, reason, count_in_db)."""
         try:
-            with self.db.get_connection() as conn:
-                cursor = conn.cursor()
-                
-                # Check if we have complete episodes in database
-                cursor.execute("""
-                    SELECT 
-                        COUNT(*) as total_in_db,
-                        COUNT(CASE WHEN dateadded IS NOT NULL AND source IS NOT NULL AND source != 'unknown' AND source != 'no_valid_date_source' THEN 1 END) as complete_episodes
-                    FROM episodes 
-                    WHERE imdb_id = %s
-                """, (imdb_id,))
-                
-                result = cursor.fetchone()
-                if not result:
-                    return False, "No database records found", 0
-                
-                total_in_db = result['total_in_db']
-                complete_episodes = result['complete_episodes']
-                
-                # Skip if we have episodes and all are complete
-                # We'll verify disk count later if needed
-                if total_in_db > 0 and complete_episodes == total_in_db:
-                    return True, f"Likely complete: {complete_episodes} episodes in DB all have valid dates", total_in_db
-                else:
-                    return False, f"Needs checking: {complete_episodes}/{total_in_db} episodes complete in DB", total_in_db
-                    
+            total_in_db, complete_episodes = self._episode_completion_counts(imdb_id, instance)
+            if total_in_db > 0 and complete_episodes == total_in_db:
+                return True, f"Likely complete: {complete_episodes} episodes in DB all have valid dates", total_in_db
+            return False, f"Needs checking: {complete_episodes}/{total_in_db} episodes complete in DB", total_in_db
         except Exception as e:
             _log("ERROR", f"Error in fast series check for {imdb_id}: {e}")
             return False, f"Error in fast check: {e}", 0
 
-    def should_skip_series(self, imdb_id: str, episodes_on_disk: int, series_name: str = "") -> Tuple[bool, str]:
-        """
-        Determine if we should skip processing this series based on completion status
-        
-        Args:
-            imdb_id: Series IMDb ID
-            episodes_on_disk: Number of episodes found on disk
-            series_name: Series name for logging
-            
-        Returns:
-            (should_skip: bool, reason: str)
-        """
+    def should_skip_series(self, imdb_id: str, episodes_on_disk: int, series_name: str = "", instance: str = 'sonarr') -> Tuple[bool, str]:
+        """Return (should_skip, reason) — skip when DB count, disk count, and date completeness all match."""
         try:
-            with self.db.get_connection() as conn:
-                cursor = conn.cursor()
-                
-                # PostgreSQL-only query
-                cursor.execute("""
-                    SELECT 
-                        COUNT(*) as total_in_db,
-                        COUNT(CASE WHEN dateadded IS NOT NULL AND source IS NOT NULL AND source != 'unknown' AND source != 'no_valid_date_source' THEN 1 END) as complete_episodes
-                    FROM episodes 
-                    WHERE imdb_id = %s
-                """, (imdb_id,))
-                
-                result = cursor.fetchone()
-                if not result:
-                    return False, "No database records found"
-                
-                # PostgreSQL RealDictCursor returns dict-like objects
-                total_in_db = result['total_in_db']
-                complete_episodes = result['complete_episodes']
-                
-                # Skip if:
-                # 1. We have episodes in database
-                # 2. Database count matches disk count (no missing episodes)
-                # 3. All episodes have valid dates and sources
-                if total_in_db > 0 and total_in_db == episodes_on_disk and complete_episodes == episodes_on_disk:
-                    return True, f"Complete: {complete_episodes}/{episodes_on_disk} episodes have valid dates"
-                elif total_in_db == 0:
-                    return False, f"New series: No episodes in database"
-                elif total_in_db != episodes_on_disk:
-                    return False, f"Disk mismatch: {total_in_db} in DB vs {episodes_on_disk} on disk"
-                else:
-                    return False, f"Incomplete: {complete_episodes}/{episodes_on_disk} episodes have valid dates"
-                    
+            total_in_db, complete_episodes = self._episode_completion_counts(imdb_id, instance)
+            if total_in_db > 0 and total_in_db == episodes_on_disk and complete_episodes == episodes_on_disk:
+                return True, f"Complete: {complete_episodes}/{episodes_on_disk} episodes have valid dates"
+            if total_in_db == 0:
+                return False, "New series: No episodes in database"
+            if total_in_db != episodes_on_disk:
+                return False, f"Disk mismatch: {total_in_db} in DB vs {episodes_on_disk} on disk"
+            return False, f"Incomplete: {complete_episodes}/{episodes_on_disk} episodes have valid dates"
         except Exception as e:
             _log("ERROR", f"Error checking series completion for {imdb_id}: {e}")
             return False, f"Error checking completion: {e}"
     
-    def process_series(self, series_path: Path, force_scan: bool = False, scan_mode: str = "smart", imdb_id: str = None) -> str:
+    def process_series(self, series_path: Path, force_scan: bool = False, scan_mode: str = "smart", imdb_id: str = None, instance: str = 'sonarr') -> str:
         """Process a TV series directory"""
         if not imdb_id:
             imdb_id = parse_imdb_from_path(series_path)
@@ -191,52 +142,39 @@ class TVProcessor:
         # Fast check first - avoid expensive filesystem scan if possible
         # Skip fast optimization for incomplete mode since we need to check NFO files first
         if not force_scan and scan_mode != "incomplete":
-            should_skip_fast, reason_fast, episodes_in_db = self.should_skip_series_fast(imdb_id, series_path.name)
+            should_skip_fast, reason_fast, episodes_in_db = self.should_skip_series_fast(imdb_id, series_path.name, instance=instance)
             if should_skip_fast:
                 _log("INFO", f"⚡ FAST SKIP: {series_path.name} [{imdb_id}] - {reason_fast}")
-                # Still update the series record to track that we've seen it
-                self.db.upsert_series(imdb_id, str(series_path))
+                self.db.upsert_series(imdb_id, str(series_path), instance=instance)
                 return "skipped"
-        
-        # Need filesystem scan - either force_scan=True or series not complete in DB
+
         disk_episodes = find_episodes_on_disk(series_path)
         _log("INFO", f"Found {len(disk_episodes)} episodes on disk")
-        
-        # Final skip check with actual episode count (unless forced)
+
         if not force_scan:
-            should_skip, reason = self.should_skip_series(imdb_id, len(disk_episodes), series_path.name)
+            should_skip, reason = self.should_skip_series(imdb_id, len(disk_episodes), series_path.name, instance=instance)
             if should_skip:
                 _log("INFO", f"⏭️ SKIPPING SERIES: {series_path.name} [{imdb_id}] - {reason}")
-                # Still update the series record to track that we've seen it
-                self.db.upsert_series(imdb_id, str(series_path))
+                self.db.upsert_series(imdb_id, str(series_path), instance=instance)
                 return "skipped"
             else:
                 _log("INFO", f"📺 PROCESSING SERIES: {series_path.name} [{imdb_id}] - {reason}")
         else:
             _log("INFO", f"🔄 FORCE PROCESSING SERIES: {series_path.name} [{imdb_id}] - Force scan enabled")
-        
-        # Update database
-        self.db.upsert_series(imdb_id, str(series_path))
-        
-        # Get episode dates
-        episode_dates = self._gather_episode_dates(series_path, imdb_id, disk_episodes)
-        
-        # Process episodes with periodic yielding for non-blocking operation
+
+        self.db.upsert_series(imdb_id, str(series_path), instance=instance)
+
+        episode_dates = self._gather_episode_dates(series_path, imdb_id, disk_episodes, instance=instance)
+
         episode_count = 0
         for (season, episode), (aired, dateadded, source) in episode_dates.items():
             if (season, episode) in disk_episodes:
                 episode_count += 1
-                
-                # NFO file operations removed - database is now the single source of truth
-                # (Phase 1: Remove NFO file write operations)
-                
-                # Save to database
                 try:
-                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True)
+                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True, instance=instance)
                     _log("DEBUG", f"S{season:02d}E{episode:02d}: Database record saved successfully")
                 except Exception as e:
                     _log("ERROR", f"S{season:02d}E{episode:02d}: Database write failed: {e}")
-                    # Continue processing other episodes
                 
         
         # Skip season.nfo and tvshow.nfo creation - focus only on episode NFOs
@@ -250,7 +188,7 @@ class TVProcessor:
         return extract_title_from_directory_name(series_path.name)
     
     
-    def _gather_episode_dates(self, series_path: Path, imdb_id: str, disk_episodes: Dict[Tuple[int, int], List[Path]], scan_mode: str = "smart") -> Dict[Tuple[int, int], Tuple[Optional[str], Optional[str], str]]:
+    def _gather_episode_dates(self, series_path: Path, imdb_id: str, disk_episodes: Dict[Tuple[int, int], List[Path]], scan_mode: str = "smart", instance: str = 'sonarr') -> Dict[Tuple[int, int], Tuple[Optional[str], Optional[str], str]]:
         """Gather episode air dates and date added information with optimization based on scan mode"""
         _log("INFO", f"🎯 GATHERING EPISODE DATES for {imdb_id}: {len(disk_episodes)} episodes on disk (mode: {scan_mode})")
         episode_dates = {}
@@ -258,7 +196,7 @@ class TVProcessor:
         
         # For incomplete mode: Start with NFO check to find missing dateadded elements
         if scan_mode == "incomplete":
-            return self._gather_episode_dates_nfo_first(series_path, imdb_id, disk_episodes)
+            return self._gather_episode_dates_nfo_first(series_path, imdb_id, disk_episodes, instance=instance)
         
         # For smart/full modes: Use database-first optimization
         # TIER 1: Check database first for existing dates (fastest)
@@ -267,8 +205,7 @@ class TVProcessor:
         episodes_needing_nfo_check = []
         
         for (season, episode) in disk_episodes:
-            # Try database first - this is much faster than API calls
-            db_result = self.db.get_episode_date(imdb_id, season, episode)
+            db_result = self.db.get_episode_date(imdb_id, season, episode, instance)
             
             if db_result and db_result.get('dateadded'):
                 # Found in database - use cached data
@@ -355,7 +292,7 @@ class TVProcessor:
         
         return episode_dates
     
-    def _gather_episode_dates_nfo_first(self, series_path: Path, imdb_id: str, disk_episodes: Dict[Tuple[int, int], List[Path]]) -> Dict[Tuple[int, int], Tuple[Optional[str], Optional[str], str]]:
+    def _gather_episode_dates_nfo_first(self, series_path: Path, imdb_id: str, disk_episodes: Dict[Tuple[int, int], List[Path]], instance: str = 'sonarr') -> Dict[Tuple[int, int], Tuple[Optional[str], Optional[str], str]]:
         """Gather episode dates for incomplete mode: Database-first then API (NFO checks removed in Phase 2)"""
         _log("INFO", f"🔍 INCOMPLETE MODE: Checking {len(disk_episodes)} episodes for missing data")
         episode_dates = {}
@@ -366,10 +303,9 @@ class TVProcessor:
         db_hits = 0
 
         for (season, episode) in disk_episodes:
-            db_result = self.db.get_episode_date(imdb_id, season, episode)
+            db_result = self.db.get_episode_date(imdb_id, season, episode, instance)
 
             if db_result and db_result.get('dateadded'):
-                # Found in database - use cached data
                 aired = db_result.get('aired')
                 dateadded = db_result.get('dateadded')
                 source = db_result.get('source', 'database_cache')
@@ -377,7 +313,6 @@ class TVProcessor:
                 db_hits += 1
                 _log("DEBUG", f"S{season:02d}E{episode:02d}: Database has dateadded={dateadded}")
             else:
-                # Not in database or incomplete - needs API lookup
                 episodes_needing_api_lookup.append((season, episode))
 
         _log("INFO", f"Database hits: {db_hits}/{len(disk_episodes)} episodes. Need API lookup: {len(episodes_needing_api_lookup)}")
@@ -426,9 +361,8 @@ class TVProcessor:
                         source = f"{source}_fallback" if source != "unknown" else "aired_fallback"
                     _log("DEBUG", f"S{season:02d}E{episode:02d}: Using aired date as dateadded fallback: {dateadded}")
                 
-                # Save to database for future lookups
                 if dateadded or aired:
-                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True)
+                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True, instance=instance)
                 
                 episode_dates[(season, episode)] = (aired, dateadded, source)
         
@@ -780,23 +714,22 @@ class TVProcessor:
         
         return processed_results
     
-    def process_webhook_episodes(self, series_path: Path, webhook_episodes: List[Dict[str, Any]], imdb_id: str = None) -> None:
-        """Process only the specific episodes mentioned in a webhook (targeted mode)"""
+    def process_webhook_episodes(self, series_path: Path, webhook_episodes: List[Dict[str, Any]], imdb_id: str = None, instance: str = 'sonarr') -> None:
+        """Process only the specific episodes mentioned in a webhook (targeted mode)."""
         if not imdb_id:
             imdb_id = parse_imdb_from_path(series_path)
         if not imdb_id:
             _log("ERROR", f"No IMDb ID found in series path: {series_path}")
             return
-        
+
         if not webhook_episodes:
             _log("WARNING", f"No episodes in webhook, falling back to series processing: {series_path}")
-            self.process_series(series_path)
+            self.process_series(series_path, instance=instance)
             return
-        
+
         _log("INFO", f"Processing {len(webhook_episodes)} webhook episodes for: {series_path.name} (IMDb: {imdb_id})")
-        
-        # Update database
-        self.db.upsert_series(imdb_id, str(series_path))
+
+        self.db.upsert_series(imdb_id, str(series_path), instance=instance)
         
         # Get enhanced metadata from Sonarr
         series_metadata = self._get_sonarr_series_metadata(imdb_id)
@@ -830,17 +763,15 @@ class TVProcessor:
                 
             # Get episode date information - webhook processing prioritizes existing DB entries
             _log("DEBUG", f"Processing webhook episode: IMDb={imdb_id}, S{season_num:02d}E{episode_num:02d}")
-            aired, dateadded, source = self._get_webhook_episode_date(imdb_id, season_num, episode_num, series_metadata, webhook_episode)
+            aired, dateadded, source = self._get_webhook_episode_date(imdb_id, season_num, episode_num, series_metadata, webhook_episode, instance=instance)
             enhanced_metadata = self._get_episode_metadata(series_metadata, season_num, episode_num, season_dir) if series_metadata else self._get_episode_metadata(None, season_num, episode_num, season_dir)
             
             # NFO file operations removed - database is now the single source of truth
             # (Phase 1: Remove NFO file write operations)
             
-            # Save to database
-            self.db.upsert_episode_date(imdb_id, season_num, episode_num, aired, dateadded, source, True)
-            
-            # Verify database entry was saved (debug)
-            verification = self.db.get_episode_date(imdb_id, season_num, episode_num)
+            self.db.upsert_episode_date(imdb_id, season_num, episode_num, aired, dateadded, source, True, instance=instance)
+
+            verification = self.db.get_episode_date(imdb_id, season_num, episode_num, instance)
             if verification:
                 _log("DEBUG", f"Verified database entry saved: S{season_num:02d}E{episode_num:02d} -> {verification['dateadded']}")
             else:
@@ -973,7 +904,7 @@ class TVProcessor:
         
         return None
     
-    def _get_webhook_episode_date(self, imdb_id: str, season_num: int, episode_num: int, series_metadata: Optional[Dict[str, Any]] = None, webhook_episode: Optional[Dict[str, Any]] = None) -> Tuple[Optional[str], Optional[str], str]:
+    def _get_webhook_episode_date(self, imdb_id: str, season_num: int, episode_num: int, series_metadata: Optional[Dict[str, Any]] = None, webhook_episode: Optional[Dict[str, Any]] = None, instance: str = 'sonarr') -> Tuple[Optional[str], Optional[str], str]:
         """
         Get episode date for webhook processing - database-first approach.
         
@@ -988,11 +919,11 @@ class TVProcessor:
         This prevents webhooks from overriding existing good data.
         """
         
-        # STEP 1: Check Chronarr database first
+        # Database-first: use existing date to avoid re-processing
         existing_entry = None
         existing_date = None
         try:
-            existing_entry = self.db.get_episode_date(imdb_id, season_num, episode_num)
+            existing_entry = self.db.get_episode_date(imdb_id, season_num, episode_num, instance)
             if existing_entry and existing_entry.get('dateadded'):
                 existing_date = existing_entry['dateadded']
                 _log("INFO", f"Found existing date in database for S{season_num:02d}E{episode_num:02d}: {existing_date}")
@@ -1057,9 +988,8 @@ class TVProcessor:
             if not hasattr(self, 'sonarr'):
                 _log("DEBUG", f"No sonarr client available")
         
-        # STEP 2: No import history found - this is likely a genuinely new show
         # Check our database to avoid duplicates
-        existing = self.db.get_episode_date(imdb_id, season_num, episode_num)
+        existing = self.db.get_episode_date(imdb_id, season_num, episode_num, instance)
         if existing and existing.get('dateadded'):
             _log("INFO", f"Episode S{season_num:02d}E{episode_num:02d} already exists in our database: {existing['dateadded']}")
             return existing.get('aired'), existing.get('dateadded'), existing.get('source', 'chronarr:database')

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,7 +1,4 @@
-"""
-File utility functions for Chronarr
-Common file operations to eliminate code duplication
-"""
+"""File utilities — path resolution, video file discovery, episode parsing."""
 import glob
 import re
 from pathlib import Path
@@ -10,65 +7,42 @@ from typing import Optional, List, Dict, Tuple, Union
 from utils.logging import _log
 
 
-# Video file extensions used throughout the application
 VIDEO_EXTENSIONS = {'.mkv', '.mp4', '.avi', '.m4v', '.mov', '.ts'}
 
-# Episode pattern for TV series files
 EPISODE_PATTERN = re.compile(
     r'.*[sS](\d{1,2})[eE](\d{1,3}).*|.*(\d{1,2})x(\d{1,3}).*'
 )
 
 
 def find_media_path_by_imdb_and_title(
-    title: str, 
-    imdb_id: str, 
-    search_paths: List[Path], 
+    title: str,
+    imdb_id: str,
+    search_paths: List[Path],
     webhook_path: Optional[str] = None,
-    path_mapper = None
+    path_mapper=None
 ) -> Optional[Path]:
-    """
-    Unified media path finder for both TV series and movies
-    
-    Args:
-        title: Media title to search for
-        imdb_id: IMDb ID to search for
-        search_paths: List of paths to search in (tv_paths or movie_paths)
-        webhook_path: Optional webhook path to try first
-        path_mapper: Optional path mapper for webhook path conversion
-    
-    Returns:
-        Path to media directory if found, None otherwise
-    """
-    # Try webhook path first if provided
+    """Find a media directory by trying the webhook path first, then searching configured paths."""
+    # The webhook payload often carries the exact path — try it before scanning directories.
     if webhook_path and path_mapper:
         try:
-            if hasattr(path_mapper, 'sonarr_path_to_container_path'):
-                container_path = path_mapper.sonarr_path_to_container_path(webhook_path)
-            elif hasattr(path_mapper, 'radarr_path_to_container_path'):
-                container_path = path_mapper.radarr_path_to_container_path(webhook_path)
-            else:
-                container_path = webhook_path
-                
+            container_path = path_mapper.map(webhook_path)
             path_obj = Path(container_path)
             if path_obj.exists():
                 return path_obj
         except Exception as e:
             _log("WARNING", f"Failed to process webhook path {webhook_path}: {e}")
     
-    # Search by IMDb ID or title in configured paths
     for media_path in search_paths:
         if not media_path.exists():
             continue
-        
-        # Search by IMDb ID first (more reliable)
+
         if imdb_id:
-            # Use proper glob pattern - escape brackets to match literal [imdb-ID]
+            # Escape brackets so glob treats them as literals, not character classes.
             pattern = str(media_path / f"*\\[imdb-{imdb_id}\\]*")
             matches = glob.glob(pattern)
             if matches:
                 return Path(matches[0])
-        
-        # Search by title as fallback
+
         if title:
             title_clean = clean_title_for_search(title)
             for item in media_path.iterdir():
@@ -81,29 +55,11 @@ def find_media_path_by_imdb_and_title(
 
 
 def clean_title_for_search(title: str) -> str:
-    """
-    Clean title for fuzzy matching
-    
-    Args:
-        title: Raw title string
-        
-    Returns:
-        Cleaned title for comparison
-    """
+    """Strip spaces, dashes, and dots for fuzzy directory name matching."""
     return title.lower().replace(" ", "").replace("-", "").replace(".", "")
 
 
 def find_video_files(directory: Path, recursive: bool = True) -> List[Path]:
-    """
-    Find all video files in a directory
-    
-    Args:
-        directory: Directory to search
-        recursive: Whether to search recursively
-        
-    Returns:
-        List of video file paths
-    """
     if not directory.exists():
         return []
     
@@ -122,15 +78,6 @@ def find_video_files(directory: Path, recursive: bool = True) -> List[Path]:
 
 
 def extract_episode_info(filename: str) -> Optional[Tuple[int, int]]:
-    """
-    Extract season and episode numbers from filename
-    
-    Args:
-        filename: Video filename to parse
-        
-    Returns:
-        Tuple of (season, episode) if found, None otherwise
-    """
     match = EPISODE_PATTERN.match(filename)
     if not match:
         return None
@@ -148,15 +95,7 @@ def extract_episode_info(filename: str) -> Optional[Tuple[int, int]]:
 
 
 def find_episodes_on_disk(series_path: Path) -> Dict[Tuple[int, int], List[Path]]:
-    """
-    Find all episodes on disk and return mapping of (season, episode) -> [video_files]
-    
-    Args:
-        series_path: Path to series directory
-        
-    Returns:
-        Dictionary mapping (season, episode) tuples to lists of video files
-    """
+    """Map (season, episode) tuples to their video files for a series directory."""
     episodes = {}
     
     if not series_path.exists():

--- a/webhooks/webhook_batcher.py
+++ b/webhooks/webhook_batcher.py
@@ -139,30 +139,29 @@ class WebhookBatcher:
                 if not self.tv_processor:
                     _log("ERROR", "TV processor not available")
                     return
-                    
-                # Check processing mode for TV webhooks
+
+                instance = webhook_data.get('instance', 'sonarr')
                 processing_mode = webhook_data.get('processing_mode', config.tv_webhook_processing_mode)
                 episodes_data = webhook_data.get('episodes', [])
-                
+
                 if processing_mode == 'targeted' and episodes_data:
                     _log("INFO", f"Using targeted episode processing for {len(episodes_data)} episodes")
-                    
-                    # Handle sequential processing for bulk downloads
                     if len(episodes_data) > 1 and config.sequential_delay > 0:
                         _log("INFO", f"Processing {len(episodes_data)} episodes sequentially with {config.sequential_delay}s delay")
-                        self._process_episodes_sequentially(path_obj, episodes_data)
+                        self._process_episodes_sequentially(path_obj, episodes_data, instance=instance)
                     else:
-                        self.tv_processor.process_webhook_episodes(path_obj, episodes_data, imdb_id=expected_imdb)
+                        self.tv_processor.process_webhook_episodes(path_obj, episodes_data, imdb_id=expected_imdb, instance=instance)
                 else:
                     _log("INFO", f"Using series processing mode (fallback or configured)")
-                    self.tv_processor.process_series(path_obj, imdb_id=expected_imdb)
-                    
+                    self.tv_processor.process_series(path_obj, imdb_id=expected_imdb, instance=instance)
+
             elif media_type == 'movie':
                 if not self.movie_processor:
                     _log("ERROR", "Movie processor not available")
                     return
-                    
-                self.movie_processor.process_movie(path_obj, webhook_mode=True, imdb_id=expected_imdb)
+
+                instance = webhook_data.get('instance', 'radarr')
+                self.movie_processor.process_movie(path_obj, webhook_mode=True, imdb_id=expected_imdb, instance=instance)
             else:
                 _log("ERROR", f"Unknown media type: {media_type}")
         
@@ -172,27 +171,21 @@ class WebhookBatcher:
             with self.lock:
                 self.processing.discard(key)
     
-    def _process_episodes_sequentially(self, path_obj: Path, episodes_data: list):
-        """Process episodes one by one with delays to avoid API spam"""        
+    def _process_episodes_sequentially(self, path_obj: Path, episodes_data: list, instance: str = 'sonarr'):
+        """Process episodes one by one with delays to avoid Sonarr API spam."""
         total_episodes = len(episodes_data)
         for i, episode in enumerate(episodes_data, 1):
             try:
                 season = episode.get('seasonNumber', '?')
                 episode_num = episode.get('episodeNumber', '?')
                 _log("INFO", f"Processing episode {i}/{total_episodes}: S{season:02d}E{episode_num:02d}")
-                
-                # Process single episode
-                self.tv_processor.process_webhook_episodes(path_obj, [episode])
-                
-                # Add delay between episodes (except for the last one)
+                self.tv_processor.process_webhook_episodes(path_obj, [episode], instance=instance)
                 if i < total_episodes and config.sequential_delay > 0:
                     _log("INFO", f"Waiting {config.sequential_delay}s before next episode...")
                     time.sleep(config.sequential_delay)
-                    
             except Exception as e:
                 _log("ERROR", f"Error processing episode {i}/{total_episodes}: {e}")
-                # Continue with next episode even if one fails
-                
+
         _log("INFO", f"Completed sequential processing of {total_episodes} episodes")
     
     def get_status(self) -> Dict:


### PR DESCRIPTION
Phase 2 of multi-instance support. Adds the instance column to movies, series, and episodes with composite PKs and an idempotent migration for existing installs. Rewrites PathMapper to take explicit root/container paths at construction so each instance gets its own mapper built at startup. Threads the instance name end-to-end from the incoming webhook URL through the batcher, processors, and all DB writes. Dynamic routes are registered at startup for each configured instance; the existing /webhook/radarr and /webhook/sonarr paths stay in place as aliases.