### PR TITLE
feat: v3 Phase 3 — multi-instance UI, setup page, Emby changelog endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,9 @@ RADARR_DB_USER=postgres
 # Add a block per extra Radarr instance. The name between RADARR_ and _URL
 # becomes part of the webhook URL: RADARR_4K_URL → /radarr_4k/webhook
 # Names must be uppercase letters and underscores only.
+#
+# After configuring instances, visit http://your-server:8081/setup
+# for the exact webhook URLs to paste into each Radarr or Sonarr instance.
 
 # RADARR_4K_URL=http://radarr4k:7878
 # RADARR_4K_API_KEY= → set in .env.secrets

--- a/Emby-DLL/CHANGELOG.md
+++ b/Emby-DLL/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Chronarr Emby Plugin — Changelog
+
+## v2.0.20 — Server Name & Admin Pre-fill
+- Server name field is now read-only and sourced automatically from Emby's configured server name
+- Admin username is pre-filled from the first Emby administrator account at startup
+- Registration and validation payloads now include structured server and user blocks for improved license server tracking
+
+## v2.0.19 — Movie Date Sync Fix
+- Movies now resolve their IMDb ID from Emby's own metadata instead of requiring it in the folder name — standard naming (Movie (Year)) is fully supported for real-time sync and scheduled task
+
+## v2.0.18 — TV Episode Date Sync
+- Real-time sync and scheduled task now resolve the series IMDb ID from Emby's own metadata instead of requiring it to be embedded in the folder name — standard Radarr/Sonarr naming (Series (Year)) is fully supported
+
+## v2.0.17 — Registration Error Handling
+- Invalid or disposable email addresses now show a clear message in the plugin configuration page instead of a misleading network error after the offline grace period expires
+
+## v2.0.16 — Database-Direct Sync + License Self-Heal
+- License validation retries every hour when invalid — self-heals after transient server outages without waiting 23 hours
+- Removed NFO file dependency — date lookups go directly to the Chronarr database; real-time sync no longer silently skips items without a sidecar NFO file
+- Movies without an IMDb ID in the filename fall back to reading the ID from movie.nfo content if present
+
+## v2.0.14 — Removed TLS Certificate Pinning
+- Removed cert pinning from the license client — the pinned hash expired every 90 days on Let's Encrypt renewal, breaking check-ins for all users
+- License responses are already protected by RSA signature verification; standard TLS CA validation is now used instead
+
+## v2.0.13 — Platform Reporting
+- License check-ins now identify the media server platform (Emby) so the admin panel can distinguish Emby from Jellyfin installs
+
+## v2.0.12 — Security: Grace Period Hardening
+- Offline grace period no longer bypasses an expired license — blocking the server after expiry is denied immediately
+- Last server-validated expiry is stored in a signed state file; signature verified on every offline check
+
+## v2.0.11 — Library Exclusions
+- New: exclude specific Emby libraries from processing — config page shows checkboxes for each library
+- Exclusions apply to both scheduled task and real-time sync

--- a/api/routes.py
+++ b/api/routes.py
@@ -3036,10 +3036,38 @@ def register_routes(app, dependencies: dict):
     async def _maintainarr_webhook(request: Request, background_tasks: BackgroundTasks):
         return await maintainarr_webhook(request, background_tasks, dependencies)
 
+    @app.get("/api/instances")
+    async def _api_instances():
+        """Return all configured instances with their webhook paths and connection status."""
+        registry = dependencies.get("registry")
+        cfg = dependencies.get("config")
+        if not registry or not cfg:
+            raise HTTPException(status_code=503, detail="Registry not initialised")
+
+        radarr_list = [
+            {
+                "name": inst.name,
+                "webhook_path": f"/{inst.name}/webhook",
+                "connected": registry.radarr_status(inst.name).get("connected", False),
+                "method": registry.radarr_status(inst.name).get("method"),
+            }
+            for inst in cfg.radarr_instances
+        ]
+        sonarr_list = [
+            {
+                "name": inst.name,
+                "webhook_path": f"/{inst.name}/webhook",
+                "connected": registry.sonarr_status(inst.name).get("connected", False),
+                "method": registry.sonarr_status(inst.name).get("method"),
+            }
+            for inst in cfg.sonarr_instances
+        ]
+        return {"radarr": radarr_list, "sonarr": sonarr_list}
+
     @app.get("/health")
     async def _health() -> HealthResponse:
         return await health(dependencies)
-    
+
     @app.get("/health/simple")
     async def _health_simple():
         """Simple health check for Docker without external dependencies"""

--- a/api/routes.py
+++ b/api/routes.py
@@ -4054,9 +4054,26 @@ def register_routes(app, dependencies: dict):
             }
 
     # ---------------------------
+    # Emby Plugin Support
+    # ---------------------------
+
+    @app.get("/emby/changelog")
+    async def _emby_changelog():
+        """Serve the Emby plugin changelog from the bundled CHANGELOG.md."""
+        import os
+        from fastapi.responses import PlainTextResponse
+        changelog_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "Emby-DLL", "CHANGELOG.md"
+        )
+        if os.path.exists(changelog_path):
+            with open(changelog_path, "r", encoding="utf-8") as f:
+                return PlainTextResponse(f.read(), media_type="text/markdown; charset=utf-8")
+        return PlainTextResponse("Changelog not found.", status_code=404)
+
+    # ---------------------------
     # Core API - No Web Interface
     # ---------------------------
-    
+
     @app.get("/")
     async def _core_info():
         """Core container API information - Web interface on separate container"""

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -91,13 +91,14 @@ async def get_movies_list(dependencies: dict,
                          source_filter: Optional[str] = Query(None),
                          search: Optional[str] = Query(None),
                          imdb_search: Optional[str] = Query(None),
-                         skipped: Optional[bool] = Query(None)):
+                         skipped: Optional[bool] = Query(None),
+                         instance_filter: Optional[str] = Query(None)):
     """Get paginated list of movies with filtering options"""
     db = dependencies["db"]
-    
+
     with db.get_connection() as conn:
         cursor = conn.cursor()
-        
+
         # Build dynamic query
         where_conditions = []
         params = []
@@ -110,10 +111,8 @@ async def get_movies_list(dependencies: dict,
 
         if has_date is not None:
             if has_date:
-                # PostgreSQL - NULL handling
                 where_conditions.append("dateadded IS NOT NULL")
             else:
-                # PostgreSQL - NULL handling
                 where_conditions.append("dateadded IS NULL")
 
         if source_filter:
@@ -127,17 +126,21 @@ async def get_movies_list(dependencies: dict,
         if imdb_search:
             where_conditions.append("imdb_id ILIKE %s")
             params.append(f"%{imdb_search}%")
-        
+
+        if instance_filter:
+            where_conditions.append("instance = %s")
+            params.append(instance_filter)
+
         where_clause = " AND ".join(where_conditions) if where_conditions else "1=1"
-        
+
         # Get total count
         count_query = f"SELECT COUNT(*) FROM movies WHERE {where_clause}"
         cursor.execute(count_query, params)
         total_count = db._get_first_value(cursor.fetchone())
-        
-        # Get paginated results - PostgreSQL
+
+        # Get paginated results
         query = f"""
-            SELECT imdb_id, title, year, path, released, dateadded, source, has_video_file, last_updated, skipped, skip_reason
+            SELECT imdb_id, instance, title, year, path, released, dateadded, source, has_video_file, last_updated, skipped, skip_reason
             FROM movies
             WHERE {where_clause}
             ORDER BY last_updated DESC
@@ -169,12 +172,13 @@ async def get_movies_list(dependencies: dict,
 
 
 async def get_tv_series_list(dependencies: dict,
-                           skip: int = Query(0, ge=0), 
+                           skip: int = Query(0, ge=0),
                            limit: int = Query(50, le=500),
                            search: Optional[str] = Query(None),
                            imdb_search: Optional[str] = Query(None),
                            date_filter: Optional[str] = Query(None),
-                           source_filter: Optional[str] = Query(None)):
+                           source_filter: Optional[str] = Query(None),
+                           instance_filter: Optional[str] = Query(None)):
     """Get paginated list of TV series with episode counts"""
     db = dependencies["db"]
     
@@ -199,10 +203,13 @@ async def get_tv_series_list(dependencies: dict,
             params.append(f"%{imdb_search}%")
             
         if source_filter:
-            # Need to check episodes for source filter
             where_conditions.append("e.source = %s")
             params.append(source_filter)
-            
+
+        if instance_filter:
+            where_conditions.append("s.instance = %s")
+            params.append(instance_filter)
+
         if date_filter:
             if date_filter == "complete":
                 # All episodes have dates
@@ -225,14 +232,13 @@ async def get_tv_series_list(dependencies: dict,
 
         # Get total count with same filtering logic as main query
         if having_clause or needs_episode_join:
-            # When using HAVING clause or filtering by episode fields, need to count filtered results with JOIN
             count_query = f"""
                 SELECT COUNT(*) FROM (
-                    SELECT s.imdb_id
+                    SELECT s.imdb_id, s.instance
                     FROM series s
-                    LEFT JOIN episodes e ON s.imdb_id = e.imdb_id
+                    LEFT JOIN episodes e ON s.imdb_id = e.imdb_id AND s.instance = e.instance
                     WHERE {where_clause}
-                    GROUP BY s.imdb_id
+                    GROUP BY s.imdb_id, s.instance
                     {('HAVING ' + having_clause) if having_clause else ''}
                 ) filtered_series
             """
@@ -245,10 +251,10 @@ async def get_tv_series_list(dependencies: dict,
         
         # Get series with episode statistics
         having_part = f" HAVING {having_clause}" if having_clause else ""
-        # PostgreSQL query
         query = f"""
             SELECT
                 s.imdb_id,
+                s.instance,
                 s.path,
                 s.last_updated,
                 COUNT(e.episode) as total_episodes,
@@ -256,9 +262,9 @@ async def get_tv_series_list(dependencies: dict,
                 COUNT(CASE WHEN e.has_video_file = TRUE THEN 1 END) as episodes_with_video,
                 COUNT(CASE WHEN e.skipped = TRUE THEN 1 END) as episodes_skipped
             FROM series s
-            LEFT JOIN episodes e ON s.imdb_id = e.imdb_id
+            LEFT JOIN episodes e ON s.imdb_id = e.imdb_id AND s.instance = e.instance
             WHERE {where_clause}
-            GROUP BY s.imdb_id, s.path, s.last_updated{having_part}
+            GROUP BY s.imdb_id, s.instance, s.path, s.last_updated{having_part}
             ORDER BY s.last_updated DESC
             LIMIT %s OFFSET %s
         """
@@ -1486,8 +1492,8 @@ def register_web_routes(app, dependencies):
     @app.get("/api/movies")
     async def api_movies_list(skip: int = 0, limit: int = 100, has_date: bool = None,
                              source_filter: str = None, search: str = None, imdb_search: str = None,
-                             skipped: bool = None):
-        return await get_movies_list(dependencies, skip, limit, has_date, source_filter, search, imdb_search, skipped)
+                             skipped: bool = None, instance: str = None):
+        return await get_movies_list(dependencies, skip, limit, has_date, source_filter, search, imdb_search, skipped, instance)
     
     @app.post("/api/movies/{imdb_id}/update-date")
     async def api_update_movie_date(imdb_id: str, dateadded: str = None, source: str = "manual"):
@@ -1599,9 +1605,10 @@ def register_web_routes(app, dependencies):
 
     # TV series endpoints
     @app.get("/api/series")
-    async def api_series_list(skip: int = 0, limit: int = 50, search: str = None, 
-                             imdb_search: str = None, date_filter: str = None, source_filter: str = None):
-        return await get_tv_series_list(dependencies, skip, limit, search, imdb_search, date_filter, source_filter)
+    async def api_series_list(skip: int = 0, limit: int = 50, search: str = None,
+                             imdb_search: str = None, date_filter: str = None,
+                             source_filter: str = None, instance: str = None):
+        return await get_tv_series_list(dependencies, skip, limit, search, imdb_search, date_filter, source_filter, instance)
     
     @app.get("/api/series/{imdb_id}/episodes")
     async def api_series_episodes(imdb_id: str):

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -2434,6 +2434,39 @@ def register_database_admin_routes(app, dependencies):
         """Get database population status"""
         return await get_populate_status()
 
+    # /setup page and its data endpoint — proxy /api/instances to the core
+    @app.get("/api/instances")
+    async def api_instances(request: Request):
+        """Proxy instance list and connection status from the core container."""
+        import urllib.request
+        import urllib.error
+        import json
+        import os
+        import socket
+
+        core_host = os.environ.get("CORE_API_HOST", "chronarr")
+        core_port = os.environ.get("CORE_API_PORT", "8080")
+        core_url = f"http://{core_host}:{core_port}/api/instances"
+
+        try:
+            req = urllib.request.Request(core_url)
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            raise HTTPException(status_code=e.code, detail=f"Core API error: {e.reason}")
+        except (urllib.error.URLError, socket.timeout) as e:
+            raise HTTPException(status_code=503, detail=f"Could not reach core container: {e}")
+
+    @app.get("/setup")
+    async def setup_page():
+        """Serve the instance setup / webhook URL reference page."""
+        import os
+        setup_file = os.path.join(os.path.dirname(__file__), "..", "static", "setup.html")
+        from fastapi.responses import FileResponse
+        if os.path.exists(setup_file):
+            return FileResponse(os.path.normpath(setup_file))
+        raise HTTPException(status_code=404, detail="Setup page not found")
+
 
 # Scheduled Scans Functions
 

--- a/core/instance_registry.py
+++ b/core/instance_registry.py
@@ -100,11 +100,19 @@ class InstanceRegistry:
         self._sonarr: Dict[str, AnySonarrClient] = {}
         self._radarr_mappers: Dict[str, PathMapper] = {}
         self._sonarr_mappers: Dict[str, PathMapper] = {}
+        # Connection status keyed by instance name — used by /setup and startup reporting.
+        # {"connected": True, "method": "direct_db"|"api"} or {"connected": False}
+        self._radarr_status: Dict[str, dict] = {}
+        self._sonarr_status: Dict[str, dict] = {}
 
         for inst in radarr_instances:
             client = _build_radarr_client(inst)
             if client:
                 self._radarr[inst.name] = client
+                method = "direct_db" if isinstance(client, RadarrDbClient) else "api"
+                self._radarr_status[inst.name] = {"connected": True, "method": method}
+            else:
+                self._radarr_status[inst.name] = {"connected": False}
             self._radarr_mappers[inst.name] = PathMapper(
                 root_folders=inst.root_folders,
                 container_paths=inst.movie_paths,
@@ -114,6 +122,10 @@ class InstanceRegistry:
             client = _build_sonarr_client(inst)
             if client:
                 self._sonarr[inst.name] = client
+                method = "direct_db" if isinstance(client, SonarrDbClient) else "api"
+                self._sonarr_status[inst.name] = {"connected": True, "method": method}
+            else:
+                self._sonarr_status[inst.name] = {"connected": False}
             self._sonarr_mappers[inst.name] = PathMapper(
                 root_folders=inst.root_folders,
                 container_paths=inst.tv_paths,
@@ -136,6 +148,23 @@ class InstanceRegistry:
     def sonarr_mapper(self, name: str = "sonarr") -> Optional[PathMapper]:
         """Look up the PathMapper for a Sonarr instance."""
         return self._sonarr_mappers.get(name)
+
+    def radarr_status(self, name: str = "radarr") -> dict:
+        """Return connection status for a Radarr instance by name.
+
+        Returns {"connected": True, "method": "direct_db"|"api"} or {"connected": False}.
+        """
+        return self._radarr_status.get(name, {"connected": False})
+
+    def sonarr_status(self, name: str = "sonarr") -> dict:
+        """Return connection status for a Sonarr instance by name."""
+        return self._sonarr_status.get(name, {"connected": False})
+
+    def all_radarr_statuses(self) -> Dict[str, dict]:
+        return dict(self._radarr_status)
+
+    def all_sonarr_statuses(self) -> Dict[str, dict]:
+        return dict(self._sonarr_status)
 
     def all_radarr(self) -> Dict[str, AnyRadarrClient]:
         return dict(self._radarr)

--- a/main.py
+++ b/main.py
@@ -20,8 +20,6 @@ from utils.logging import _log
 from core.database import ChronarrDatabase
 from core.instance_registry import build_registry
 from core.path_mapper import PathMapper
-from clients.radarr_db_client import RadarrDbClient
-from clients.sonarr_db_client import SonarrDbClient
 
 # Import processors
 from processors.tv_processor import TVProcessor
@@ -216,10 +214,10 @@ def test_database_connections(registry=None):
         print(f"  No Radarr instances configured")
     else:
         for inst in config.radarr_instances:
-            client = registry.radarr(inst.name)
-            if client is None:
-                print(f"  [{inst.name}]  ⚠️  No client — check URL and API key config")
-            elif isinstance(client, RadarrDbClient):
+            status = registry.radarr_status(inst.name)
+            if not status["connected"]:
+                print(f"  [{inst.name}]  ⚠️  No client — check URL, API key, and DB settings in .env")
+            elif status["method"] == "direct_db":
                 print(f"  [{inst.name}]  ✅ CONNECTED (direct DB)")
             else:
                 print(f"  [{inst.name}]  ✅ CONNECTED (API)")
@@ -230,13 +228,22 @@ def test_database_connections(registry=None):
         print(f"  No Sonarr instances configured")
     else:
         for inst in config.sonarr_instances:
-            client = registry.sonarr(inst.name)
-            if client is None:
-                print(f"  [{inst.name}]  ⚠️  No client — check URL and API key config")
-            elif isinstance(client, SonarrDbClient):
+            status = registry.sonarr_status(inst.name)
+            if not status["connected"]:
+                print(f"  [{inst.name}]  ⚠️  No client — check URL, API key, and DB settings in .env")
+            elif status["method"] == "direct_db":
                 print(f"  [{inst.name}]  ✅ CONNECTED (direct DB)")
             else:
                 print(f"  [{inst.name}]  ✅ CONNECTED (API)")
+
+    # Summary warning — flag any instance without a working client
+    no_client = (
+        [n for n, s in registry.all_radarr_statuses().items() if not s["connected"]]
+        + [n for n, s in registry.all_sonarr_statuses().items() if not s["connected"]]
+    )
+    if no_client:
+        print(f"\n  ⚠️  {len(no_client)} instance(s) have no client: {', '.join(no_client)}")
+        print(f"  Webhooks received for these instances will be ignored until resolved.")
 
     print("\n" + "="*70 + "\n")
 

--- a/main.py
+++ b/main.py
@@ -19,8 +19,9 @@ from utils.logging import _log
 # Import core components
 from core.database import ChronarrDatabase
 from core.instance_registry import build_registry
-
 from core.path_mapper import PathMapper
+from clients.radarr_db_client import RadarrDbClient
+from clients.sonarr_db_client import SonarrDbClient
 
 # Import processors
 from processors.tv_processor import TVProcessor
@@ -84,14 +85,14 @@ def _noop_mapper() -> PathMapper:
     return PathMapper(root_folders=[], container_paths=[])
 
 
-def initialize_components():
+def initialize_components(registry=None):
     start_time = datetime.now(timezone.utc)
 
     db = ChronarrDatabase(config=config)
 
-    # Build the instance registry — one client + one path mapper per configured
-    # Radarr/Sonarr instance, derived from env vars at startup.
-    registry = build_registry(config)
+    # Use the registry built at startup if passed in; otherwise build it now.
+    if registry is None:
+        registry = build_registry(config)
 
     # Processors get the default instance's client and mapper. Multi-instance
     # requests pass instance name explicitly at process time; the processors look
@@ -169,171 +170,73 @@ def signal_handler(signum, frame):
     sys.exit(0)
 
 
-def test_database_connections():
-    """Test and report all database connections at startup with actual connection tests"""
+def test_database_connections(registry=None):
+    """Report all database connection statuses at startup."""
     import psycopg2
     import sqlite3
-    from pathlib import Path
 
     print("\n" + "="*70)
     print("  DATABASE CONNECTION STATUS")
     print("="*70)
 
-    # Test Chronarr internal database
+    # Chronarr's own DB — always present
     print(f"\n  Chronarr Database:")
     if config.db_type == "postgresql":
-        print(f"  Type: PostgreSQL")
-        print(f"  Host: {config.db_host}:{config.db_port}")
-        print(f"  Database: {config.db_name}")
-        print(f"  User: {config.db_user}")
-
+        print(f"  Type: PostgreSQL  Host: {config.db_host}:{config.db_port}  Database: {config.db_name}")
         try:
-            # Attempt actual connection
             conn = psycopg2.connect(
-                host=config.db_host,
-                port=config.db_port,
-                database=config.db_name,
-                user=config.db_user,
-                password=config.db_password
+                host=config.db_host, port=config.db_port,
+                database=config.db_name, user=config.db_user, password=config.db_password
             )
-            cursor = conn.cursor()
-            cursor.execute("SELECT 1")
-            cursor.close()
+            conn.cursor().execute("SELECT 1")
             conn.close()
             print(f"  Status: ✅ CONNECTED")
         except Exception as e:
-            print(f"  Status: ❌ ERROR - {str(e)[:50]}")
+            print(f"  Status: ❌ ERROR - {str(e)[:60]}")
     else:
-        print(f"  Type: SQLite")
-        print(f"  Path: {config.db_path}")
+        print(f"  Type: SQLite  Path: {config.db_path}")
         try:
             if Path(config.db_path).exists():
                 conn = sqlite3.connect(config.db_path)
-                cursor = conn.cursor()
-                cursor.execute("SELECT 1")
-                cursor.close()
+                conn.cursor().execute("SELECT 1")
                 conn.close()
                 print(f"  Status: ✅ CONNECTED")
             else:
-                print(f"  Status: ⚠️  Database file will be created on first use")
+                print(f"  Status: ⚠️  Will be created on first use")
         except Exception as e:
-            print(f"  Status: ❌ ERROR - {str(e)[:50]}")
+            print(f"  Status: ❌ ERROR - {str(e)[:60]}")
 
-    # Test Radarr database
-    print(f"\n  Radarr Database:")
-    radarr_db_type = os.environ.get("RADARR_DB_TYPE", "").lower()
+    if not registry:
+        print("\n" + "="*70 + "\n")
+        return
 
-    if radarr_db_type == "postgresql":
-        radarr_db_host = os.environ.get("RADARR_DB_HOST", "")
-        radarr_db_port = os.environ.get("RADARR_DB_PORT", "5432")
-        radarr_db_name = os.environ.get("RADARR_DB_NAME", "")
-        radarr_db_user = os.environ.get("RADARR_DB_USER", "")
-        radarr_db_password = os.environ.get("RADARR_DB_PASSWORD", "")
-
-        print(f"  Type: PostgreSQL")
-        print(f"  Host: {radarr_db_host}:{radarr_db_port}")
-        print(f"  Database: {radarr_db_name}")
-        print(f"  User: {radarr_db_user}")
-
-        if not radarr_db_host or not radarr_db_name:
-            print(f"  Status: ⚠️  NOT CONFIGURED (missing host or database name)")
-        else:
-            try:
-                conn = psycopg2.connect(
-                    host=radarr_db_host,
-                    port=int(radarr_db_port),
-                    database=radarr_db_name,
-                    user=radarr_db_user,
-                    password=radarr_db_password
-                )
-                cursor = conn.cursor()
-                cursor.execute("SELECT 1")
-                cursor.close()
-                conn.close()
-                print(f"  Status: ✅ CONNECTED - Using direct database access")
-            except Exception as e:
-                print(f"  Status: ❌ ERROR - {str(e)[:50]}")
-
-    elif radarr_db_type == "sqlite":
-        radarr_db_path = os.environ.get("RADARR_DB_PATH", "")
-        print(f"  Type: SQLite")
-        print(f"  Path: {radarr_db_path}")
-
-        if not radarr_db_path:
-            print(f"  Status: ⚠️  NOT CONFIGURED (missing database path)")
-        elif not Path(radarr_db_path).exists():
-            print(f"  Status: ❌ ERROR - Database file not found")
-        else:
-            try:
-                conn = sqlite3.connect(radarr_db_path)
-                cursor = conn.cursor()
-                cursor.execute("SELECT 1")
-                cursor.close()
-                conn.close()
-                print(f"  Status: ✅ CONNECTED - Using direct database access")
-            except Exception as e:
-                print(f"  Status: ❌ ERROR - {str(e)[:50]}")
+    # Radarr instances — one line each
+    print(f"\n  Radarr:")
+    if not config.radarr_instances:
+        print(f"  No Radarr instances configured")
     else:
-        print(f"  Type: Not configured")
-        print(f"  Status: ⚠️  Will use Radarr API instead of direct database access")
+        for inst in config.radarr_instances:
+            client = registry.radarr(inst.name)
+            if client is None:
+                print(f"  [{inst.name}]  ⚠️  No client — check URL and API key config")
+            elif isinstance(client, RadarrDbClient):
+                print(f"  [{inst.name}]  ✅ CONNECTED (direct DB)")
+            else:
+                print(f"  [{inst.name}]  ✅ CONNECTED (API)")
 
-    # Test Sonarr database
-    print(f"\n  Sonarr Database:")
-    sonarr_db_type = os.environ.get("SONARR_DB_TYPE", "").lower()
-
-    if sonarr_db_type == "postgresql":
-        sonarr_db_host = os.environ.get("SONARR_DB_HOST", "")
-        sonarr_db_port = os.environ.get("SONARR_DB_PORT", "5432")
-        sonarr_db_name = os.environ.get("SONARR_DB_NAME", "")
-        sonarr_db_user = os.environ.get("SONARR_DB_USER", "")
-        sonarr_db_password = os.environ.get("SONARR_DB_PASSWORD", "")
-
-        print(f"  Type: PostgreSQL")
-        print(f"  Host: {sonarr_db_host}:{sonarr_db_port}")
-        print(f"  Database: {sonarr_db_name}")
-        print(f"  User: {sonarr_db_user}")
-
-        if not sonarr_db_host or not sonarr_db_name:
-            print(f"  Status: ⚠️  NOT CONFIGURED (missing host or database name)")
-        else:
-            try:
-                conn = psycopg2.connect(
-                    host=sonarr_db_host,
-                    port=int(sonarr_db_port),
-                    database=sonarr_db_name,
-                    user=sonarr_db_user,
-                    password=sonarr_db_password
-                )
-                cursor = conn.cursor()
-                cursor.execute("SELECT 1")
-                cursor.close()
-                conn.close()
-                print(f"  Status: ✅ CONNECTED - Using direct database access")
-            except Exception as e:
-                print(f"  Status: ❌ ERROR - {str(e)[:50]}")
-
-    elif sonarr_db_type == "sqlite":
-        sonarr_db_path = os.environ.get("SONARR_DB_PATH", "")
-        print(f"  Type: SQLite")
-        print(f"  Path: {sonarr_db_path}")
-
-        if not sonarr_db_path:
-            print(f"  Status: ⚠️  NOT CONFIGURED (missing database path)")
-        elif not Path(sonarr_db_path).exists():
-            print(f"  Status: ❌ ERROR - Database file not found")
-        else:
-            try:
-                conn = sqlite3.connect(sonarr_db_path)
-                cursor = conn.cursor()
-                cursor.execute("SELECT 1")
-                cursor.close()
-                conn.close()
-                print(f"  Status: ✅ CONNECTED - Using direct database access")
-            except Exception as e:
-                print(f"  Status: ❌ ERROR - {str(e)[:50]}")
+    # Sonarr instances — one line each
+    print(f"\n  Sonarr:")
+    if not config.sonarr_instances:
+        print(f"  No Sonarr instances configured")
     else:
-        print(f"  Type: Not configured")
-        print(f"  Status: ⚠️  Will use Sonarr API instead of direct database access")
+        for inst in config.sonarr_instances:
+            client = registry.sonarr(inst.name)
+            if client is None:
+                print(f"  [{inst.name}]  ⚠️  No client — check URL and API key config")
+            elif isinstance(client, SonarrDbClient):
+                print(f"  [{inst.name}]  ✅ CONNECTED (direct DB)")
+            else:
+                print(f"  [{inst.name}]  ✅ CONNECTED (API)")
 
     print("\n" + "="*70 + "\n")
 
@@ -358,14 +261,17 @@ def main():
     _log("INFO", f"Config: manage_nfo={config.manage_nfo}, fix_mtimes={config.fix_dir_mtimes}")
     _log("INFO", f"Movie priority: {config.movie_priority}")
 
+    # Build registry once — used for connection status display and component init
+    registry = build_registry(config)
+
     # Test and display all database connections
-    test_database_connections()
-    
+    test_database_connections(registry)
+
     # Create FastAPI app
     app = create_app()
-    
+
     # Initialize components
-    dependencies = initialize_components()
+    dependencies = initialize_components(registry=registry)
     
     # Note: Authentication and web interface handled by separate chronarr-web container
     _log("INFO", "Core API: Authentication handled by separate web container")

--- a/processors/tv_processor.py
+++ b/processors/tv_processor.py
@@ -486,58 +486,48 @@ class TVProcessor:
             _log("ERROR", f"Failed to get Sonarr episodes for {imdb_id}: {e}")
             return {}
     
-    def process_season(self, series_path: str, season_name: str) -> Dict[str, Any]:
+    def process_season(self, series_path: str, season_name: str, instance: str = 'sonarr') -> Dict[str, Any]:
         """Process a specific season"""
         series_path_obj = Path(series_path)
         if not series_path_obj.exists():
             raise FileNotFoundError(f"Series path not found: {series_path}")
-        
+
         season_path = series_path_obj / season_name
         if not season_path.exists():
             raise FileNotFoundError(f"Season directory not found: {season_path}")
-        
-        # Extract season number from directory name
+
         season_match = re.search(r'(\d+)', season_name)
         if not season_match:
             raise ValueError(f"Could not extract season number from: {season_name}")
-        
+
         season_num = int(season_match.group(1))
-        
-        # Get series IMDb ID
-        imdb_id = parse_imdb_from_path(series_path_obj)  # Phase 3: Using imdb_utils
+
+        imdb_id = parse_imdb_from_path(series_path_obj)
         if not imdb_id:
             raise ValueError(f"No IMDb ID found in series path: {series_path}")
 
         _log("INFO", f"Processing season {season_num} of series: {series_path_obj.name}")
-        
-        # Find episodes in this season
+
         disk_episodes = find_episodes_on_disk(series_path_obj)
         season_episodes = {k: v for k, v in disk_episodes.items() if k[0] == season_num}
-        
+
         if not season_episodes:
             return {"status": "no_episodes", "season": season_num, "episodes_found": 0}
-        
-        # Get episode dates
-        episode_dates = self._gather_episode_dates(series_path_obj, imdb_id, season_episodes)
-        
-        # Process episodes
+
+        episode_dates = self._gather_episode_dates(series_path_obj, imdb_id, season_episodes, instance=instance)
+
         processed_count = 0
         for (season, episode), (aired, dateadded, source) in episode_dates.items():
             if (season, episode) in season_episodes:
-                # NFO file operations removed - database is now the single source of truth
-                # (Phase 1: Remove NFO file write operations)
-                
-                # Save to database
                 try:
-                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True)
+                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True, instance=instance)
                     _log("DEBUG", f"S{season:02d}E{episode:02d}: Database record saved successfully")
                 except Exception as e:
                     _log("ERROR", f"S{season:02d}E{episode:02d}: Database write failed: {e}")
-                    # Continue processing other episodes
                 processed_count += 1
-        
+
         _log("INFO", f"Processed {processed_count} episodes in season {season_num}")
-        
+
         return {
             "status": "success",
             "season": season_num,
@@ -545,63 +535,56 @@ class TVProcessor:
             "episodes_processed": processed_count
         }
     
-    def process_episode(self, series_path: str, season_name: str, episode_name: str) -> Dict[str, Any]:
+    def process_episode(self, series_path: str, season_name: str, episode_name: str, instance: str = 'sonarr') -> Dict[str, Any]:
         """Process a specific episode"""
         series_path_obj = Path(series_path)
         if not series_path_obj.exists():
             raise FileNotFoundError(f"Series path not found: {series_path}")
-        
+
         season_path = series_path_obj / season_name
         if not season_path.exists():
             raise FileNotFoundError(f"Season directory not found: {season_path}")
-        
+
         episode_path = season_path / episode_name
         if not episode_path.exists():
             raise FileNotFoundError(f"Episode file not found: {episode_path}")
-        
-        # Extract season and episode numbers
+
         season_match = re.search(r'(\d+)', season_name)
         episode_match = re.search(r'[sS](\d+)[eE](\d+)|(\d+)x(\d+)', episode_name)
-        
+
         if not season_match:
             raise ValueError(f"Could not extract season number from: {season_name}")
-        
+
         if not episode_match:
             raise ValueError(f"Could not extract episode number from: {episode_name}")
-        
+
         season_num = int(season_match.group(1))
-        
-        if episode_match.group(1) and episode_match.group(2):  # SxxExx format
+
+        if episode_match.group(1) and episode_match.group(2):
             episode_num = int(episode_match.group(2))
-        elif episode_match.group(3) and episode_match.group(4):  # NxNN format
+        elif episode_match.group(3) and episode_match.group(4):
             episode_num = int(episode_match.group(4))
         else:
             raise ValueError(f"Could not parse episode number from: {episode_name}")
-        
-        # Get series IMDb ID
-        imdb_id = parse_imdb_from_path(series_path_obj)  # Phase 3: Using imdb_utils
+
+        imdb_id = parse_imdb_from_path(series_path_obj)
         if not imdb_id:
             raise ValueError(f"No IMDb ID found in series path: {series_path}")
 
         _log("INFO", f"Processing episode S{season_num:02d}E{episode_num:02d} of series: {series_path_obj.name}")
-        
-        # Get episode data
+
         disk_episodes = {(season_num, episode_num): [episode_path]}
-        episode_dates = self._gather_episode_dates(series_path_obj, imdb_id, disk_episodes)
-        
+        episode_dates = self._gather_episode_dates(series_path_obj, imdb_id, disk_episodes, instance=instance)
+
         if (season_num, episode_num) not in episode_dates:
             return {"status": "no_data", "season": season_num, "episode": episode_num}
-        
+
         aired, dateadded, source = episode_dates[(season_num, episode_num)]
-        
-        # NFO file operations removed - database is now the single source of truth
-        # (Phase 1: Remove NFO file write operations)
-        
-        # Save to database
-        self.db.upsert_episode_date(imdb_id, season_num, episode_num, aired, dateadded, source, True)
-        
+
+        self.db.upsert_episode_date(imdb_id, season_num, episode_num, aired, dateadded, source, True, instance=instance)
+
         _log("INFO", f"Processed episode S{season_num:02d}E{episode_num:02d}")
-        
+
         return {
             "status": "success",
             "season": season_num,
@@ -613,61 +596,39 @@ class TVProcessor:
     
     # ===== ASYNC METHODS =====
     
-    async def async_process_series(self, series_path: Path) -> Dict[str, Any]:
-        """
-        Async process a TV series directory with concurrent episode processing
-        
-        Args:
-            series_path: Path to series directory
-            
-        Returns:
-            Dictionary with processing results
-        """
-        imdb_id = parse_imdb_from_path(series_path)  # Phase 3: Using imdb_utils
+    async def async_process_series(self, series_path: Path, instance: str = 'sonarr') -> Dict[str, Any]:
+        """Async process a TV series directory with concurrent episode processing."""
+        imdb_id = parse_imdb_from_path(series_path)
         if not imdb_id:
             return {"status": "error", "reason": f"No IMDb ID found in series path: {series_path}"}
-        
+
         _log("INFO", f"Async processing TV series: {series_path.name}")
-        
-        # Update database
-        self.db.upsert_series(imdb_id, str(series_path))
-        
-        # Find video files asynchronously
+
+        self.db.upsert_series(imdb_id, str(series_path), instance=instance)
+
         disk_episodes = await async_find_episodes_on_disk(series_path)
         _log("INFO", f"Found {len(disk_episodes)} episodes on disk")
-        
-        # Get episode dates (sync for now, could be made async later)
-        episode_dates = self._gather_episode_dates(series_path, imdb_id, disk_episodes)
-        
-        # Prepare episode data for concurrent processing
-        episode_data_list = []
-        mtime_operations = []
-        
+
+        # sync for now — could be made async if episode date gathering becomes a bottleneck
+        episode_dates = self._gather_episode_dates(series_path, imdb_id, disk_episodes, instance=instance)
+
+        processed_count = 0
         for (season, episode), (aired, dateadded, source) in episode_dates.items():
             if (season, episode) in disk_episodes:
-                # NFO file operations removed - database is now the single source of truth
-                # (Phase 1: Remove NFO file write operations)
-                
-                # Save to database
                 try:
-                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True)
+                    self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, source, True, instance=instance)
                     _log("DEBUG", f"S{season:02d}E{episode:02d}: Database record saved successfully")
+                    processed_count += 1
                 except Exception as e:
                     _log("ERROR", f"S{season:02d}E{episode:02d}: Database write failed: {e}")
-                    # Continue processing other episodes
-        
-        # NFO and mtime operations removed - database is now the single source of truth
-        # (Phase 1: Remove NFO file write operations)
-        results = {}
-        
+
         _log("INFO", f"Completed async processing TV series: {series_path.name}")
-        
+
         return {
             "status": "success",
             "imdb_id": imdb_id,
             "episodes_found": len(disk_episodes),
-            "episodes_processed": len(episode_data_list),
-            "results": results
+            "episodes_processed": processed_count,
         }
     
     async def async_process_multiple_series(
@@ -1005,46 +966,30 @@ class TVProcessor:
     async def async_batch_episode_processing(
         self,
         episodes_data: List[Dict[str, Any]],
-        max_concurrent: int = 5
+        max_concurrent: int = 5,
+        instance: str = 'sonarr',
     ) -> Dict[str, Any]:
-        """
-        Process episodes from webhook data concurrently
-        
-        Args:
-            episodes_data: List of episode data from webhooks
-            max_concurrent: Maximum concurrent episode processing
-            
-        Returns:
-            Processing results summary
-        """
+        """Process episodes from webhook data concurrently."""
         async def _process_single_episode(episode_data: Dict[str, Any]) -> Dict[str, Any]:
             try:
-                # Extract episode information
                 series_path = Path(episode_data.get('series_path'))
                 season = episode_data.get('season')
                 episode = episode_data.get('episode')
                 aired = episode_data.get('aired')
                 dateadded = episode_data.get('dateadded')
-                
-                # Get IMDb ID
-                imdb_id = parse_imdb_from_path(series_path)  # Phase 3: Using imdb_utils
+
+                imdb_id = parse_imdb_from_path(series_path)
                 if not imdb_id:
                     return {"status": "error", "reason": "No IMDb ID found"}
-                
-                # NFO file operations removed - database is now the single source of truth
-                # (Phase 1: Remove NFO file write operations)
-                nfo_success = True  # Always True since we're not creating NFOs anymore
-                
-                # Update database
-                self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, "webhook", True)
-                
+
+                self.db.upsert_episode_date(imdb_id, season, episode, aired, dateadded, "webhook", True, instance=instance)
+
                 return {
                     "status": "success",
                     "season": season,
                     "episode": episode,
-                    "nfo_created": nfo_success
                 }
-                
+
             except Exception as e:
                 return {
                     "status": "error",

--- a/static/index.html
+++ b/static/index.html
@@ -39,6 +39,9 @@
                 <button class="nav-tab" data-tab="tools">
                     <i class="fas fa-tools"></i> Tools
                 </button>
+                <a href="/setup" class="nav-tab" style="text-decoration:none">
+                    <i class="fas fa-plug"></i> Setup
+                </a>
             </nav>
         </header>
 
@@ -128,6 +131,9 @@
                             <select id="movies-filter-source">
                                 <option value="">All Sources</option>
                             </select>
+                            <select id="movies-filter-instance">
+                                <option value="">All Instances</option>
+                            </select>
                             <button class="btn btn-primary" onclick="refreshMovies()">
                                 <i class="fas fa-sync"></i> Refresh
                             </button>
@@ -146,6 +152,7 @@
                                 <th>Source</th>
                                 <th>Date Type</th>
                                 <th>Video File</th>
+                                <th id="movies-instance-col" style="display:none">Instance</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
@@ -185,6 +192,9 @@
                             <select id="series-filter-source">
                                 <option value="">All Sources</option>
                             </select>
+                            <select id="series-filter-instance">
+                                <option value="">All Instances</option>
+                            </select>
                             <button class="btn btn-primary" onclick="refreshSeries()">
                                 <i class="fas fa-sync"></i> Refresh
                             </button>
@@ -201,6 +211,7 @@
                                 <th>Episodes</th>
                                 <th>With Dates</th>
                                 <th>With Video</th>
+                                <th id="series-instance-col" style="display:none">Instance</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', function() {
     checkAuthStatus();  // Check authentication status on page load
     loadDashboard();
     loadSeriesSources();
+    loadInstanceDropdowns();
 });
 
 // Tab management
@@ -70,8 +71,10 @@ function initializeEventListeners() {
     // Filter dropdowns
     document.getElementById('movies-filter-date').addEventListener('change', loadMovies);
     document.getElementById('movies-filter-source').addEventListener('change', loadMovies);
+    document.getElementById('movies-filter-instance').addEventListener('change', loadMovies);
     document.getElementById('series-filter-date').addEventListener('change', loadSeries);
     document.getElementById('series-filter-source').addEventListener('change', loadSeries);
+    document.getElementById('series-filter-instance').addEventListener('change', loadSeries);
     
     // Forms
     document.getElementById('edit-form').addEventListener('submit', handleEditSubmit);
@@ -198,19 +201,21 @@ async function loadMovies(page = 1) {
     const imdbSearch = document.getElementById('movies-imdb-search').value;
     const hasDate = document.getElementById('movies-filter-date').value;
     const sourceFilter = document.getElementById('movies-filter-source').value;
-    
+    const instanceFilter = document.getElementById('movies-filter-instance').value;
+
     const skip = (page - 1) * 100;
     console.log(`DEBUG: loadMovies called with page=${page}, calculated skip=${skip}`);
-    
+
     const params = new URLSearchParams({
         skip: skip,
         limit: 100
     });
-    
+
     if (search) params.append('search', search);
     if (imdbSearch) params.append('imdb_search', imdbSearch);
     if (hasDate) params.append('has_date', hasDate);
     if (sourceFilter) params.append('source_filter', sourceFilter);
+    if (instanceFilter) params.append('instance', instanceFilter);
     
     try {
         const data = await apiCall(`/api/movies?${params}`);
@@ -276,6 +281,9 @@ function updateMoviesTable(data) {
             dateTypeBadge = 'badge-warning';
         }
         
+        const instanceColStyle = document.getElementById('movies-instance-col') &&
+            document.getElementById('movies-instance-col').style.display !== 'none'
+            ? '' : 'display:none';
         return `
             <tr>
                 <td>${escapeHtml(movie.title)}</td>
@@ -285,6 +293,7 @@ function updateMoviesTable(data) {
                 <td><span class="badge badge-secondary">${movie.source_description || movie.source || 'Unknown'}</span></td>
                 <td><span class="badge ${dateTypeBadge}">${dateType}</span></td>
                 <td>${hasVideoBadge}</td>
+                <td style="${instanceColStyle}"><code>${movie.instance || '-'}</code></td>
                 <td>
                     <button class="btn btn-sm btn-primary" onclick="editMovie('${movie.imdb_id}', '${dateadded}', '${movie.source || ''}')">
                         <i class="fas fa-edit"></i> Edit
@@ -360,6 +369,38 @@ async function loadSeriesSources() {
     }
 }
 
+async function loadInstanceDropdowns() {
+    try {
+        const data = await apiCall('/api/instances');
+        const instances = [...(data.radarr || []), ...(data.sonarr || [])];
+        if (instances.length <= 1) return; // no dropdown needed when only one instance
+
+        const movieSel = document.getElementById('movies-filter-instance');
+        const seriesSel = document.getElementById('series-filter-instance');
+
+        const radarrNames = (data.radarr || []).map(i => i.name);
+        const sonarrNames = (data.sonarr || []).map(i => i.name);
+
+        movieSel.innerHTML = '<option value="">All Instances</option>';
+        radarrNames.forEach(n => {
+            movieSel.innerHTML += `<option value="${n}">${n}</option>`;
+        });
+
+        seriesSel.innerHTML = '<option value="">All Instances</option>';
+        sonarrNames.forEach(n => {
+            seriesSel.innerHTML += `<option value="${n}">${n}</option>`;
+        });
+
+        // Show Instance column header when multiple instances are available
+        const moviesColHeader = document.getElementById('movies-instance-col');
+        const seriesColHeader = document.getElementById('series-instance-col');
+        if (moviesColHeader) moviesColHeader.style.display = '';
+        if (seriesColHeader) seriesColHeader.style.display = '';
+    } catch (error) {
+        console.error('Failed to load instance list:', error);
+    }
+}
+
 function refreshMovies() {
     loadMovies(isNaN(currentMoviesPage) ? 1 : currentMoviesPage);
 }
@@ -375,19 +416,21 @@ async function loadSeries(page = 1) {
     const imdbSearch = document.getElementById('series-imdb-search').value;
     const dateFilter = document.getElementById('series-filter-date').value;
     const sourceFilter = document.getElementById('series-filter-source').value;
-    
+    const instanceFilter = document.getElementById('series-filter-instance').value;
+
     const skip = (page - 1) * 50;
     console.log(`DEBUG: loadSeries called with page=${page}, calculated skip=${skip}`);
-    
+
     const params = new URLSearchParams({
         skip: skip,
         limit: 50
     });
-    
+
     if (search) params.append('search', search);
     if (imdbSearch) params.append('imdb_search', imdbSearch);
     if (dateFilter) params.append('date_filter', dateFilter);
     if (sourceFilter) params.append('source_filter', sourceFilter);
+    if (instanceFilter) params.append('instance', instanceFilter);
     
     try {
         const data = await apiCall(`/api/series?${params}`);
@@ -407,10 +450,15 @@ function updateSeriesTable(data) {
         return;
     }
     
+    const showSeriesInstance = document.getElementById('series-instance-col') &&
+        document.getElementById('series-instance-col').style.display !== 'none';
+
     tbody.innerHTML = data.series.map(series => {
-        const progressPercent = series.total_episodes > 0 ? 
+        const progressPercent = series.total_episodes > 0 ?
             ((series.episodes_with_dates / series.total_episodes) * 100).toFixed(1) : 0;
-        
+        const instanceCell = showSeriesInstance
+            ? `<td><code>${series.instance || '-'}</code></td>` : '<td style="display:none"></td>';
+
         return `
             <tr>
                 <td>${escapeHtml(series.title)}</td>
@@ -421,6 +469,7 @@ function updateSeriesTable(data) {
                     <small class="text-muted">(${progressPercent}%)</small>
                 </td>
                 <td>${series.episodes_with_video}</td>
+                ${instanceCell}
                 <td>
                     <button class="btn btn-sm btn-primary" onclick="viewSeriesEpisodes('${series.imdb_id}')">
                         <i class="fas fa-list"></i> Episodes

--- a/static/setup.html
+++ b/static/setup.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chronarr — Setup</title>
+    <link rel="stylesheet" href="/static/css/styles.css?v=setup-page">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        .setup-container {
+            max-width: 800px;
+            margin: 2rem auto;
+            padding: 0 1rem;
+        }
+
+        .setup-section {
+            background: white;
+            border-radius: 8px;
+            box-shadow: var(--shadow);
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .setup-section h2 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: var(--dark-color);
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .base-url-row {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .base-url-row label {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            white-space: nowrap;
+        }
+
+        .base-url-row input {
+            flex: 1;
+            min-width: 200px;
+            padding: 0.4rem 0.75rem;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            font-size: 0.9rem;
+            font-family: inherit;
+        }
+
+        .base-url-row input:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.15);
+        }
+
+        .instance-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .instance-row {
+            display: grid;
+            grid-template-columns: auto 1fr auto;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.75rem 1rem;
+            background: var(--light-color);
+            border-radius: 6px;
+            border: 1px solid var(--border-color);
+        }
+
+        .instance-meta {
+            display: flex;
+            flex-direction: column;
+            gap: 0.2rem;
+        }
+
+        .instance-name {
+            font-weight: 600;
+            font-size: 0.9rem;
+        }
+
+        .instance-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            font-size: 0.75rem;
+            padding: 0.15rem 0.5rem;
+            border-radius: 12px;
+            font-weight: 500;
+        }
+
+        .badge-ok {
+            background: #d4edda;
+            color: #155724;
+        }
+
+        .badge-warn {
+            background: #fff3cd;
+            color: #856404;
+        }
+
+        .badge-method {
+            background: #e2e3e5;
+            color: #495057;
+            margin-left: 0.3rem;
+        }
+
+        .webhook-url-cell {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            min-width: 0;
+        }
+
+        .webhook-url-cell input {
+            flex: 1;
+            padding: 0.35rem 0.6rem;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            font-size: 0.82rem;
+            font-family: "SFMono-Regular", Consolas, monospace;
+            color: #495057;
+            background: white;
+            min-width: 0;
+        }
+
+        .btn-copy {
+            flex-shrink: 0;
+            padding: 0.35rem 0.75rem;
+            background: #667eea;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 0.3rem;
+            transition: background 0.15s;
+            white-space: nowrap;
+        }
+
+        .btn-copy:hover {
+            background: #5a6fd6;
+        }
+
+        .btn-copy.copied {
+            background: var(--success-color);
+        }
+
+        .empty-note {
+            color: var(--text-muted);
+            font-size: 0.9rem;
+            font-style: italic;
+        }
+
+        .hint-text {
+            font-size: 0.82rem;
+            color: var(--text-muted);
+            margin-top: 0.75rem;
+            line-height: 1.5;
+        }
+
+        .hint-text code {
+            background: #f0f0f0;
+            padding: 0.1rem 0.3rem;
+            border-radius: 3px;
+            font-family: "SFMono-Regular", Consolas, monospace;
+            font-size: 0.8rem;
+        }
+
+        .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+            margin-bottom: 1rem;
+            color: #667eea;
+            text-decoration: none;
+            font-size: 0.9rem;
+        }
+
+        .back-link:hover {
+            text-decoration: underline;
+        }
+
+        .loading-note {
+            color: var(--text-muted);
+            font-size: 0.9rem;
+        }
+
+        .error-note {
+            color: var(--danger-color);
+            font-size: 0.9rem;
+        }
+
+        /* Responsive — on narrow screens, stack the instance row */
+        @media (max-width: 560px) {
+            .instance-row {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="app-container">
+        <header class="app-header">
+            <div class="header-content">
+                <h1><i class="fas fa-shield-alt"></i> Chronarr</h1>
+                <p>Setup &amp; Webhook Configuration</p>
+            </div>
+        </header>
+
+        <div class="setup-container">
+            <a href="/" class="back-link">
+                <i class="fas fa-arrow-left"></i> Back to Dashboard
+            </a>
+
+            <!-- Base URL -->
+            <div class="setup-section">
+                <h2><i class="fas fa-link"></i> Chronarr Core URL</h2>
+                <div class="base-url-row">
+                    <label for="base-url">Base URL:</label>
+                    <input type="text" id="base-url" placeholder="http://your-server:8080" />
+                </div>
+                <p class="hint-text">
+                    This is the address Radarr and Sonarr will use to reach Chronarr's core container.
+                    It should be the hostname (or IP) your media apps can reach, on port
+                    <code>8080</code> by default. Edit it once here and all webhook URLs below update automatically.
+                </p>
+            </div>
+
+            <!-- Radarr -->
+            <div class="setup-section">
+                <h2><i class="fas fa-film"></i> Radarr Instances</h2>
+                <div class="instance-list" id="radarr-list">
+                    <span class="loading-note">Loading&hellip;</span>
+                </div>
+            </div>
+
+            <!-- Sonarr -->
+            <div class="setup-section">
+                <h2><i class="fas fa-tv"></i> Sonarr Instances</h2>
+                <div class="instance-list" id="sonarr-list">
+                    <span class="loading-note">Loading&hellip;</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Infer the likely core URL from the current page's host, swapping port to 8080.
+        // The user can override this in the input.
+        function defaultCoreUrl() {
+            const { protocol, hostname } = window.location;
+            return `${protocol}//${hostname}:8080`;
+        }
+
+        const baseInput = document.getElementById('base-url');
+        baseInput.value = defaultCoreUrl();
+        baseInput.addEventListener('input', rebuildUrls);
+
+        function buildWebhookUrl(path) {
+            const base = (baseInput.value || '').replace(/\/$/, '');
+            return base + path;
+        }
+
+        function renderInstances(containerId, instances, serviceLabel) {
+            const container = document.getElementById(containerId);
+            if (!instances || instances.length === 0) {
+                container.innerHTML = `<span class="empty-note">No ${serviceLabel} instances configured.</span>`;
+                return;
+            }
+
+            container.innerHTML = '';
+            for (const inst of instances) {
+                const row = document.createElement('div');
+                row.className = 'instance-row';
+                row.dataset.path = inst.webhook_path;
+
+                const statusBadge = inst.connected
+                    ? `<span class="instance-badge badge-ok"><i class="fas fa-check-circle"></i> Connected</span>`
+                    : `<span class="instance-badge badge-warn"><i class="fas fa-exclamation-triangle"></i> No client</span>`;
+
+                const methodBadge = inst.method
+                    ? `<span class="instance-badge badge-method">${inst.method === 'direct_db' ? 'Direct DB' : 'API'}</span>`
+                    : '';
+
+                const webhookUrl = buildWebhookUrl(inst.webhook_path);
+
+                row.innerHTML = `
+                    <div class="instance-meta">
+                        <span class="instance-name">${escHtml(inst.name)}</span>
+                        <div>${statusBadge}${methodBadge}</div>
+                    </div>
+                    <div class="webhook-url-cell">
+                        <input type="text" class="url-field" value="${escHtml(webhookUrl)}" readonly />
+                    </div>
+                    <button class="btn-copy" onclick="copyUrl(this)">
+                        <i class="fas fa-copy"></i> Copy
+                    </button>
+                `;
+                container.appendChild(row);
+            }
+        }
+
+        function rebuildUrls() {
+            document.querySelectorAll('.instance-row').forEach(row => {
+                const path = row.dataset.path;
+                const input = row.querySelector('.url-field');
+                if (input && path) {
+                    input.value = buildWebhookUrl(path);
+                }
+            });
+        }
+
+        function copyUrl(btn) {
+            const input = btn.closest('.instance-row').querySelector('.url-field');
+            if (!input) return;
+            navigator.clipboard.writeText(input.value).then(() => {
+                btn.classList.add('copied');
+                const icon = btn.querySelector('i');
+                const originalHtml = btn.innerHTML;
+                btn.innerHTML = '<i class="fas fa-check"></i> Copied';
+                setTimeout(() => {
+                    btn.innerHTML = originalHtml;
+                    btn.classList.remove('copied');
+                }, 1800);
+            }).catch(() => {
+                // Fallback for older browsers / HTTP contexts
+                input.select();
+                document.execCommand('copy');
+            });
+        }
+
+        function escHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;');
+        }
+
+        async function loadInstances() {
+            try {
+                const resp = await fetch('/api/instances');
+                if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+                const data = await resp.json();
+                renderInstances('radarr-list', data.radarr || [], 'Radarr');
+                renderInstances('sonarr-list', data.sonarr || [], 'Sonarr');
+            } catch (err) {
+                const msg = `<span class="error-note"><i class="fas fa-times-circle"></i> Could not load instance data: ${escHtml(err.message)}</span>`;
+                document.getElementById('radarr-list').innerHTML = msg;
+                document.getElementById('sonarr-list').innerHTML = msg;
+            }
+        }
+
+        loadInstances();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## What's in this PR

Phase 3 of the v3 multi-instance feature set. Builds on Phase 2 (already merged into `feature/v3`).

### Changes

- **Instance dropdown + combined view** on content pages — switch between instances or view all combined
- **Setup page** (`/setup`) — shows per-instance webhook URLs and live connection status
- **Per-instance startup connection status** — stored in registry on boot, surfaced on setup page
- **Instance threading** — remaining processors and non-webhook paths wired through instance context
- **Emby changelog endpoint** (`GET /emby/changelog`) — serves `Emby-DLL/CHANGELOG.md` as markdown; consumed by the Emby plugin config page
- **Emby plugin CHANGELOG.md** added to `Emby-DLL/`

### What's NOT in this PR

The updated Emby plugin DLL (`Emby-DLL/Chronarr.Emby.Plugin.dll`) is coming in a separate PR after testing is confirmed.

### Merges into

`feature/v3` — not yet in `dev` or `main`