### PR TITLE
Feat/sidebar nav instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,7 @@ MOVIE_PATHS=/media/movies
 
 # Radarr database (direct DB access — faster than API for large libraries)
 RADARR_DB_TYPE=postgresql
-RADARR_DB_HOST=192.168.255.50
+RADARR_DB_HOST=your-radarr-db-host
 RADARR_DB_PORT=5432
 RADARR_DB_NAME=radarr-main
 RADARR_DB_USER=postgres
@@ -84,7 +84,7 @@ RADARR_DB_USER=postgres
 # RADARR_4K_ROOT_FOLDERS=/mnt/unionfs/Media/Movies/movies4k
 # RADARR_4K_MOVIE_PATHS=/media/movies4k
 # RADARR_4K_DB_TYPE=postgresql
-# RADARR_4K_DB_HOST=192.168.255.50
+# RADARR_4K_DB_HOST=your-radarr-4k-db-host
 # RADARR_4K_DB_PORT=5432
 # RADARR_4K_DB_NAME=radarr-4k
 # RADARR_4K_DB_USER=postgres
@@ -102,7 +102,7 @@ TV_PATHS=/media/tv
 
 # Sonarr database
 SONARR_DB_TYPE=postgresql
-SONARR_DB_HOST=192.168.255.50
+SONARR_DB_HOST=your-sonarr-db-host
 SONARR_DB_PORT=5432
 SONARR_DB_NAME=sonarr-main
 SONARR_DB_USER=postgres
@@ -121,7 +121,7 @@ SONARR_DB_USER=postgres
 # SONARR_4K_ROOT_FOLDERS=/mnt/unionfs/Media/TV/tv4k
 # SONARR_4K_TV_PATHS=/media/tv4k
 # SONARR_4K_DB_TYPE=postgresql
-# SONARR_4K_DB_HOST=192.168.255.50
+# SONARR_4K_DB_HOST=your-sonarr-4k-db-host
 # SONARR_4K_DB_PORT=5432
 # SONARR_4K_DB_NAME=sonarr-4k
 # SONARR_4K_DB_USER=postgres

--- a/.env.secrets.example
+++ b/.env.secrets.example
@@ -6,16 +6,21 @@
 # ===========================================
 # CHRONARR DATABASE CREDENTIALS (REQUIRED)
 # ===========================================
-# Chronarr PostgreSQL database password (REQUIRED for v2.6+)
+# Chronarr PostgreSQL database password (required)
 DB_PASSWORD=your_secure_chronarr_password
 # Optional: Override default database user (defaults to 'chronarr')
 # DB_USER=chronarr
 
 # ===========================================
-# RADARR DATABASE CREDENTIALS (OPTIONAL)
+# RADARR / SONARR DATABASE CREDENTIALS
 # ===========================================
-# Database password for external Radarr PostgreSQL connection (optional optimization)
+# Database passwords for direct Radarr/Sonarr PostgreSQL access (optional, recommended)
 RADARR_DB_PASSWORD=your_radarr_db_password
+SONARR_DB_PASSWORD=your_sonarr_db_password
+
+# Named instance passwords (uncomment if using additional instances)
+# RADARR_4K_DB_PASSWORD=your_radarr_4k_db_password
+# SONARR_4K_DB_PASSWORD=your_sonarr_4k_db_password
 
 # ===========================================
 # API KEYS (SENSITIVE DATA)
@@ -29,15 +34,18 @@ OMDB_API_KEY=your_omdb_api_key
 # Radarr API key (optional - for fallback only)
 RADARR_API_KEY=your_radarr_api_key
 
-# Sonarr API key (REQUIRED for v0.6.0+ Enhanced TV NFO Generation)
+# Sonarr API key (required for series lookups and TV episode metadata)
 SONARR_API_KEY=your_sonarr_api_key
+
+# Named instance API keys (uncomment if using additional instances)
+# RADARR_4K_API_KEY=your_radarr_4k_api_key
+# SONARR_4K_API_KEY=your_sonarr_4k_api_key
 
 # Jellyseerr API key (optional)
 JELLYSEERR_API_KEY=your_jellyseerr_api_key
 
-# TVDB API key (RECOMMENDED for v0.6.1+ Emby TV NFO Compatibility)
-# Required to convert IMDB IDs to TVDB IDs for proper Emby metadata loading
-# Get free API key at: https://thetvdb.com/api-information
+# TVDB API key (optional — used for TV episode air date lookups)
+# Get a free API key at: https://thetvdb.com/api-information
 TVDB_API_KEY=your_tvdb_api_key
 
 # ===========================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-# Chronarr Plugin Changelog
+# Chronarr Changelog
+
+## Core App
+
+### v3.0.0
+
+- **Multi-instance support** — Configure multiple Radarr and/or Sonarr instances using a `NAME` segment in the env var (e.g., `RADARR_4K_URL`). Each instance is discovered automatically and tracked independently in the database
+- **Sidebar navigation** — Replaced the horizontal tab bar with a collapsible dark sidebar; Movies and TV Shows expand to show per-instance sub-items with colored dots
+- **Instance badges** — Table rows display a colored pill badge identifying which instance the record belongs to; colors are consistent between the sidebar dots and the table badges
+- **Instance-aware edit and smart-fix** — Date edits, smart-fix actions, and skipped-item updates are scoped to the correct instance, preventing cross-instance updates in multi-instance setups
+- **Cold-start populate fix** — Database population triggered at startup now loops all configured Radarr and Sonarr instances instead of only the first
+- **Delete series** — New API endpoint (`DELETE /api/series/{imdb_id}?instance=sonarr`) and UI button to remove an entire TV series and all its episode records in one operation
+- **Series title cleanup** — Series titles sourced from folder paths no longer include media-manager ID suffixes such as `[imdb-tt1234567]`
+
+---
+
+## Emby and Jellyfin Plugin
 
 Full version history for the Emby and Jellyfin plugins. The config page inside each plugin shows the latest 5 entries only.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -89,7 +89,7 @@ docker-compose restart
 ### 4. Populate Database
 
 1. Open web interface: `http://your-server:8081`
-2. Click **Admin** tab
+2. Click **Tools** in the sidebar
 3. Click **Populate Database**
 4. Select **Movies** and/or **TV Shows**
 5. Click **Start Population**

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -121,14 +121,14 @@ docker-compose restart
 1. Go to **Settings → Connect**
 2. Add **Webhook** connection:
    - Name: `Chronarr`
-   - URL: `http://chronarr-core:8080/webhook/radarr`
+   - URL: `http://chronarr-core:8080/radarr/webhook`
    - Triggers: On Import, On Upgrade, On Rename
 
 ### Sonarr
 1. Go to **Settings → Connect**
 2. Add **Webhook** connection:
    - Name: `Chronarr`
-   - URL: `http://chronarr-core:8080/webhook/sonarr`
+   - URL: `http://chronarr-core:8080/sonarr/webhook`
    - Triggers: On Import, On Upgrade, On Rename, On Episode File Delete
 
 ## Useful Commands

--- a/README.md
+++ b/README.md
@@ -201,10 +201,9 @@ SONARR_DB_PATH=/sonarr-config/sonarr.db
 ```bash
 # Apply configuration changes
 docker-compose restart
-
-# Access web interface
-open http://your-server:8081
 ```
+
+Browse to `http://your-server:8081`
 
 Then in the web interface:
 1. Open the sidebar and click **Tools**
@@ -510,7 +509,7 @@ docker exec -it chronarr-core psql -h radarr-db -U radarr -d radarr-main
 
 ### Missing Dates
 - Check **Dashboard** → **Skipped Items** section
-- Review **Source** column in Movies/TV tabs
+- Review **Source** column in the Movies or TV Shows sections
 - Use **Debug** button to inspect raw database data
 - Verify Radarr/Sonarr have import history data
 
@@ -524,15 +523,16 @@ docker exec -it chronarr-core psql -h radarr-db -U radarr -d radarr-main
 ### Project Structure
 ```
 chronarr/
-├── api/                    # API route handlers
+├── api/                    # Core API route handlers
 ├── clients/                # Radarr/Sonarr API clients
 ├── config/                 # Configuration management
 ├── core/                   # Core database and logic
-├── chronarr-web/          # Web interface container
-│   ├── static/            # HTML, CSS, JavaScript
-│   └── api/               # Web-specific API routes
-├── processors/            # Webhook processors (legacy)
-├── utils/                 # Utility functions
+├── chronarr-web/           # Web interface container
+│   ├── static/             # HTML, CSS, JavaScript (served by web container)
+│   └── api/                # Web-specific API routes (web_routes.py)
+├── static/                 # Shared static assets
+├── processors/             # Webhook processors
+├── utils/                  # Utility functions
 └── docker-compose.yml.example  # Docker Compose configuration template
 ```
 
@@ -545,8 +545,9 @@ cd chronarr
 # Build Docker image
 docker build -t chronarr:dev .
 
-# Run with development settings
-docker-compose -f docker-compose.dev.yml up -d
+# Run with the example compose file
+cp docker-compose.yml.example docker-compose.yml
+docker-compose up -d
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -593,6 +593,22 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 - **GitHub Issues**: [https://github.com/sbcrumb/chronarr/issues](https://github.com/sbcrumb/chronarr/issues)
 
+## Upgrading from v2 to v3
+
+v3 is a drop-in upgrade for single-instance setups. Pull the new image and restart — no config changes are required.
+
+**What you'll notice immediately:**
+- The horizontal tab bar is replaced by a collapsible sidebar. Dashboard, Movies, TV Shows, Reports, and Tools are all still there.
+- The "Admin" tab is now **Tools** in the sidebar.
+
+**Webhooks:** The old `/webhook/radarr` and `/webhook/sonarr` URLs still work — they're kept as aliases. The new canonical format is `/radarr/webhook` and `/sonarr/webhook`, and you can update your Radarr/Sonarr connections at any time, but there's no urgency.
+
+**Database:** Schema migrations run automatically on startup. Existing movie and episode records are preserved and tagged with the default instance name (`radarr` / `sonarr`).
+
+**Multi-instance (optional):** If you run a second Radarr (e.g., 4K) or second Sonarr, see the [Multi-Instance Configuration](#multi-instance-configuration-v30) block in the Configuration section. Each extra instance just needs a `RADARR_{NAME}_URL` block in your `.env` and its own webhook connection in Radarr/Sonarr.
+
+---
+
 ## Changelog
 
 ### v3.0.0

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Chronarr tracks and manages "dateadded" timestamps for all your movies and TV ep
 - **Direct Database Access** - Required for Radarr, optional for Sonarr (PostgreSQL & SQLite support)
 - **API Integration** - Sonarr API support for metadata and series lookups
 - **Webhook Support** - Real-time updates on import, upgrade, and rename events
-- **Bulk Import** - One-click population of entire Radarr/Sonarr libraries
+- **Multi-Instance Support** - Run multiple Radarr instances (e.g., standard + 4K) and/or multiple Sonarr instances, each tracked independently with per-instance badges and filtering
+- **Bulk Import** - One-click population of entire Radarr/Sonarr libraries across all instances
 - **Path Mapping** - Intelligent path translation for Docker/remote setups
 
 ### **Jellyfin Plugin**
@@ -206,7 +207,7 @@ open http://your-server:8081
 ```
 
 Then in the web interface:
-1. Click **Admin** tab
+1. Open the sidebar and click **Tools**
 2. Click **Populate Database**
 3. Select **Movies** and/or **TV Shows**
 4. Click **Start Population**
@@ -335,11 +336,39 @@ SONARR_DB_PASSWORD=sonarr_pass       # Sonarr database password (.env.secrets)
 # See docker-compose.yml.example for volume mount configuration
 ```
 
+**Multi-Instance Configuration (v3.0+):**
+
+Add additional Radarr or Sonarr instances using a `NAME` segment between the prefix and the variable suffix. The name becomes the instance identifier in Chronarr's UI and database.
+
+```bash
+# Second Radarr instance (e.g., 4K library)
+RADARR_4K_URL=http://radarr-4k:7878
+RADARR_4K_API_KEY=your_4k_api_key   # (.env.secrets)
+RADARR_4K_DB_TYPE=postgresql
+RADARR_4K_DB_HOST=radarr-4k-db
+RADARR_4K_DB_NAME=radarr-main
+RADARR_4K_DB_USER=radarr
+RADARR_4K_DB_PASSWORD=radarr_4k_pass  # (.env.secrets)
+
+# Second Sonarr instance (e.g., anime library)
+SONARR_ANIME_URL=http://sonarr-anime:8989
+SONARR_ANIME_API_KEY=your_anime_key  # (.env.secrets)
+SONARR_ANIME_DB_TYPE=postgresql
+SONARR_ANIME_DB_HOST=sonarr-anime-db
+SONARR_ANIME_DB_NAME=sonarr-main
+SONARR_ANIME_DB_USER=sonarr
+SONARR_ANIME_DB_PASSWORD=sonarr_anime_pass  # (.env.secrets)
+```
+
+Each named instance gets its own webhook endpoint (`/radarr_4k/webhook`, `/sonarr_anime/webhook`) and appears as a separate entry in the sidebar. An "All" view aggregates across all instances with colored instance badges on each row.
+
 **SQLite Docker Configuration:**
 
 When using SQLite databases with Docker, you must mount the database directories as read-only volumes. See the Quick Start guide (step 3) or check `docker-compose.yml.example` for detailed examples.
 
 ## Web Interface
+
+The web interface uses a dark sidebar for navigation. Sections expand to show per-instance sub-items; clicking an instance filters the view to that instance only. An "All" sub-item shows the full library with colored instance badges on each row.
 
 ### Dashboard
 - **Statistics** - Total movies, episodes, dates populated, missing dates
@@ -347,23 +376,25 @@ When using SQLite databases with Docker, you must mount the database directories
 - **Recent Activity** - Last 7 days of processing history
 - **Skipped Items** - Items without valid dates
 
-### Movies Tab
+### Movies
 - **Search & Filter** - By title, path, IMDb ID, date status, source
+- **Instance Filter** - Click an instance in the sidebar or view all with badges
 - **Bulk Actions** - Delete, edit dates, update IMDb IDs
 - **Smart Sorting** - By date added, release date, title
 - **Debug Tools** - Raw database inspection for troubleshooting
 
-### TV Shows Tab
+### TV Shows
 - **Series Management** - View all series with episode counts and progress
 - **Episode Browsing** - Detailed episode lists with dates and sources
 - **Season Filtering** - Filter episodes by season
+- **Delete Series** - Remove an entire series and all its episode records
+- **Instance Filter** - Click an instance in the sidebar or view all with badges
 - **Batch Updates** - Update multiple episodes at once
 
-### Admin Tab
-- **Database Population** - One-click import from Radarr/Sonarr
+### Tools
+- **Database Population** - One-click import from Radarr/Sonarr across all instances
 - **Progress Tracking** - Real-time progress bars and statistics
 - **Validation** - Pre-population checks for connectivity and permissions
-- **Manual Scans** - Trigger ad-hoc scans (future feature)
 
 ## API Endpoints
 
@@ -376,7 +407,8 @@ When using SQLite databases with Docker, you must mount the database directories
 - `POST /api/movies/{imdb_id}/migrate-imdb` - Migrate placeholder IMDb ID to real ID
 
 ### TV Shows
-- `GET /api/series` - List all series with episode counts
+- `GET /api/series` - List all series with episode counts (`?instance=sonarr` to filter)
+- `DELETE /api/series/{imdb_id}` - Delete an entire series and all its episodes (`?instance=sonarr`)
 - `GET /api/series/{imdb_id}/episodes` - Get episodes for series
 - `GET /api/episodes/{imdb_id}/{season}/{episode}` - Get specific episode
 - `PUT /api/episodes/{imdb_id}/{season}/{episode}` - Update episode date
@@ -384,29 +416,35 @@ When using SQLite databases with Docker, you must mount the database directories
 - `POST /api/series/{imdb_id}/migrate-imdb` - Migrate series IMDb ID
 
 ### Administration
-- `POST /admin/populate-database` - Trigger database population
+- `POST /admin/populate-database` - Trigger database population across all configured instances
 - `GET /api/dashboard` - Get dashboard statistics
 - `GET /health` - Health check endpoint
 
 ## Webhook Configuration
+
+Each Radarr/Sonarr instance gets its own webhook endpoint. The URL path matches the instance name derived from the environment variable: `RADARR_URL` → `/radarr/webhook`, `RADARR_4K_URL` → `/radarr_4k/webhook`.
 
 ### Radarr
 1. Go to **Settings → Connect**
 2. Add **Webhook** connection
 3. Configure:
    - **Name**: Chronarr
-   - **URL**: `http://chronarr-core:8080/webhook/radarr`
+   - **URL**: `http://chronarr-core:8080/radarr/webhook` (default instance)
    - **Triggers**: On Import, On Upgrade, On Rename
    - **Tags**: (optional, leave blank for all movies)
+
+For a second instance (e.g., `RADARR_4K_URL`), use `http://chronarr-core:8080/radarr_4k/webhook`.
 
 ### Sonarr
 1. Go to **Settings → Connect**
 2. Add **Webhook** connection
 3. Configure:
    - **Name**: Chronarr
-   - **URL**: `http://chronarr-core:8080/webhook/sonarr`
+   - **URL**: `http://chronarr-core:8080/sonarr/webhook` (default instance)
    - **Triggers**: On Import, On Upgrade, On Rename, On Episode File Delete
    - **Tags**: (optional, leave blank for all series)
+
+For a second instance (e.g., `SONARR_ANIME_URL`), use `http://chronarr-core:8080/sonarr_anime/webhook`.
 
 ## Jellyfin Integration
 
@@ -529,11 +567,11 @@ A: Yes, Chronarr can read from both SQLite and PostgreSQL databases for both Rad
 
 Chronarr's core application does not collect personal data. It reads only from your local Radarr and Sonarr databases and stores date information in your own PostgreSQL instance.
 
-The **Emby plugin** collects the following information during license registration:
+The **Emby and Jellyfin plugins** collect the following information during license registration:
 
 - **Name** — used to identify your license
 - **Email address** — used to deliver your license key and send license status notifications
-- **Server name** — used to associate a license with a specific Emby installation
+- **Server name** — used to associate a license with a specific media server installation
 
 This data is transmitted to the Chronarr license server and is used solely for license management. It is never sold, shared with third parties, or used for any purpose other than validating and managing your license.
 
@@ -555,6 +593,15 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - **GitHub Issues**: [https://github.com/sbcrumb/chronarr/issues](https://github.com/sbcrumb/chronarr/issues)
 
 ## Changelog
+
+### v3.0.0
+- 🏠 **Sidebar navigation** - Replaced horizontal tab bar with a collapsible dark sidebar; instance sub-items expand under Movies and TV Shows
+- 🔀 **Multi-instance support** - Configure multiple Radarr and/or Sonarr instances; each is tracked separately and shown with colored badges in the UI
+- 🏷️ **Instance badges** - Every row in the Movies and TV tables shows a colored badge identifying its instance; badge colors are consistent between the sidebar and the table
+- 🚀 **Cold-start populate fix** - Database population on startup now iterates all configured instances, not just the first
+- 🗑️ **Delete series** - Remove an entire TV series and all its episode records from the database in one click
+- 🔧 **Instance-aware edit** - Date edits, smart fixes, and skipped-item updates are now scoped to the correct instance
+- 🧹 **Series title cleanup** - Series titles derived from folder paths no longer include media-manager ID suffixes (e.g., `[imdb-tt1234567]`)
 
 ### v2.0.0 (2025-11-05)
 - 🎉 **Initial release** - Comprehensive date and chronology management for Radarr and Sonarr

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -389,8 +389,8 @@ async def get_series_episodes(dependencies: dict, imdb_id: str):
         
         # Get episodes - PostgreSQL
         cursor.execute("""
-            SELECT season, episode, aired, dateadded, source, has_video_file, last_updated
-            FROM episodes 
+            SELECT season, episode, instance, aired, dateadded, source, has_video_file, last_updated
+            FROM episodes
             WHERE imdb_id = %s
             ORDER BY season, episode
         """, (imdb_id,))
@@ -417,8 +417,8 @@ async def get_missing_dates_report(dependencies: dict):
         
         # Movies without dates - PostgreSQL
         cursor.execute("""
-            SELECT imdb_id, path, released, source, last_updated
-            FROM movies 
+            SELECT imdb_id, instance, path, released, source, last_updated
+            FROM movies
             WHERE dateadded IS NULL OR source = 'no_valid_date_source'
             ORDER BY last_updated DESC
         """)
@@ -435,9 +435,9 @@ async def get_missing_dates_report(dependencies: dict):
         
         # Episodes without dates - PostgreSQL
         cursor.execute("""
-            SELECT e.imdb_id, e.season, e.episode, e.aired, e.source, e.last_updated, s.path
+            SELECT e.imdb_id, e.instance, e.season, e.episode, e.aired, e.source, e.last_updated, s.path
             FROM episodes e
-            JOIN series s ON e.imdb_id = s.imdb_id
+            JOIN series s ON e.imdb_id = s.imdb_id AND s.instance = e.instance
             WHERE e.dateadded IS NULL OR e.source = 'no_valid_date_source'
             ORDER BY e.last_updated DESC
         """)
@@ -572,7 +572,7 @@ async def get_dashboard_stats(dependencies: dict):
 # Database Modification Endpoints
 # ---------------------------
 
-async def update_movie_date(dependencies: dict, imdb_id: str, dateadded: Optional[str], source: str):
+async def update_movie_date(dependencies: dict, imdb_id: str, dateadded: Optional[str], source: str, instance: str = 'radarr'):
     """Update dateadded for a specific movie"""
     db = dependencies["db"]
     
@@ -600,26 +600,27 @@ async def update_movie_date(dependencies: dict, imdb_id: str, dateadded: Optiona
             raise HTTPException(status_code=422, detail=f"Invalid date format: {dateadded}")
     
     # Validate movie exists
-    movie = db.get_movie_dates(imdb_id)
+    movie = db.get_movie_dates(imdb_id, instance)
     if not movie:
         raise HTTPException(status_code=404, detail="Movie not found")
-    
+
     # Update the date
     db.upsert_movie_dates(
         imdb_id=imdb_id,
         released=movie.get('released'),
         dateadded=dateadded,
         source=source,
-        has_video_file=movie.get('has_video_file', False)
+        has_video_file=movie.get('has_video_file', False),
+        instance=instance
     )
-    
+
     # Add to processing history
     try:
         db.add_processing_history(
             imdb_id=imdb_id,
             media_type="movie",
             event_type="manual_date_update",
-            details={"old_source": movie.get('source'), "new_source": source, "dateadded": dateadded}
+            details={"old_source": movie.get('source'), "new_source": source, "dateadded": dateadded, "instance": instance}
         )
     except Exception as e:
         print(f"⚠️ Failed to add processing history: {e}")
@@ -629,15 +630,15 @@ async def update_movie_date(dependencies: dict, imdb_id: str, dateadded: Optiona
     return {"status": "success", "message": f"Updated movie {imdb_id}"}
 
 
-async def update_episode_date(dependencies: dict, imdb_id: str, season: int, episode: int, 
-                            dateadded: Optional[str], source: str):
+async def update_episode_date(dependencies: dict, imdb_id: str, season: int, episode: int,
+                            dateadded: Optional[str], source: str, instance: str = 'sonarr'):
     """Update dateadded for a specific episode"""
     db = dependencies["db"]
     
     _log("DEBUG", f"update_episode_date called with dateadded={repr(dateadded)}, source={repr(source)}")
     
     # Get existing episode
-    episode_data = db.get_episode_date(imdb_id, season, episode)
+    episode_data = db.get_episode_date(imdb_id, season, episode, instance)
     if not episode_data:
         raise HTTPException(status_code=404, detail="Episode not found")
     
@@ -661,7 +662,8 @@ async def update_episode_date(dependencies: dict, imdb_id: str, season: int, epi
         aired=episode_data.get('aired'),
         dateadded=dateadded,
         source=source,
-        has_video_file=episode_data.get('has_video_file', False)
+        has_video_file=episode_data.get('has_video_file', False),
+        instance=instance
     )
     
     # Trigger NFO file update via core container
@@ -772,12 +774,12 @@ async def bulk_update_source(dependencies: dict, media_type: str, old_source: st
     }
 
 
-async def get_movie_date_options(dependencies: dict, imdb_id: str):
+async def get_movie_date_options(dependencies: dict, imdb_id: str, instance: str = 'radarr'):
     """Get available date options for a movie (Radarr import, digital release, etc.)"""
     db = dependencies["db"]
 
     # Get current movie data
-    movie = db.get_movie_dates(imdb_id)
+    movie = db.get_movie_dates(imdb_id, instance)
     if not movie:
         raise HTTPException(status_code=404, detail="Movie not found")
     
@@ -948,9 +950,9 @@ async def get_movie_date_options(dependencies: dict, imdb_id: str):
     }
 
 
-async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int, episode: int):
+async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int, episode: int, instance: str = 'sonarr'):
     """Get available date options for an episode"""
-    _log("DEBUG", f"get_episode_date_options called with imdb_id={imdb_id}, season={season}, episode={episode}")
+    _log("DEBUG", f"get_episode_date_options called with imdb_id={imdb_id}, season={season}, episode={episode}, instance={instance}")
     db = dependencies["db"]
     
     # Validate parameters with enhanced checking
@@ -975,7 +977,7 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
         raise HTTPException(status_code=422, detail=f"Invalid parameter types: {e}")
     
     # Get current episode data
-    episode_data = db.get_episode_date(imdb_id, season, episode)
+    episode_data = db.get_episode_date(imdb_id, season, episode, instance)
     _log("DEBUG", f"Episode data from DB: {episode_data}")
     if not episode_data:
         print(f"❌ Episode not found in database: {imdb_id} S{season:02d}E{episode:02d}")
@@ -1506,20 +1508,22 @@ def register_web_routes(app, dependencies):
             data = await request.json()
             dateadded = data.get('dateadded')
             source = data.get('source', 'manual')
+            instance = data.get('instance', 'radarr')
 
             _log("DEBUG", f"API PUT /api/movies/{imdb_id} - Received JSON:")
             print(f"   - Raw data: {data}")
             print(f"   - dateadded: {dateadded}")
             print(f"   - source: {source}")
+            print(f"   - instance: {instance}")
 
-            return await update_movie_date(dependencies, imdb_id, dateadded, source)
+            return await update_movie_date(dependencies, imdb_id, dateadded, source, instance)
         except Exception as e:
             print(f"❌ Error parsing request body: {e}")
             raise HTTPException(status_code=400, detail=f"Invalid request body: {str(e)}")
     
     @app.get("/api/movies/{imdb_id}/date-options")
-    async def api_movie_date_options(imdb_id: str):
-        return await get_movie_date_options(dependencies, imdb_id)
+    async def api_movie_date_options(imdb_id: str, instance: str = 'radarr'):
+        return await get_movie_date_options(dependencies, imdb_id, instance)
 
     @app.get("/api/debug/movie/{imdb_id}/raw")
     async def api_debug_movie_raw(imdb_id: str):
@@ -1670,14 +1674,15 @@ def register_web_routes(app, dependencies):
             data = await request.json()
             dateadded = data.get('dateadded')
             source = data.get('source', 'manual')
-            return await update_episode_date(dependencies, imdb_id, season, episode, dateadded, source)
+            instance = data.get('instance', 'sonarr')
+            return await update_episode_date(dependencies, imdb_id, season, episode, dateadded, source, instance)
         except Exception as e:
             print(f"❌ Error parsing episode update request: {e}")
             raise HTTPException(status_code=400, detail=f"Invalid request format: {str(e)}")
     
     @app.get("/api/episodes/{imdb_id}/{season}/{episode}/date-options")
-    async def api_episode_date_options(imdb_id: str, season: int, episode: int):
-        return await get_episode_date_options(dependencies, imdb_id, season, episode)
+    async def api_episode_date_options(imdb_id: str, season: int, episode: int, instance: str = 'sonarr'):
+        return await get_episode_date_options(dependencies, imdb_id, season, episode, instance)
     
     @app.delete("/api/episodes/{imdb_id}/{season}/{episode}")
     async def api_delete_episode(imdb_id: str, season: int, episode: int):

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -1669,6 +1669,32 @@ def register_web_routes(app, dependencies):
             print(f"❌ Error migrating series IMDb ID: {e}")
             raise HTTPException(status_code=500, detail=f"Failed to migrate IMDb ID: {str(e)}")
 
+    @app.delete("/api/series/{imdb_id}")
+    async def api_delete_series(imdb_id: str, instance: str = 'sonarr'):
+        """Delete a series and all its episodes from the database"""
+        db = dependencies["db"]
+
+        try:
+            episodes_deleted = db.delete_series_episodes(imdb_id, instance)
+            series_deleted = db.delete_series(imdb_id, instance)
+
+            if series_deleted or episodes_deleted > 0:
+                return {
+                    "success": True,
+                    "status": "success",
+                    "message": f"Deleted series {imdb_id} and {episodes_deleted} episode(s)",
+                    "imdb_id": imdb_id,
+                    "episodes_deleted": episodes_deleted
+                }
+            else:
+                raise HTTPException(status_code=404, detail="Series not found")
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            print(f"❌ Error deleting series: {e}")
+            raise HTTPException(status_code=500, detail=f"Failed to delete series: {str(e)}")
+
     # Episode endpoints
     @app.post("/api/episodes/{imdb_id}/{season}/{episode}/update-date")
     async def api_update_episode_date(imdb_id: str, season: int, episode: int, 

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -4,6 +4,7 @@ Provides endpoints for the web-based database manipulation interface
 """
 import json
 import os
+import re
 import tempfile
 import multiprocessing
 from datetime import datetime, timezone
@@ -13,6 +14,13 @@ from pathlib import Path
 
 from api.models import *
 from utils.logging import _log
+
+# Strip [imdb-tt...] or [tmdb-...] suffixes that media managers append to folder names
+_FOLDER_ID_SUFFIX = re.compile(r'\s*\[[a-z]+-[^\]]+\]', re.IGNORECASE)
+
+def _clean_folder_title(raw: str) -> str:
+    """Remove media-manager ID suffixes from a folder name used as a display title."""
+    return _FOLDER_ID_SUFFIX.sub('', raw).strip()
 
 
 # Status file for cross-process communication
@@ -275,7 +283,7 @@ async def get_tv_series_list(dependencies: dict,
             series_data = dict(row)
             # Extract title from path
             try:
-                series_data['title'] = Path(series_data['path']).name if series_data['path'] else series_data['imdb_id']
+                series_data['title'] = _clean_folder_title(Path(series_data['path']).name) if series_data['path'] else series_data['imdb_id']
             except:
                 series_data['title'] = series_data['imdb_id']
             series.append(series_data)
@@ -383,7 +391,7 @@ async def get_series_episodes(dependencies: dict, imdb_id: str):
         
         series_info = dict(series_row)
         try:
-            series_info['title'] = Path(series_info['path']).name if series_info['path'] else imdb_id
+            series_info['title'] = _clean_folder_title(Path(series_info['path']).name) if series_info['path'] else imdb_id
         except:
             series_info['title'] = imdb_id
         
@@ -445,7 +453,7 @@ async def get_missing_dates_report(dependencies: dict):
         for row in cursor.fetchall():
             episode = dict(row)
             try:
-                episode['series_title'] = Path(episode['path']).name if episode['path'] else episode['imdb_id']
+                episode['series_title'] = _clean_folder_title(Path(episode['path']).name) if episode['path'] else episode['imdb_id']
             except:
                 episode['series_title'] = episode['imdb_id']
             # Map source to user-friendly description

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -1333,47 +1333,72 @@ def _populate_worker_process(media_type: str, status_file: str):
         # Import here (inside process) to avoid pickling issues
         from core.database import ChronarrDatabase
         from core.database_populator import DatabasePopulator
-        from clients.radarr_client import RadarrClient
-        from clients.sonarr_client import SonarrClient
         from config.settings import config
 
-        # Initialize components
         db = ChronarrDatabase(config)
-        radarr_client = RadarrClient(
-            os.environ.get("RADARR_URL", ""),
-            os.environ.get("RADARR_API_KEY", "")
-        )
-        sonarr_client = SonarrClient(
-            os.environ.get("SONARR_URL", ""),
-            os.environ.get("SONARR_API_KEY", "")
-        )
 
-        populator = DatabasePopulator(db, radarr_client, sonarr_client)
+        def _merge_movie_stats(all_stats):
+            merged = {'total': 0, 'added': 0, 'updated': 0, 'skipped': 0, 'errors': 0,
+                      'duration': 0.0, 'skipped_items': []}
+            for inst_name, s in all_stats:
+                for k in ('total', 'added', 'updated', 'skipped', 'errors'):
+                    merged[k] += s.get(k, 0)
+                merged['duration'] += s.get('duration', 0.0)
+                merged['skipped_items'].extend(s.get('skipped_items', []))
+            return merged
+
+        def _merge_tv_stats(all_stats):
+            merged = {'total_series': 0, 'total_episodes': 0, 'added': 0, 'updated': 0,
+                      'skipped': 0, 'errors': 0, 'duration': 0.0, 'skipped_items': []}
+            for inst_name, s in all_stats:
+                for k in ('total_series', 'total_episodes', 'added', 'updated', 'skipped', 'errors'):
+                    merged[k] += s.get(k, 0)
+                merged['duration'] += s.get('duration', 0.0)
+                merged['skipped_items'].extend(s.get('skipped_items', []))
+            return merged
 
         print(f"INFO: [Worker Process] Starting database population: {media_type}")
+        radarr_instances = config.radarr_instances
+        sonarr_instances = config.sonarr_instances
+        print(f"INFO: [Worker Process] Radarr instances: {[i.name for i in radarr_instances]}")
+        print(f"INFO: [Worker Process] Sonarr instances: {[i.name for i in sonarr_instances]}")
 
         # Run population based on media type
         if media_type in ["movies", "both"]:
-            status["movies"]["status"] = "running"
-            update_status(status)
+            all_movie_stats = []
+            for inst in radarr_instances:
+                status["movies"]["status"] = f"running ({inst.name})"
+                update_status(status)
+                print(f"INFO: [Worker Process] Populating movies for instance '{inst.name}'")
 
-            movie_stats = populator.populate_movies()
+                pop = DatabasePopulator.from_radarr_instance(inst, db)
+                inst_stats = pop.populate_movies(instance=inst.name)
+                all_movie_stats.append((inst.name, inst_stats))
+                print(f"INFO: [Worker Process] Movies done for '{inst.name}': {inst_stats}")
 
+            movie_stats = _merge_movie_stats(all_movie_stats)
             status["movies"]["status"] = "completed"
             status["movies"]["stats"] = movie_stats
             update_status(status)
-            print(f"INFO: [Worker Process] Movie population completed: {movie_stats}")
+            print(f"INFO: [Worker Process] All movie population complete: {movie_stats}")
 
         if media_type in ["tv", "both"]:
-            status["tv"]["status"] = "running"
-            update_status(status)
+            all_tv_stats = []
+            for inst in sonarr_instances:
+                status["tv"]["status"] = f"running ({inst.name})"
+                update_status(status)
+                print(f"INFO: [Worker Process] Populating TV for instance '{inst.name}'")
 
-            tv_stats = populator.populate_tv_episodes()
+                pop = DatabasePopulator.from_sonarr_instance(inst, db)
+                inst_stats = pop.populate_tv_episodes(instance=inst.name)
+                all_tv_stats.append((inst.name, inst_stats))
+                print(f"INFO: [Worker Process] TV done for '{inst.name}': {inst_stats}")
 
+            tv_stats = _merge_tv_stats(all_tv_stats)
             status["tv"]["status"] = "completed"
             status["tv"]["stats"] = tv_stats
             update_status(status)
-            print(f"INFO: [Worker Process] TV population completed: {tv_stats}")
+            print(f"INFO: [Worker Process] All TV population complete: {tv_stats}")
 
         # Mark as completed
         status["completed"] = True

--- a/core/database_populator.py
+++ b/core/database_populator.py
@@ -23,7 +23,16 @@ from utils.imdb_utils import parse_imdb_from_path
 class DatabasePopulator:
     """Populates Chronarr database from Radarr/Sonarr sources"""
 
-    def __init__(self, db: ChronarrDatabase, radarr_client: RadarrClient = None, sonarr_client: SonarrClient = None):
+    def __init__(self, db: ChronarrDatabase, radarr_client: RadarrClient = None,
+                 sonarr_client: SonarrClient = None,
+                 _radarr_db_override=None, _sonarr_db_override=None):
+        """
+        Build a DatabasePopulator.
+
+        Normal callers pass nothing (uses env vars) or pass API client fallbacks.
+        Per-instance constructors use _radarr_db_override / _sonarr_db_override to
+        inject a pre-built DB or API client directly, bypassing from_env() discovery.
+        """
         self.db = db
 
         # Try database clients first, fall back to API clients
@@ -35,38 +44,110 @@ class DatabasePopulator:
         self.using_sonarr_db = False
 
         # Radarr setup
-        try:
-            self.radarr_db = RadarrDbClient.from_env()
-            if self.radarr_db:
-                _log("INFO", "DatabasePopulator: Using Radarr direct database access")
-                self.radarr = self.radarr_db
+        if _radarr_db_override is not None:
+            # Pre-built client from from_radarr_instance() — skip env discovery
+            if isinstance(_radarr_db_override, RadarrDbClient):
+                self.radarr_db = _radarr_db_override
+                self.radarr = _radarr_db_override
                 self.using_radarr_db = True
+                _log("INFO", "DatabasePopulator: Using pre-built Radarr DB client")
             else:
-                raise Exception("Database not configured")
-        except Exception:
-            self.radarr_api = radarr_client if radarr_client else RadarrClient(
-                os.environ.get("RADARR_URL", ""),
-                os.environ.get("RADARR_API_KEY", "")
-            )
-            self.radarr = self.radarr_api
-            _log("INFO", "DatabasePopulator: Using Radarr API client")
+                self.radarr_api = _radarr_db_override
+                self.radarr = _radarr_db_override
+                _log("INFO", "DatabasePopulator: Using pre-built Radarr API client")
+        else:
+            try:
+                self.radarr_db = RadarrDbClient.from_env()
+                if self.radarr_db:
+                    _log("INFO", "DatabasePopulator: Using Radarr direct database access")
+                    self.radarr = self.radarr_db
+                    self.using_radarr_db = True
+                else:
+                    raise Exception("Database not configured")
+            except Exception:
+                self.radarr_api = radarr_client if radarr_client else RadarrClient(
+                    os.environ.get("RADARR_URL", ""),
+                    os.environ.get("RADARR_API_KEY", "")
+                )
+                self.radarr = self.radarr_api
+                _log("INFO", "DatabasePopulator: Using Radarr API client")
 
         # Sonarr setup
-        try:
-            self.sonarr_db = SonarrDbClient.from_env()
-            if self.sonarr_db:
-                _log("INFO", "DatabasePopulator: Using Sonarr direct database access")
-                self.sonarr = self.sonarr_db
+        if _sonarr_db_override is not None:
+            # Pre-built client from from_sonarr_instance() — skip env discovery
+            if isinstance(_sonarr_db_override, SonarrDbClient):
+                self.sonarr_db = _sonarr_db_override
+                self.sonarr = _sonarr_db_override
                 self.using_sonarr_db = True
+                _log("INFO", "DatabasePopulator: Using pre-built Sonarr DB client")
             else:
-                raise Exception("Database not configured")
-        except Exception:
-            self.sonarr_api = sonarr_client if sonarr_client else SonarrClient(
-                os.environ.get("SONARR_URL", ""),
-                os.environ.get("SONARR_API_KEY", "")
-            )
-            self.sonarr = self.sonarr_api
-            _log("INFO", "DatabasePopulator: Using Sonarr API client")
+                self.sonarr_api = _sonarr_db_override
+                self.sonarr = _sonarr_db_override
+                _log("INFO", "DatabasePopulator: Using pre-built Sonarr API client")
+        else:
+            try:
+                self.sonarr_db = SonarrDbClient.from_env()
+                if self.sonarr_db:
+                    _log("INFO", "DatabasePopulator: Using Sonarr direct database access")
+                    self.sonarr = self.sonarr_db
+                    self.using_sonarr_db = True
+                else:
+                    raise Exception("Database not configured")
+            except Exception:
+                self.sonarr_api = sonarr_client if sonarr_client else SonarrClient(
+                    os.environ.get("SONARR_URL", ""),
+                    os.environ.get("SONARR_API_KEY", "")
+                )
+                self.sonarr = self.sonarr_api
+                _log("INFO", "DatabasePopulator: Using Sonarr API client")
+
+    @classmethod
+    def from_radarr_instance(cls, inst, db: ChronarrDatabase) -> 'DatabasePopulator':
+        """Build a populator wired to one specific RadarrInstance.
+
+        Tries direct DB access using the instance's db_type/db_path/host config;
+        falls back to the HTTP API client if DB access isn't configured or fails.
+        """
+        client = None
+        if inst.db_type:
+            try:
+                client = RadarrDbClient(
+                    db_type=inst.db_type,
+                    db_path=inst.db_path or None,
+                    db_host=inst.db_host or None,
+                    db_port=inst.db_port or None,
+                    db_name=inst.db_name or None,
+                    db_user=inst.db_user or None,
+                    db_password=inst.db_password or None,
+                )
+                _log("INFO", f"DatabasePopulator: DB access configured for Radarr instance '{inst.name}'")
+            except Exception as e:
+                _log("WARNING", f"DatabasePopulator: DB access failed for Radarr '{inst.name}', falling back to API: {e}")
+        if client is None:
+            client = RadarrClient(inst.url, inst.api_key)
+        return cls(db, _radarr_db_override=client)
+
+    @classmethod
+    def from_sonarr_instance(cls, inst, db: ChronarrDatabase) -> 'DatabasePopulator':
+        """Build a populator wired to one specific SonarrInstance."""
+        client = None
+        if inst.db_type:
+            try:
+                client = SonarrDbClient(
+                    db_type=inst.db_type,
+                    db_path=inst.db_path or None,
+                    db_host=inst.db_host or None,
+                    db_port=inst.db_port or None,
+                    db_name=inst.db_name or None,
+                    db_user=inst.db_user or None,
+                    db_password=inst.db_password or None,
+                )
+                _log("INFO", f"DatabasePopulator: DB access configured for Sonarr instance '{inst.name}'")
+            except Exception as e:
+                _log("WARNING", f"DatabasePopulator: DB access failed for Sonarr '{inst.name}', falling back to API: {e}")
+        if client is None:
+            client = SonarrClient(inst.url, inst.api_key)
+        return cls(db, _sonarr_db_override=client)
 
     def get_episode_import_history(self, episode_id: int) -> Optional[str]:
         """
@@ -83,9 +164,12 @@ class DatabasePopulator:
         else:
             return None
 
-    def populate_movies(self) -> Dict[str, any]:
+    def populate_movies(self, instance: str = 'radarr') -> Dict[str, any]:
         """
-        Populate movies from Radarr database/API
+        Populate movies from Radarr database/API.
+
+        Args:
+            instance: Instance name to tag records with (e.g. 'radarr', 'radarr_4k').
 
         Returns:
             Dictionary with statistics: {
@@ -97,7 +181,7 @@ class DatabasePopulator:
                 'duration': float
             }
         """
-        _log("INFO", "Starting movie population from Radarr")
+        _log("INFO", f"Starting movie population from Radarr instance '{instance}'")
         start_time = time.time()
 
         stats = {
@@ -164,13 +248,14 @@ class DatabasePopulator:
                             title=movie.get('title', 'Unknown'),
                             year=movie.get('year', 0),
                             path=path,
-                            reason=skip_reason
+                            reason=skip_reason,
+                            instance=instance,
                         )
                         stats['skipped'] += 1
                         continue
 
                     # Check if movie already exists in database
-                    existing = self.db.get_movie_dates(imdb_id)
+                    existing = self.db.get_movie_dates(imdb_id, instance=instance)
                     if existing and existing.get('dateadded'):
                         # Already in database - update file path and video status if needed
                         existing_path = existing.get('path')
@@ -242,7 +327,8 @@ class DatabasePopulator:
                                 title=movie.get('title', 'Unknown'),
                                 year=movie.get('year', 0),
                                 path=path or 'unknown',
-                                reason=skip_reason
+                                reason=skip_reason,
+                                instance=instance,
                             )
                             stats['skipped'] += 1
                             continue
@@ -267,7 +353,8 @@ class DatabasePopulator:
                             title=movie.get('title', 'Unknown'),
                             year=movie.get('year', 0),
                             path=path or 'unknown',
-                            reason=skip_reason
+                            reason=skip_reason,
+                            instance=instance,
                         )
                         stats['skipped'] += 1
                         continue
@@ -277,7 +364,8 @@ class DatabasePopulator:
                     year = movie.get('year')
                     self.db.upsert_movie_dates(
                         imdb_id, released, dateadded, source,
-                        has_video_file=True, title=title, year=year
+                        has_video_file=True, title=title, year=year,
+                        instance=instance,
                     )
 
                     # Add to processing history
@@ -314,9 +402,12 @@ class DatabasePopulator:
 
         return stats
 
-    def populate_tv_episodes(self) -> Dict[str, any]:
+    def populate_tv_episodes(self, instance: str = 'sonarr') -> Dict[str, any]:
         """
-        Populate TV episodes from Sonarr API
+        Populate TV episodes from Sonarr database/API.
+
+        Args:
+            instance: Instance name to tag records with (e.g. 'sonarr', 'sonarr_4k').
 
         Returns:
             Dictionary with statistics: {
@@ -375,7 +466,7 @@ class DatabasePopulator:
                         _log("DEBUG", f"Series without IMDb ID: {series_title} (path: {series_path}), using placeholder {imdb_id}")
 
                     # Update series record
-                    self.db.upsert_series(imdb_id, series_path)
+                    self.db.upsert_series(imdb_id, series_path, instance=instance)
 
                     # Try high-performance database bulk query first
                     bulk_import_dates = {}
@@ -412,7 +503,7 @@ class DatabasePopulator:
                             stats['total_episodes'] += 1
 
                             # Check if episode already exists
-                            existing = self.db.get_episode_date(imdb_id, season_num, episode_num)
+                            existing = self.db.get_episode_date(imdb_id, season_num, episode_num, instance=instance)
                             if existing and existing.get('dateadded'):
                                 # Already in database - update file path and video status if needed
                                 existing_path = existing.get('path')
@@ -495,13 +586,14 @@ class DatabasePopulator:
                                     imdb_id=imdb_id,
                                     season=season_num,
                                     episode=episode_num,
-                                    reason=skip_reason
+                                    reason=skip_reason,
+                                    instance=instance,
                                 )
                                 stats['skipped'] += 1
                                 continue
 
                             # Insert into database
-                            self.db.upsert_episode_date(imdb_id, season_num, episode_num, aired, dateadded, source, has_file)
+                            self.db.upsert_episode_date(imdb_id, season_num, episode_num, aired, dateadded, source, has_file, instance=instance)
 
                             # Add to processing history
                             try:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -158,7 +158,7 @@ networks:
 # 4. Access Web Interface:
 #    http://your-server:8081
 #
-#    Then click Admin → Populate Database
+#    Then open the sidebar → Tools → Populate Database
 #
 # ========================================
 # Configuration Notes

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -30,120 +30,257 @@ body {
 .app-container {
     min-height: 100vh;
     display: flex;
+    flex-direction: row;
+    align-items: stretch;
+}
+
+/* Sidebar */
+.sidebar {
+    width: 220px;
+    min-width: 220px;
+    background: #1a1d23;
+    color: #8b95a1;
+    display: flex;
     flex-direction: column;
+    min-height: 100vh;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+    flex-shrink: 0;
 }
 
-/* Header */
-.app-header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
-    padding: 1rem 0;
-    box-shadow: var(--shadow-lg);
-    position: relative;
-}
-
-.header-content {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1rem;
-    text-align: center;
-}
-
-.header-content h1 {
-    font-size: 2rem;
-    font-weight: 300;
-    margin-bottom: 0.5rem;
-}
-
-.header-content h1 i {
-    margin-right: 0.5rem;
-}
-
-.header-content p {
-    opacity: 0.9;
-    font-size: 1rem;
-}
-
-/* Authentication Status */
-.auth-status {
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
+.sidebar-brand {
+    padding: 1.125rem 1rem;
     display: flex;
     align-items: center;
-    gap: 1rem;
-    color: white;
-    font-size: 0.9rem;
+    gap: 0.625rem;
+    color: #ffffff;
+    font-size: 1.1rem;
+    font-weight: 600;
+    border-bottom: 1px solid #2d3139;
+    text-decoration: none;
+}
+
+.sidebar-brand i {
+    color: #0096c7;
+    font-size: 1.2rem;
+}
+
+/* Auth block in sidebar */
+.sidebar-auth {
+    padding: 0.625rem 1rem;
+    border-bottom: 1px solid #2d3139;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    font-size: 0.8rem;
+    color: #8b95a1;
 }
 
 .auth-user {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    opacity: 0.9;
+    gap: 0.375rem;
+    opacity: 0.85;
 }
 
 .auth-logout {
-    background: rgba(255, 255, 255, 0.2);
-    color: white;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    padding: 0.5rem 1rem;
+    background: rgba(255, 255, 255, 0.08);
+    color: #8b95a1;
+    border: 1px solid #3a3f4a;
+    padding: 0.3rem 0.625rem;
     border-radius: 0.25rem;
     cursor: pointer;
-    font-size: 0.85rem;
+    font-size: 0.775rem;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.375rem;
     transition: all 0.2s ease;
+    width: fit-content;
 }
 
 .auth-logout:hover {
-    background: rgba(255, 255, 255, 0.3);
-    border-color: rgba(255, 255, 255, 0.5);
-    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.14);
+    color: #c9d1d9;
 }
 
-.nav-tabs {
-    max-width: 1200px;
-    margin: 1rem auto 0;
-    padding: 0 1rem;
+/* Sidebar nav */
+.sidebar-nav {
+    flex: 1;
+    padding: 0.5rem 0 1rem;
     display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-direction: column;
 }
 
-.nav-tab {
-    background: rgba(255, 255, 255, 0.1);
+.nav-section-label {
+    padding: 0.875rem 1rem 0.25rem;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #4a5260;
+}
+
+.sidebar-item {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    padding: 0.45rem 0.75rem;
+    margin: 0.1rem 0.5rem;
+    width: calc(100% - 1rem);
+    background: none;
     border: none;
-    color: white;
-    padding: 0.75rem 1.5rem;
-    border-radius: 0.5rem;
+    color: #8b95a1;
     cursor: pointer;
-    transition: all 0.3s ease;
-    font-size: 0.9rem;
+    font-size: 0.875rem;
+    text-align: left;
+    text-decoration: none;
+    border-radius: 0.375rem;
+    transition: background 0.15s, color 0.15s;
+    font-family: inherit;
+}
+
+.sidebar-item i {
+    width: 1.1rem;
+    text-align: center;
+    font-size: 0.85rem;
+    flex-shrink: 0;
+}
+
+.sidebar-item:hover {
+    background: #252930;
+    color: #c9d1d9;
+}
+
+.sidebar-item.active {
+    background: rgba(0, 150, 199, 0.14);
+    color: #0096c7;
+}
+
+/* Expandable group */
+.sidebar-group {
+    margin: 0.1rem 0;
+}
+
+.sidebar-group-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.45rem 0.75rem;
+    margin: 0 0.5rem;
+    width: calc(100% - 1rem);
+    background: none;
+    border: none;
+    color: #8b95a1;
+    cursor: pointer;
+    font-size: 0.875rem;
+    border-radius: 0.375rem;
+    transition: background 0.15s, color 0.15s;
+    font-family: inherit;
+}
+
+.sidebar-group-toggle:hover {
+    background: #252930;
+    color: #c9d1d9;
+}
+
+.toggle-content {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+}
+
+.toggle-content i {
+    width: 1.1rem;
+    text-align: center;
+    font-size: 0.85rem;
+}
+
+.toggle-chevron {
+    font-size: 0.65rem;
+    transition: transform 0.2s ease;
+    opacity: 0.5;
+}
+
+.sidebar-group-toggle[aria-expanded="true"] .toggle-chevron {
+    transform: rotate(180deg);
+}
+
+/* Sub-items (collapsed by default, expand via .expanded) */
+.sidebar-sub-items {
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.2s ease;
+}
+
+.sidebar-sub-items.expanded {
+    max-height: 400px;
+}
+
+.sidebar-sub-item {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    padding: 0.35rem 0.75rem 0.35rem 2.5rem;
+    width: 100%;
+    background: none;
+    border: none;
+    color: #626c7a;
+    cursor: pointer;
+    font-size: 0.825rem;
+    text-align: left;
+    transition: color 0.15s, background 0.15s;
+    font-family: inherit;
 }
 
-.nav-tab:hover {
-    background: rgba(255, 255, 255, 0.2);
-    transform: translateY(-1px);
+.sidebar-sub-item:hover {
+    color: #c9d1d9;
+    background: #202328;
 }
 
-.nav-tab.active {
-    background: rgba(255, 255, 255, 0.9);
-    color: var(--dark-color);
+.sidebar-sub-item.active {
+    color: #0096c7;
+}
+
+.instance-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    display: inline-block;
+}
+
+.sidebar-divider {
+    height: 1px;
+    background: #2d3139;
+    margin: 0.625rem 0.75rem;
+}
+
+/* Instance badge in table cells */
+.instance-badge {
+    padding: 0.2rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    border: 1px solid transparent;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+/* badge-primary (used in source type display) */
+.badge-primary {
+    background-color: #cfe2ff;
+    color: #084298;
 }
 
 /* Main Content */
 .main-content {
     flex: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
-    width: 100%;
+    padding: 1.75rem 2rem;
+    overflow-y: auto;
+    min-height: 100vh;
+    background: #f5f5f5;
 }
 
 .tab-content {
@@ -793,38 +930,61 @@ body {
 }
 
 /* Responsive */
-@media (max-width: 768px) {
+@media (max-width: 900px) {
+    .sidebar {
+        width: 180px;
+        min-width: 180px;
+    }
+}
+
+@media (max-width: 640px) {
+    .app-container {
+        flex-direction: column;
+    }
+
+    .sidebar {
+        width: 100%;
+        min-width: unset;
+        height: auto;
+        min-height: unset;
+        position: static;
+    }
+
+    .sidebar-sub-items.expanded {
+        max-height: 600px;
+    }
+
+    .main-content {
+        min-height: unset;
+        padding: 1rem;
+    }
+
     .content-header {
         flex-direction: column;
         align-items: stretch;
     }
-    
+
     .content-controls {
         justify-content: center;
     }
-    
+
     .search-box input {
         width: 200px;
     }
-    
-    .nav-tabs {
-        flex-direction: column;
-        gap: 0.25rem;
-    }
-    
+
     .data-table {
         font-size: 0.8rem;
     }
-    
+
     .data-table th,
     .data-table td {
         padding: 0.5rem 0.25rem;
     }
-    
+
     .dashboard-grid {
         grid-template-columns: 1fr;
     }
-    
+
     .tools-grid {
         grid-template-columns: 1fr;
     }

--- a/static/index.html
+++ b/static/index.html
@@ -462,6 +462,7 @@
                     <input type="hidden" id="edit-season">
                     <input type="hidden" id="edit-episode">
                     <input type="hidden" id="edit-media-type">
+                    <input type="hidden" id="edit-instance">
                     
                     <div class="form-group">
                         <label for="edit-dateadded">Date Added:</label>

--- a/static/index.html
+++ b/static/index.html
@@ -4,18 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Chronarr - Database Management</title>
-    <link rel="stylesheet" href="/static/css/styles.css?v=manual-scan-ui">
+    <link rel="stylesheet" href="/static/css/styles.css?v=sidebar-nav">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
 </head>
 <body>
     <div class="app-container">
-        <!-- Header -->
-        <header class="app-header">
-            <div class="header-content">
-                <h1><i class="fas fa-shield-alt"></i> Chronarr</h1>
-                <p>Database Management & Reporting</p>
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <div class="sidebar-brand">
+                <i class="fas fa-shield-alt"></i>
+                <span>Chronarr</span>
             </div>
-            <div class="auth-status" id="auth-status" style="display: none;">
+
+            <div class="sidebar-auth" id="auth-status" style="display: none;">
                 <span class="auth-user">
                     <i class="fas fa-user"></i> <span id="auth-username">Loading...</span>
                 </span>
@@ -23,27 +24,59 @@
                     <i class="fas fa-sign-out-alt"></i> Logout
                 </button>
             </div>
-            <nav class="nav-tabs">
-                <button class="nav-tab active" data-tab="dashboard">
+
+            <nav class="sidebar-nav">
+                <button class="sidebar-item active" data-tab="dashboard" onclick="switchTab('dashboard')">
                     <i class="fas fa-tachometer-alt"></i> Dashboard
                 </button>
-                <button class="nav-tab" data-tab="movies">
-                    <i class="fas fa-film"></i> Movies
-                </button>
-                <button class="nav-tab" data-tab="tv">
-                    <i class="fas fa-tv"></i> TV Series
-                </button>
-                <button class="nav-tab" data-tab="reports">
+
+                <div class="nav-section-label">LIBRARY</div>
+
+                <div class="sidebar-group">
+                    <button class="sidebar-group-toggle" aria-expanded="true" onclick="toggleSidebarGroup('movies-sub', 'movies')">
+                        <span class="toggle-content">
+                            <i class="fas fa-film"></i> Movies
+                        </span>
+                        <i class="fas fa-chevron-down toggle-chevron"></i>
+                    </button>
+                    <div class="sidebar-sub-items expanded" id="movies-sub">
+                        <button class="sidebar-sub-item active" id="sub-movies-all" onclick="selectMovieInstance('')">
+                            All Movies
+                        </button>
+                    </div>
+                </div>
+
+                <div class="sidebar-group">
+                    <button class="sidebar-group-toggle" aria-expanded="true" onclick="toggleSidebarGroup('tv-sub', 'tv')">
+                        <span class="toggle-content">
+                            <i class="fas fa-tv"></i> TV Series
+                        </span>
+                        <i class="fas fa-chevron-down toggle-chevron"></i>
+                    </button>
+                    <div class="sidebar-sub-items expanded" id="tv-sub">
+                        <button class="sidebar-sub-item active" id="sub-tv-all" onclick="selectTvInstance('')">
+                            All Series
+                        </button>
+                    </div>
+                </div>
+
+                <button class="sidebar-item" data-tab="reports" onclick="switchTab('reports')">
                     <i class="fas fa-chart-bar"></i> Reports
                 </button>
-                <button class="nav-tab" data-tab="tools">
+
+                <div class="nav-section-label">AUTOMATION</div>
+
+                <button class="sidebar-item" data-tab="tools" onclick="switchTab('tools')">
                     <i class="fas fa-tools"></i> Tools
                 </button>
-                <a href="/setup" class="nav-tab" style="text-decoration:none">
+
+                <div class="sidebar-divider"></div>
+
+                <a href="/setup" class="sidebar-item">
                     <i class="fas fa-plug"></i> Setup
                 </a>
             </nav>
-        </header>
+        </aside>
 
         <!-- Main Content -->
         <main class="main-content">
@@ -60,7 +93,7 @@
                             <small id="movies-with-dates">- with dates</small>
                         </div>
                     </div>
-                    
+
                     <div class="stat-card">
                         <div class="stat-icon tv">
                             <i class="fas fa-tv"></i>
@@ -71,7 +104,7 @@
                             <small id="episodes-total">- episodes</small>
                         </div>
                     </div>
-                    
+
                     <div class="stat-card">
                         <div class="stat-icon missing">
                             <i class="fas fa-exclamation-triangle"></i>
@@ -82,7 +115,7 @@
                             <small id="no-valid-source-total">- no valid source</small>
                         </div>
                     </div>
-                    
+
                     <div class="stat-card">
                         <div class="stat-icon activity">
                             <i class="fas fa-history"></i>
@@ -131,16 +164,13 @@
                             <select id="movies-filter-source">
                                 <option value="">All Sources</option>
                             </select>
-                            <select id="movies-filter-instance">
-                                <option value="">All Instances</option>
-                            </select>
                             <button class="btn btn-primary" onclick="refreshMovies()">
                                 <i class="fas fa-sync"></i> Refresh
                             </button>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="table-container">
                     <table class="data-table" id="movies-table">
                         <thead>
@@ -152,18 +182,18 @@
                                 <th>Source</th>
                                 <th>Date Type</th>
                                 <th>Video File</th>
-                                <th id="movies-instance-col" style="display:none">Instance</th>
+                                <th id="movies-instance-col">Instance</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody id="movies-tbody">
                             <tr>
-                                <td colspan="8" class="loading">Loading movies...</td>
+                                <td colspan="9" class="loading">Loading movies...</td>
                             </tr>
                         </tbody>
                     </table>
                 </div>
-                
+
                 <div class="pagination" id="movies-pagination"></div>
             </div>
 
@@ -192,16 +222,13 @@
                             <select id="series-filter-source">
                                 <option value="">All Sources</option>
                             </select>
-                            <select id="series-filter-instance">
-                                <option value="">All Instances</option>
-                            </select>
                             <button class="btn btn-primary" onclick="refreshSeries()">
                                 <i class="fas fa-sync"></i> Refresh
                             </button>
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="table-container">
                     <table class="data-table" id="series-table">
                         <thead>
@@ -211,18 +238,18 @@
                                 <th>Episodes</th>
                                 <th>With Dates</th>
                                 <th>With Video</th>
-                                <th id="series-instance-col" style="display:none">Instance</th>
+                                <th id="series-instance-col">Instance</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody id="series-tbody">
                             <tr>
-                                <td colspan="6" class="loading">Loading series...</td>
+                                <td colspan="7" class="loading">Loading series...</td>
                             </tr>
                         </tbody>
                     </table>
                 </div>
-                
+
                 <div class="pagination" id="series-pagination"></div>
             </div>
 
@@ -463,13 +490,13 @@
                     <input type="hidden" id="edit-episode">
                     <input type="hidden" id="edit-media-type">
                     <input type="hidden" id="edit-instance">
-                    
+
                     <div class="form-group">
                         <label for="edit-dateadded">Date Added:</label>
                         <input type="datetime-local" id="edit-dateadded">
                         <small>Leave empty to clear date</small>
                     </div>
-                    
+
                     <div class="form-group">
                         <label for="edit-source">Source:</label>
                         <select id="edit-source" required>
@@ -481,7 +508,7 @@
                             <option value="no_valid_date_source">No Valid Source</option>
                         </select>
                     </div>
-                    
+
                     <div class="form-actions">
                         <button type="button" class="btn btn-secondary" onclick="closeModal()">Cancel</button>
                         <button type="submit" class="btn btn-primary">Save Changes</button>
@@ -494,6 +521,6 @@
     <!-- Toast Notifications -->
     <div class="toast-container" id="toast-container"></div>
 
-    <script src="/static/js/app.js?v=manual-scan-ui"></script>
+    <script src="/static/js/app.js?v=sidebar-nav"></script>
 </body>
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -493,6 +493,9 @@ function updateSeriesTable(data) {
                     <button class="btn btn-sm btn-primary" onclick="viewSeriesEpisodes('${series.imdb_id}')">
                         <i class="fas fa-list"></i> Episodes
                     </button>
+                    <button class="btn btn-sm btn-danger" onclick="deleteSeries('${series.imdb_id}', '${series.instance || 'sonarr'}', ${JSON.stringify(series.title || series.imdb_id)})" style="margin-left: 5px;" title="Delete Series">
+                        <i class="fas fa-trash"></i> Delete
+                    </button>
                 </td>
             </tr>
         `;
@@ -1476,6 +1479,33 @@ async function deleteMovie(imdbId) {
         
     } catch (error) {
         console.error('Delete movie failed:', error);
+        showToast(`❌ Delete failed: ${error.message}`, 'error');
+    }
+}
+
+async function deleteSeries(imdbId, instance, title) {
+    if (!confirm(`⚠️ Delete Series?\n\n"${title}"\n\nThis will permanently remove the series and ALL its episodes from the database.\n\nAre you sure you want to continue?`)) {
+        return;
+    }
+
+    try {
+        const response = await fetch(`/api/series/${imdbId}?instance=${encodeURIComponent(instance)}`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' }
+        });
+
+        const result = await response.json();
+
+        if (response.ok && result.success) {
+            showToast(`✅ Series deleted (${result.episodes_deleted} episode(s) removed)`, 'success');
+            loadSeries(currentSeriesPage);
+        } else {
+            const errorMsg = result.message || result.detail || result.error || 'Unknown error';
+            showToast(`❌ Failed to delete series: ${errorMsg}`, 'error');
+        }
+
+    } catch (error) {
+        console.error('Delete series failed:', error);
         showToast(`❌ Delete failed: ${error.message}`, 'error');
     }
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -5,58 +5,118 @@ let currentTab = 'dashboard';
 let currentMoviesPage = 1;
 let currentSeriesPage = 1;
 let dashboardData = null;
+let currentMovieInstance = '';
+let currentTvInstance = '';
+
+// Instance badge color palette — assigned in order as instances are discovered
+const instanceColorMap = {};
+const instanceColors = ['#3b82f6', '#8b5cf6', '#10b981', '#f59e0b', '#ef4444'];
+let instanceColorIndex = 0;
+
+function getInstanceColor(name) {
+    if (!name) return '#6b7280';
+    if (!instanceColorMap[name]) {
+        instanceColorMap[name] = instanceColors[instanceColorIndex++ % instanceColors.length];
+    }
+    return instanceColorMap[name];
+}
+
+function instanceBadge(name) {
+    if (!name) return '<span class="text-muted">-</span>';
+    const c = getInstanceColor(name);
+    return `<span class="instance-badge" style="background:${c}1a;color:${c};border-color:${c}40">${escapeHtml(name)}</span>`;
+}
 
 // Initialize app
 document.addEventListener('DOMContentLoaded', function() {
-    initializeTabs();
     initializeEventListeners();
-    checkAuthStatus();  // Check authentication status on page load
+    checkAuthStatus();
     loadDashboard();
     loadSeriesSources();
-    loadInstanceDropdowns();
+    buildSidebarInstances();
 });
 
 // Tab management
-function initializeTabs() {
-    const tabButtons = document.querySelectorAll('.nav-tab');
-    const tabContents = document.querySelectorAll('.tab-content');
-    
-    tabButtons.forEach(button => {
-        button.addEventListener('click', function() {
-            const tabName = this.dataset.tab;
-            switchTab(tabName);
-        });
-    });
-}
-
 function switchTab(tabName) {
-    // Update button states
-    document.querySelectorAll('.nav-tab').forEach(btn => btn.classList.remove('active'));
-    document.querySelector(`[data-tab="${tabName}"]`).classList.add('active');
-    
+    // Update sidebar item active states
+    document.querySelectorAll('.sidebar-item[data-tab]').forEach(btn => btn.classList.remove('active'));
+    const activeBtn = document.querySelector(`.sidebar-item[data-tab="${tabName}"]`);
+    if (activeBtn) activeBtn.classList.add('active');
+
     // Update content
     document.querySelectorAll('.tab-content').forEach(content => content.classList.remove('active'));
     document.getElementById(tabName).classList.add('active');
-    
+
     currentTab = tabName;
-    
-    // Load tab-specific data
+
     switch(tabName) {
-        case 'dashboard':
-            loadDashboard();
-            break;
-        case 'movies':
-            loadMovies();
-            break;
-        case 'tv':
-            loadSeries();
-            break;
-        case 'reports':
-            loadReport();
-            break;
-        case 'tools':
-            loadDetailedStats();
-            break;
+        case 'dashboard': loadDashboard(); break;
+        case 'movies': loadMovies(); break;
+        case 'tv': loadSeries(); break;
+        case 'reports': loadReport(); break;
+        case 'tools': loadDetailedStats(); break;
+    }
+}
+
+// Sidebar instance navigation
+function toggleSidebarGroup(subId, tabName) {
+    const sub = document.getElementById(subId);
+    const isExpanded = sub.classList.toggle('expanded');
+    const toggle = sub.closest('.sidebar-group').querySelector('.sidebar-group-toggle');
+    toggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    if (tabName) switchTab(tabName);
+}
+
+function selectMovieInstance(name) {
+    currentMovieInstance = name;
+    currentMoviesPage = 1;
+    document.querySelectorAll('#movies-sub .sidebar-sub-item').forEach(btn => btn.classList.remove('active'));
+    const target = document.getElementById(name ? `sub-movies-${name}` : 'sub-movies-all');
+    if (target) target.classList.add('active');
+    switchTab('movies');
+}
+
+function selectTvInstance(name) {
+    currentTvInstance = name;
+    currentSeriesPage = 1;
+    document.querySelectorAll('#tv-sub .sidebar-sub-item').forEach(btn => btn.classList.remove('active'));
+    const target = document.getElementById(name ? `sub-tv-${name}` : 'sub-tv-all');
+    if (target) target.classList.add('active');
+    switchTab('tv');
+}
+
+async function buildSidebarInstances() {
+    try {
+        const data = await apiCall('/api/instances');
+        const radarrNames = (data.radarr || []).map(i => i.name);
+        const sonarrNames = (data.sonarr || []).map(i => i.name);
+
+        // Pre-assign colors so badges match sidebar dots
+        [...radarrNames, ...sonarrNames].forEach(n => getInstanceColor(n));
+
+        const moviesSub = document.getElementById('movies-sub');
+        radarrNames.forEach(name => {
+            const color = getInstanceColor(name);
+            const btn = document.createElement('button');
+            btn.className = 'sidebar-sub-item';
+            btn.id = `sub-movies-${name}`;
+            btn.onclick = () => selectMovieInstance(name);
+            btn.innerHTML = `<span class="instance-dot" style="background:${color}"></span>${escapeHtml(name)}`;
+            moviesSub.appendChild(btn);
+        });
+
+        const tvSub = document.getElementById('tv-sub');
+        sonarrNames.forEach(name => {
+            const color = getInstanceColor(name);
+            const btn = document.createElement('button');
+            btn.className = 'sidebar-sub-item';
+            btn.id = `sub-tv-${name}`;
+            btn.onclick = () => selectTvInstance(name);
+            btn.innerHTML = `<span class="instance-dot" style="background:${color}"></span>${escapeHtml(name)}`;
+            tvSub.appendChild(btn);
+        });
+    } catch (error) {
+        console.error('Failed to build sidebar instances:', error);
     }
 }
 
@@ -71,10 +131,8 @@ function initializeEventListeners() {
     // Filter dropdowns
     document.getElementById('movies-filter-date').addEventListener('change', loadMovies);
     document.getElementById('movies-filter-source').addEventListener('change', loadMovies);
-    document.getElementById('movies-filter-instance').addEventListener('change', loadMovies);
     document.getElementById('series-filter-date').addEventListener('change', loadSeries);
     document.getElementById('series-filter-source').addEventListener('change', loadSeries);
-    document.getElementById('series-filter-instance').addEventListener('change', loadSeries);
     
     // Forms
     document.getElementById('edit-form').addEventListener('submit', handleEditSubmit);
@@ -201,7 +259,7 @@ async function loadMovies(page = 1) {
     const imdbSearch = document.getElementById('movies-imdb-search').value;
     const hasDate = document.getElementById('movies-filter-date').value;
     const sourceFilter = document.getElementById('movies-filter-source').value;
-    const instanceFilter = document.getElementById('movies-filter-instance').value;
+    const instanceFilter = currentMovieInstance;
 
     const skip = (page - 1) * 100;
     console.log(`DEBUG: loadMovies called with page=${page}, calculated skip=${skip}`);
@@ -232,7 +290,7 @@ function updateMoviesTable(data) {
     const tbody = document.getElementById('movies-tbody');
     
     if (!data.movies || data.movies.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="8" class="text-center">No movies found</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="9" class="text-center">No movies found</td></tr>';
         return;
     }
     
@@ -281,9 +339,6 @@ function updateMoviesTable(data) {
             dateTypeBadge = 'badge-warning';
         }
         
-        const instanceColStyle = document.getElementById('movies-instance-col') &&
-            document.getElementById('movies-instance-col').style.display !== 'none'
-            ? '' : 'display:none';
         return `
             <tr>
                 <td>${escapeHtml(movie.title)}</td>
@@ -293,7 +348,7 @@ function updateMoviesTable(data) {
                 <td><span class="badge badge-secondary">${movie.source_description || movie.source || 'Unknown'}</span></td>
                 <td><span class="badge ${dateTypeBadge}">${dateType}</span></td>
                 <td>${hasVideoBadge}</td>
-                <td style="${instanceColStyle}"><code>${movie.instance || '-'}</code></td>
+                <td>${instanceBadge(movie.instance)}</td>
                 <td>
                     <button class="btn btn-sm btn-primary" onclick="editMovie('${movie.imdb_id}', '${dateadded}', '${movie.source || ''}', '${movie.instance || 'radarr'}')">
                         <i class="fas fa-edit"></i> Edit
@@ -369,37 +424,6 @@ async function loadSeriesSources() {
     }
 }
 
-async function loadInstanceDropdowns() {
-    try {
-        const data = await apiCall('/api/instances');
-        const instances = [...(data.radarr || []), ...(data.sonarr || [])];
-        if (instances.length <= 1) return; // no dropdown needed when only one instance
-
-        const movieSel = document.getElementById('movies-filter-instance');
-        const seriesSel = document.getElementById('series-filter-instance');
-
-        const radarrNames = (data.radarr || []).map(i => i.name);
-        const sonarrNames = (data.sonarr || []).map(i => i.name);
-
-        movieSel.innerHTML = '<option value="">All Instances</option>';
-        radarrNames.forEach(n => {
-            movieSel.innerHTML += `<option value="${n}">${n}</option>`;
-        });
-
-        seriesSel.innerHTML = '<option value="">All Instances</option>';
-        sonarrNames.forEach(n => {
-            seriesSel.innerHTML += `<option value="${n}">${n}</option>`;
-        });
-
-        // Show Instance column header when multiple instances are available
-        const moviesColHeader = document.getElementById('movies-instance-col');
-        const seriesColHeader = document.getElementById('series-instance-col');
-        if (moviesColHeader) moviesColHeader.style.display = '';
-        if (seriesColHeader) seriesColHeader.style.display = '';
-    } catch (error) {
-        console.error('Failed to load instance list:', error);
-    }
-}
 
 function refreshMovies() {
     loadMovies(isNaN(currentMoviesPage) ? 1 : currentMoviesPage);
@@ -416,7 +440,7 @@ async function loadSeries(page = 1) {
     const imdbSearch = document.getElementById('series-imdb-search').value;
     const dateFilter = document.getElementById('series-filter-date').value;
     const sourceFilter = document.getElementById('series-filter-source').value;
-    const instanceFilter = document.getElementById('series-filter-instance').value;
+    const instanceFilter = currentTvInstance;
 
     const skip = (page - 1) * 50;
     console.log(`DEBUG: loadSeries called with page=${page}, calculated skip=${skip}`);
@@ -446,18 +470,13 @@ function updateSeriesTable(data) {
     const tbody = document.getElementById('series-tbody');
     
     if (!data.series || data.series.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="6" class="text-center">No series found</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="7" class="text-center">No series found</td></tr>';
         return;
     }
-    
-    const showSeriesInstance = document.getElementById('series-instance-col') &&
-        document.getElementById('series-instance-col').style.display !== 'none';
 
     tbody.innerHTML = data.series.map(series => {
         const progressPercent = series.total_episodes > 0 ?
             ((series.episodes_with_dates / series.total_episodes) * 100).toFixed(1) : 0;
-        const instanceCell = showSeriesInstance
-            ? `<td><code>${series.instance || '-'}</code></td>` : '<td style="display:none"></td>';
 
         return `
             <tr>
@@ -469,7 +488,7 @@ function updateSeriesTable(data) {
                     <small class="text-muted">(${progressPercent}%)</small>
                 </td>
                 <td>${series.episodes_with_video}</td>
-                ${instanceCell}
+                <td>${instanceBadge(series.instance)}</td>
                 <td>
                     <button class="btn btn-sm btn-primary" onclick="viewSeriesEpisodes('${series.imdb_id}')">
                         <i class="fas fa-list"></i> Episodes

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -295,7 +295,7 @@ function updateMoviesTable(data) {
                 <td>${hasVideoBadge}</td>
                 <td style="${instanceColStyle}"><code>${movie.instance || '-'}</code></td>
                 <td>
-                    <button class="btn btn-sm btn-primary" onclick="editMovie('${movie.imdb_id}', '${dateadded}', '${movie.source || ''}')">
+                    <button class="btn btn-sm btn-primary" onclick="editMovie('${movie.imdb_id}', '${dateadded}', '${movie.source || ''}', '${movie.instance || 'radarr'}')">
                         <i class="fas fa-edit"></i> Edit
                     </button>
                     <button class="btn btn-sm btn-secondary" onclick="debugMovie('${movie.imdb_id}')" title="Debug Data">
@@ -601,7 +601,7 @@ function showEpisodesModal(data) {
                                             <td><span class="badge badge-secondary">${episode.source_description || episode.source || 'Unknown'}</span></td>
                                             <td>${hasVideoBadge}</td>
                                             <td>
-                                                <button class="btn btn-sm btn-primary" onclick="editEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode}, '${dateadded}', '${episode.source || ''}')">
+                                                <button class="btn btn-sm btn-primary" onclick="editEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode}, '${dateadded}', '${episode.source || ''}', '${episode.instance || 'sonarr'}')">
                                                     <i class="fas fa-edit"></i> Edit
                                                 </button>
                                                 <button class="btn btn-sm btn-danger" onclick="deleteEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode})" style="margin-left: 5px;">
@@ -684,7 +684,7 @@ function updateReportTables(data) {
                 <td>${movie.released || '-'}</td>
                 <td><span class="badge badge-warning">${movie.source_description || movie.source || 'Unknown'}</span></td>
                 <td>
-                    <button class="btn btn-sm btn-success" onclick="smartFixMovie('${movie.imdb_id}')">
+                    <button class="btn btn-sm btn-success" onclick="smartFixMovie('${movie.imdb_id}', '${movie.instance || 'radarr'}')">
                         <i class="fas fa-magic"></i> Smart Fix
                     </button>
                 </td>
@@ -705,7 +705,7 @@ function updateReportTables(data) {
                 <td>${episode.aired || '-'}</td>
                 <td><span class="badge badge-warning">${episode.source_description || episode.source || 'Unknown'}</span></td>
                 <td>
-                    <button class="btn btn-sm btn-success" onclick="smartFixEpisode('${episode.imdb_id}', ${episode.season}, ${episode.episode})">
+                    <button class="btn btn-sm btn-success" onclick="smartFixEpisode('${episode.imdb_id}', ${episode.season}, ${episode.episode}, '${episode.instance || 'sonarr'}')">
                         <i class="fas fa-magic"></i> Smart Fix
                     </button>
                 </td>
@@ -719,36 +719,39 @@ function refreshReport() {
 }
 
 // Smart fix functions
-async function smartFixMovie(imdbId) {
+async function smartFixMovie(imdbId, instance) {
+    instance = instance || 'radarr';
     try {
-        console.log('🔍 SMART FIX: Loading options for movie', imdbId);
-        const options = await apiCall(`/api/movies/${imdbId}/date-options`);
+        console.log('🔍 SMART FIX: Loading options for movie', imdbId, 'instance', instance);
+        const options = await apiCall(`/api/movies/${imdbId}/date-options?instance=${encodeURIComponent(instance)}`);
         console.log('🔍 SMART FIX: Received options:', options);
-        showSmartFixModal('movie', options);
+        showSmartFixModal('movie', options, instance);
     } catch (error) {
         console.error('Failed to load movie options:', error);
         showToast('Failed to load movie options', 'error');
     }
 }
 
-async function smartFixEpisode(imdbId, season, episode) {
+async function smartFixEpisode(imdbId, season, episode, instance) {
     // Validate parameters
     if (!imdbId || season === undefined || season === null || episode === undefined || episode === null) {
         console.error('smartFixEpisode: Invalid parameters:', {imdbId, season, episode});
         showToast('Invalid episode parameters', 'error');
         return;
     }
-    
+
+    instance = instance || 'sonarr';
     try {
-        const options = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}/date-options`);
-        showSmartFixModal('episode', options);
+        const options = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}/date-options?instance=${encodeURIComponent(instance)}`);
+        showSmartFixModal('episode', options, instance);
     } catch (error) {
         console.error('Failed to load episode options:', error);
         showToast('Failed to load episode options', 'error');
     }
 }
 
-function showSmartFixModal(mediaType, options) {
+function showSmartFixModal(mediaType, options, instance) {
+    instance = instance || (mediaType === 'movie' ? 'radarr' : 'sonarr');
     console.log('🔍 SMART FIX: Showing modal for', mediaType, 'with options:', options);
     
     const modal = document.getElementById('smart-fix-modal');
@@ -800,7 +803,7 @@ function showSmartFixModal(mediaType, options) {
     optionsHtml += `
         <div class="form-actions">
             <button type="button" class="btn btn-secondary" onclick="closeSmartFixModal()">Cancel</button>
-            <button type="button" class="btn btn-success" onclick="applySmartFix('${mediaType}', ${JSON.stringify(options).replace(/'/g, "&apos;")})">
+            <button type="button" class="btn btn-success" onclick="applySmartFix('${mediaType}', ${JSON.stringify(options).replace(/'/g, "&apos;")}, '${instance}')">
                 <i class="fas fa-magic"></i> Apply Fix
             </button>
         </div>
@@ -814,7 +817,8 @@ function closeSmartFixModal() {
     document.getElementById('smart-fix-modal').classList.remove('active');
 }
 
-async function applySmartFix(mediaType, options) {
+async function applySmartFix(mediaType, options, instance) {
+    instance = instance || (mediaType === 'movie' ? 'radarr' : 'sonarr');
     const selectedRadio = document.querySelector('input[name="date-option"]:checked');
     if (!selectedRadio) {
         showToast('Please select a date option', 'warning');
@@ -876,9 +880,9 @@ async function applySmartFix(mediaType, options) {
     
     try {
         if (mediaType === 'movie') {
-            await updateMovieDate(options.imdb_id, dateadded, source);
+            await updateMovieDate(options.imdb_id, dateadded, source, instance);
         } else {
-            await updateEpisodeDate(options.imdb_id, options.season, options.episode, dateadded, source);
+            await updateEpisodeDate(options.imdb_id, options.season, options.episode, dateadded, source, instance);
         }
         closeSmartFixModal();
     } catch (error) {
@@ -965,19 +969,21 @@ async function handleBulkUpdate(event) {
 }
 
 // Edit modal functions
-async function editMovie(imdbId, dateadded, source) {
+async function editMovie(imdbId, dateadded, source, instance) {
+    instance = instance || 'radarr';
     try {
         // Load movie options to populate available dates
-        const options = await apiCall(`/api/movies/${imdbId}/date-options`);
-        showEnhancedEditModal('movie', options, dateadded, source);
+        const options = await apiCall(`/api/movies/${imdbId}/date-options?instance=${encodeURIComponent(instance)}`);
+        showEnhancedEditModal('movie', options, dateadded, source, instance);
     } catch (error) {
         console.error('Failed to load movie options for edit:', error);
         // Fallback to basic edit modal
-        showBasicEditModal('movie', imdbId, dateadded, source);
+        showBasicEditModal('movie', imdbId, dateadded, source, null, null, instance);
     }
 }
 
-function showEnhancedEditModal(mediaType, options, currentDateadded, currentSource) {
+function showEnhancedEditModal(mediaType, options, currentDateadded, currentSource, instance) {
+    instance = instance || (mediaType === 'movie' ? 'radarr' : 'sonarr');
     const modal = document.getElementById('edit-modal');
     const title = document.getElementById('modal-title');
     const modalBody = document.querySelector('#edit-modal .modal-body');
@@ -995,6 +1001,7 @@ function showEnhancedEditModal(mediaType, options, currentDateadded, currentSour
     let formHtml = `
         <input type="hidden" id="edit-imdb-id" value="${options.imdb_id}">
         <input type="hidden" id="edit-media-type" value="${mediaType}">
+        <input type="hidden" id="edit-instance" value="${instance}">
         ${mediaType === 'episode' ? `
             <input type="hidden" id="edit-season" value="${options.season}">
             <input type="hidden" id="edit-episode" value="${options.episode}">
@@ -1077,11 +1084,13 @@ function showEnhancedEditModal(mediaType, options, currentDateadded, currentSour
     modal.classList.add('active');
 }
 
-function showBasicEditModal(mediaType, imdbId, dateadded, source) {
+function showBasicEditModal(mediaType, imdbId, dateadded, source, season, episode, instance) {
     // Fallback to original basic edit modal
+    instance = instance || (mediaType === 'movie' ? 'radarr' : 'sonarr');
     document.getElementById('modal-title').textContent = `Edit ${mediaType}: ${imdbId}`;
     document.getElementById('edit-imdb-id').value = imdbId;
     document.getElementById('edit-media-type').value = mediaType;
+    document.getElementById('edit-instance').value = instance;
     
     if (dateadded && dateadded !== '-') {
         try {
@@ -1135,11 +1144,12 @@ function updateEditDateFromOption(optionIndex, option) {
 
 async function handleEnhancedEditSubmit(event) {
     event.preventDefault();
-    
+
     const modal = document.getElementById('edit-modal');
     const options = JSON.parse(modal.dataset.options);
     const imdbId = options.imdb_id;
     const mediaType = document.getElementById('edit-media-type').value;
+    const instance = document.getElementById('edit-instance')?.value || (mediaType === 'movie' ? 'radarr' : 'sonarr');
     const dateadded = document.getElementById('edit-dateadded').value;
     const source = document.getElementById('edit-source').value;
     
@@ -1159,11 +1169,11 @@ async function handleEnhancedEditSubmit(event) {
     
     try {
         if (mediaType === 'movie') {
-            await updateMovieDate(imdbId, isoDateadded, source);
+            await updateMovieDate(imdbId, isoDateadded, source, instance);
         } else {
-            await updateEpisodeDate(imdbId, options.season, options.episode, isoDateadded, source);
+            await updateEpisodeDate(imdbId, options.season, options.episode, isoDateadded, source, instance);
         }
-        
+
         closeModal();
     } catch (error) {
         console.error('Enhanced edit failed:', error);
@@ -1171,22 +1181,23 @@ async function handleEnhancedEditSubmit(event) {
     }
 }
 
-async function editEpisode(imdbId, season, episode, dateadded, source) {
+async function editEpisode(imdbId, season, episode, dateadded, source, instance) {
     // Validate parameters
     if (!imdbId || season === undefined || season === null || episode === undefined || episode === null) {
         console.error('editEpisode: Invalid parameters:', {imdbId, season, episode});
         showToast('Invalid episode parameters', 'error');
         return;
     }
-    
+
+    instance = instance || 'sonarr';
     try {
         // Load episode options to populate available dates
-        const options = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}/date-options`);
-        showEnhancedEditModal('episode', options, dateadded, source);
+        const options = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}/date-options?instance=${encodeURIComponent(instance)}`);
+        showEnhancedEditModal('episode', options, dateadded, source, instance);
     } catch (error) {
         console.error('Failed to load episode options for edit:', error);
         // Fallback to basic edit modal
-        showBasicEditModal('episode', imdbId, dateadded, source, season, episode);
+        showBasicEditModal('episode', imdbId, dateadded, source, season, episode, instance);
     }
 }
 
@@ -1196,24 +1207,25 @@ function closeModal() {
 
 async function handleEditSubmit(event) {
     event.preventDefault();
-    
+
     const imdbId = document.getElementById('edit-imdb-id').value;
     const mediaType = document.getElementById('edit-media-type').value;
+    const instance = document.getElementById('edit-instance')?.value || (mediaType === 'movie' ? 'radarr' : 'sonarr');
     const season = document.getElementById('edit-season').value;
     const episode = document.getElementById('edit-episode').value;
     const dateadded = document.getElementById('edit-dateadded').value;
     const source = document.getElementById('edit-source').value;
-    
+
     // Convert datetime-local to ISO string
     const isoDateadded = dateadded ? new Date(dateadded).toISOString() : null;
-    
+
     try {
         if (mediaType === 'movie') {
-            await updateMovieDate(imdbId, isoDateadded, source);
+            await updateMovieDate(imdbId, isoDateadded, source, instance);
         } else {
-            await updateEpisodeDate(imdbId, parseInt(season), parseInt(episode), isoDateadded, source);
+            await updateEpisodeDate(imdbId, parseInt(season), parseInt(episode), isoDateadded, source, instance);
         }
-        
+
         closeModal();
     } catch (error) {
         console.error('Update failed:', error);
@@ -1221,13 +1233,15 @@ async function handleEditSubmit(event) {
 }
 
 // Update functions
-async function updateMovieDate(imdbId, dateadded, source) {
+async function updateMovieDate(imdbId, dateadded, source, instance) {
+    instance = instance || 'radarr';
     try {
         const result = await apiCall(`/api/movies/${imdbId}`, {
             method: 'PUT',
             body: JSON.stringify({
                 dateadded: dateadded,
-                source: source
+                source: source,
+                instance: instance
             })
         });
         
@@ -1243,13 +1257,15 @@ async function updateMovieDate(imdbId, dateadded, source) {
     }
 }
 
-async function updateEpisodeDate(imdbId, season, episode, dateadded, source) {
+async function updateEpisodeDate(imdbId, season, episode, dateadded, source, instance) {
+    instance = instance || 'sonarr';
     try {
         const result = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}`, {
             method: 'PUT',
             body: JSON.stringify({
                 dateadded: dateadded,
-                source: source
+                source: source,
+                instance: instance
             })
         });
         


### PR DESCRIPTION
Sidebar nav redesign + multi-instance support end-to-end.

UI

Dark collapsible sidebar replaces horizontal tab bar
Movies and TV Shows expand to show per-instance sub-items; click an instance to filter, or "All" for the full library with colored instance badges on each row
Removed old <select> instance dropdowns
Features

All DB operations now scoped to the correct instance (edit, smart-fix, skip, populate)
DELETE /api/series/{imdb_id} — removes a series and all its episodes in one shot
Cold-start populate now iterates all configured Radarr/Sonarr instances (previously only the first)
Series titles sourced from folder paths no longer include [imdb-tt...] suffixes
Docs

README, CHANGELOG, QUICKSTART updated for v3
Removed hardcoded internal IP from .env.example
Fixed stale "Admin tab" and old webhook URL references throughout