### PR TITLE
fix: per-instance paths — remove global MOVIE_PATHS/TV_PATHS requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,14 +47,20 @@ WEB_EXTERNAL_PORT=8081
 # RADARR — MAIN INSTANCE
 # ===========================================
 # Paths: RADARR_ROOT_FOLDERS is what Radarr sees on the host (or UNC path on Windows).
-#        MOVIE_PATHS is what Chronarr sees inside the container.
-#        Both are comma-separated and positionally paired.
+#        RADARR_MOVIE_PATHS is what Chronarr sees inside the container.
+#        Both are comma-separated.
+#
+# IMPORTANT — multi-instance users:
+#   Define paths per-instance (RADARR_MOVIE_PATHS, RADARR_4K_MOVIE_PATHS, etc.)
+#   Do NOT use the global MOVIE_PATHS key when running multiple instances —
+#   if it appears more than once in your env file, Docker only keeps the last
+#   definition and silently drops the others.
 
 RADARR_URL=http://radarr:7878
 # RADARR_API_KEY= → set in .env.secrets
 # RADARR_WEBHOOK_SECRET= → set in .env.secrets (optional, for webhook validation)
 RADARR_ROOT_FOLDERS=/mnt/unionfs/Media/Movies/movies
-MOVIE_PATHS=/media/movies
+RADARR_MOVIE_PATHS=/media/movies
 
 # Radarr database (direct DB access — faster than API for large libraries)
 RADARR_DB_TYPE=postgresql
@@ -75,30 +81,37 @@ RADARR_DB_USER=postgres
 # becomes part of the webhook URL: RADARR_4K_URL → /radarr_4k/webhook
 # Names must be uppercase letters and underscores only.
 #
+# Each instance defines ALL of its own settings here — URL, API key, paths,
+# and database access. Do NOT set MOVIE_PATHS again in this block; use
+# RADARR_4K_MOVIE_PATHS instead. If MOVIE_PATHS appears twice in your env
+# file, Docker only keeps the last value and silently drops the first.
+#
 # After configuring instances, visit http://your-server:8081/setup
-# for the exact webhook URLs to paste into each Radarr or Sonarr instance.
+# for the exact webhook URLs to paste into each Radarr instance.
 
 # RADARR_4K_URL=http://radarr4k:7878
 # RADARR_4K_API_KEY= → set in .env.secrets
 # RADARR_4K_WEBHOOK_SECRET= → set in .env.secrets (optional)
 # RADARR_4K_ROOT_FOLDERS=/mnt/unionfs/Media/Movies/movies4k
-# RADARR_4K_MOVIE_PATHS=/media/movies4k
+# RADARR_4K_MOVIE_PATHS=/media/movies4k   ← per-instance paths, NOT MOVIE_PATHS
 # RADARR_4K_DB_TYPE=postgresql
 # RADARR_4K_DB_HOST=your-radarr-4k-db-host
 # RADARR_4K_DB_PORT=5432
 # RADARR_4K_DB_NAME=radarr-4k
 # RADARR_4K_DB_USER=postgres
 # RADARR_4K_DB_PASSWORD= → set in .env.secrets
-# SQLite: RADARR_4K_DB_TYPE=sqlite / RADARR_4K_DB_PATH=/path/to/radarr4k.db
+# SQLite: RADARR_4K_DB_TYPE=sqlite / RADARR_4K_DB_PATH=/radarr-4k-data/radarr.db
 
 # ===========================================
 # SONARR — MAIN INSTANCE
 # ===========================================
+# Same paths rule as Radarr: use SONARR_TV_PATHS here, not the global TV_PATHS,
+# so each instance's paths stay self-contained.
 SONARR_URL=http://sonarr:8989
 # SONARR_API_KEY= → set in .env.secrets
 # SONARR_WEBHOOK_SECRET= → set in .env.secrets (optional)
 SONARR_ROOT_FOLDERS=/mnt/unionfs/Media/TV/tv
-TV_PATHS=/media/tv
+SONARR_TV_PATHS=/media/tv
 
 # Sonarr database
 SONARR_DB_TYPE=postgresql
@@ -115,11 +128,12 @@ SONARR_DB_USER=postgres
 # ===========================================
 # SONARR — ADDITIONAL INSTANCES (OPTIONAL)
 # ===========================================
+# Same rule: use SONARR_4K_TV_PATHS, NOT TV_PATHS, in additional instance blocks.
 # SONARR_4K_URL=http://sonarr4k:8989
 # SONARR_4K_API_KEY= → set in .env.secrets
 # SONARR_4K_WEBHOOK_SECRET= → set in .env.secrets (optional)
 # SONARR_4K_ROOT_FOLDERS=/mnt/unionfs/Media/TV/tv4k
-# SONARR_4K_TV_PATHS=/media/tv4k
+# SONARR_4K_TV_PATHS=/media/tv4k              ← per-instance paths, NOT TV_PATHS
 # SONARR_4K_DB_TYPE=postgresql
 # SONARR_4K_DB_HOST=your-sonarr-4k-db-host
 # SONARR_4K_DB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -339,31 +339,56 @@ SONARR_DB_PASSWORD=sonarr_pass       # Sonarr database password (.env.secrets)
 
 Add additional Radarr or Sonarr instances using a `NAME` segment between the prefix and the variable suffix. The name becomes the instance identifier in Chronarr's UI and database.
 
+Each instance block is fully self-contained — define all settings including paths directly within it. **Do not use the global `MOVIE_PATHS` or `TV_PATHS` keys in additional instance blocks.** If those keys appear more than once in your env file, Docker only keeps the last value and silently drops the rest, corrupting path matching for every instance.
+
 ```bash
+# Main Radarr instance — use RADARR_MOVIE_PATHS, not MOVIE_PATHS
+RADARR_URL=http://radarr:7878
+RADARR_API_KEY=your_api_key         # (.env.secrets)
+RADARR_ROOT_FOLDERS=/mnt/nas/Movies
+RADARR_MOVIE_PATHS=/media/movies
+RADARR_DB_TYPE=sqlite
+RADARR_DB_PATH=/radarr-data/radarr.db
+
 # Second Radarr instance (e.g., 4K library)
 RADARR_4K_URL=http://radarr-4k:7878
 RADARR_4K_API_KEY=your_4k_api_key   # (.env.secrets)
-RADARR_4K_DB_TYPE=postgresql
-RADARR_4K_DB_HOST=radarr-4k-db
-RADARR_4K_DB_NAME=radarr-main
-RADARR_4K_DB_USER=radarr
-RADARR_4K_DB_PASSWORD=radarr_4k_pass  # (.env.secrets)
+RADARR_4K_ROOT_FOLDERS=/mnt/nas/Movies-4K
+RADARR_4K_MOVIE_PATHS=/media/movies-4k   # ← per-instance, NOT MOVIE_PATHS
+RADARR_4K_DB_TYPE=sqlite
+RADARR_4K_DB_PATH=/radarr-4k-data/radarr.db
+
+# Main Sonarr instance — use SONARR_TV_PATHS, not TV_PATHS
+SONARR_URL=http://sonarr:8989
+SONARR_API_KEY=your_sonarr_key      # (.env.secrets)
+SONARR_ROOT_FOLDERS=/mnt/nas/TV
+SONARR_TV_PATHS=/media/tv
+SONARR_DB_TYPE=sqlite
+SONARR_DB_PATH=/sonarr-data/sonarr.db
 
 # Second Sonarr instance (e.g., anime library)
 SONARR_ANIME_URL=http://sonarr-anime:8989
 SONARR_ANIME_API_KEY=your_anime_key  # (.env.secrets)
-SONARR_ANIME_DB_TYPE=postgresql
-SONARR_ANIME_DB_HOST=sonarr-anime-db
-SONARR_ANIME_DB_NAME=sonarr-main
-SONARR_ANIME_DB_USER=sonarr
-SONARR_ANIME_DB_PASSWORD=sonarr_anime_pass  # (.env.secrets)
+SONARR_ANIME_ROOT_FOLDERS=/mnt/nas/Anime
+SONARR_ANIME_TV_PATHS=/media/anime   # ← per-instance, NOT TV_PATHS
+SONARR_ANIME_DB_TYPE=sqlite
+SONARR_ANIME_DB_PATH=/sonarr-anime-data/sonarr.db
 ```
 
 Each named instance gets its own webhook endpoint (`/radarr_4k/webhook`, `/sonarr_anime/webhook`) and appears as a separate entry in the sidebar. An "All" view aggregates across all instances with colored instance badges on each row.
 
-**SQLite Docker Configuration:**
+**SQLite Docker Configuration (multi-instance):**
 
-When using SQLite databases with Docker, you must mount the database directories as read-only volumes. See the Quick Start guide (step 3) or check `docker-compose.yml.example` for detailed examples.
+Each SQLite database needs its own volume mount in `docker-compose.yml`. The container path you choose must match the `_DB_PATH` value in your `.env`:
+
+```yaml
+# In docker-compose.yml, under chronarr-core volumes:
+- /host/path/to/radarr/config:/radarr-data:ro          # → RADARR_DB_PATH=/radarr-data/radarr.db
+- /host/path/to/radarr-4k/config:/radarr-4k-data:ro    # → RADARR_4K_DB_PATH=/radarr-4k-data/radarr.db
+- /host/path/to/sonarr/config:/sonarr-data:ro           # → SONARR_DB_PATH=/sonarr-data/sonarr.db
+```
+
+The `radarr.db` file is usually at the top level of Radarr's config directory. If the database fails to open, browse that directory on your host to find the actual filename and depth, then adjust `DB_PATH` accordingly. See `docker-compose.yml.example` for a complete annotated example.
 
 ## Web Interface
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -119,7 +119,10 @@ class ChronarrConfig:
         
         # External connections
         self._load_external_connections()
-        
+
+        # Warn if any discovered instance has no paths at all
+        self._warn_missing_instance_paths()
+
         # Movie processing
         self._load_movie_settings()
         
@@ -130,39 +133,21 @@ class ChronarrConfig:
         self._load_auth_settings()
     
     def _load_paths(self) -> None:
-        """Load and validate path configuration"""
-        tv_paths_env = os.environ.get("TV_PATHS", "")
+        """Load global path fallbacks.
+
+        MOVIE_PATHS and TV_PATHS are optional global fallbacks used when an
+        instance does not define its own per-instance paths variable
+        (RADARR_{NAME}_MOVIE_PATHS / SONARR_{NAME}_TV_PATHS).
+
+        For single-instance setups these remain the simplest approach.
+        For multi-instance setups, define paths per-instance so each block
+        is fully self-contained and there is no risk of one definition
+        silently overriding another (Docker env_file last-definition-wins).
+        """
         movie_paths_env = os.environ.get("MOVIE_PATHS", "")
-        
-        if not tv_paths_env:
-            raise ConfigurationError(
-                setting="TV_PATHS",
-                reason="TV_PATHS environment variable is required but not set"
-            )
-        
-        if not movie_paths_env:
-            raise ConfigurationError(
-                setting="MOVIE_PATHS", 
-                reason="MOVIE_PATHS environment variable is required but not set"
-            )
-            
-        # Parse paths
-        self.tv_paths = [Path(p.strip()) for p in tv_paths_env.split(",") if p.strip()]
+        tv_paths_env = os.environ.get("TV_PATHS", "")
         self.movie_paths = [Path(p.strip()) for p in movie_paths_env.split(",") if p.strip()]
-        
-        if not self.tv_paths:
-            raise ConfigurationError(
-                setting="TV_PATHS",
-                reason="No valid TV paths found after parsing",
-                current_value=tv_paths_env
-            )
-        
-        if not self.movie_paths:
-            raise ConfigurationError(
-                setting="MOVIE_PATHS",
-                reason="No valid movie paths found after parsing", 
-                current_value=movie_paths_env
-            )
+        self.tv_paths = [Path(p.strip()) for p in tv_paths_env.split(",") if p.strip()]
     
     def _load_server_settings(self) -> None:
         """Load server configuration"""
@@ -334,6 +319,39 @@ class ChronarrConfig:
                 instances.append(self._load_sonarr_instance(name_segment, url))
 
         return instances
+
+    def _warn_missing_instance_paths(self) -> None:
+        """Warn at startup if any configured instance has no paths.
+
+        An instance with empty movie_paths / tv_paths cannot match file
+        paths to media items — date assignment from the DB will still work,
+        but any path-based lookup will silently find nothing.
+
+        Each instance should define its own paths variable:
+          RADARR_{NAME}_MOVIE_PATHS  (or RADARR_MOVIE_PATHS for the default)
+          SONARR_{NAME}_TV_PATHS     (or SONARR_TV_PATHS for the default)
+
+        MOVIE_PATHS / TV_PATHS act as a global fallback when no per-instance
+        variable is set.
+        """
+        for inst in self.radarr_instances:
+            if not inst.movie_paths:
+                logger.warning(
+                    "Radarr instance '%s' has no movie paths configured. "
+                    "Set %s_MOVIE_PATHS in your .env (or MOVIE_PATHS as a "
+                    "global fallback). Path matching will not work for this instance.",
+                    inst.name,
+                    inst.name.upper(),
+                )
+        for inst in self.sonarr_instances:
+            if not inst.tv_paths:
+                logger.warning(
+                    "Sonarr instance '%s' has no TV paths configured. "
+                    "Set %s_TV_PATHS in your .env (or TV_PATHS as a "
+                    "global fallback). Path matching will not work for this instance.",
+                    inst.name,
+                    inst.name.upper(),
+                )
 
     def _load_movie_settings(self) -> None:
         """Load movie processing settings"""

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -67,12 +67,28 @@ services:
       - chronarr_logs:/app/data/logs
       # Optional: Radarr SQLite database (read-only access)
       # Required if using RADARR_DB_TYPE=sqlite in config
-      # - /path/to/radarr/config:/radarr-config:ro
-      # Then set RADARR_DB_PATH=/radarr-config/radarr.db in .env
+      # - /path/to/radarr/config:/radarr-data:ro
+      # Then set RADARR_DB_PATH=/radarr-data/radarr.db in .env
+      #
+      # Additional Radarr instances — one mount per instance:
+      # - /path/to/radarr-4k/config:/radarr-4k-data:ro
+      # Then set RADARR_4K_DB_PATH=/radarr-4k-data/radarr.db in .env
+      #
+      # Media paths — one mount per instance if libraries differ:
+      # - /path/to/movies:/media/movies:ro
+      # - /path/to/movies-4k:/media/movies-4k:ro
+      # Then set RADARR_MOVIE_PATHS=/media/movies and
+      #          RADARR_4K_MOVIE_PATHS=/media/movies-4k in .env
+      #
       # Optional: Sonarr SQLite database (read-only access)
       # Required if using SONARR_DB_TYPE=sqlite in config
-      # - /path/to/sonarr/config:/sonarr-config:ro
-      # Then set SONARR_DB_PATH=/sonarr-config/sonarr.db in .env
+      # - /path/to/sonarr/config:/sonarr-data:ro
+      # Then set SONARR_DB_PATH=/sonarr-data/sonarr.db in .env
+      #
+      # Additional Sonarr instances:
+      # - /path/to/sonarr-anime/config:/sonarr-anime-data:ro
+      # Then set SONARR_ANIME_DB_PATH=/sonarr-anime-data/sonarr.db in .env
+      #
       # Optional: Emby plugin deployment
       # - /path/to/emby/plugins:/emby-plugins
     ports:
@@ -176,20 +192,25 @@ networks:
 #
 # SQLite Database Access (for Radarr/Sonarr):
 # - If using SQLite databases, you MUST mount them read-only
-# - Radarr example:
-#   1. Uncomment: - /path/to/radarr/config:/radarr-config:ro
-#   2. Update path to your Radarr config directory
-#   3. In ./config/.env set: RADARR_DB_TYPE=sqlite
-#   4. In ./config/.env set: RADARR_DB_PATH=/radarr-config/radarr.db
+# - Each instance needs its own volume mount and its own DB_PATH variable
+# - Radarr (default instance) example:
+#   1. Add volume: - /path/to/radarr/config:/radarr-data:ro
+#   2. In ./config/.env set: RADARR_DB_TYPE=sqlite
+#   3. In ./config/.env set: RADARR_DB_PATH=/radarr-data/radarr.db
+# - Radarr 4K instance example:
+#   1. Add volume: - /path/to/radarr-4k/config:/radarr-4k-data:ro
+#   2. In ./config/.env set: RADARR_4K_DB_TYPE=sqlite
+#   3. In ./config/.env set: RADARR_4K_DB_PATH=/radarr-4k-data/radarr.db
 # - Sonarr example:
-#   1. Uncomment: - /path/to/sonarr/config:/sonarr-config:ro
-#   2. Update path to your Sonarr config directory
-#   3. In ./config/.env set: SONARR_DB_TYPE=sqlite
-#   4. In ./config/.env set: SONARR_DB_PATH=/sonarr-config/sonarr.db
-# - Common paths:
-#   - Docker: /path/to/radarr/config (where radarr.db lives)
-#   - Windows: C:/ProgramData/Radarr or C:/ProgramData/Sonarr
-#   - Linux: /home/user/.config/Radarr or /var/lib/radarr
+#   1. Add volume: - /path/to/sonarr/config:/sonarr-data:ro
+#   2. In ./config/.env set: SONARR_DB_TYPE=sqlite
+#   3. In ./config/.env set: SONARR_DB_PATH=/sonarr-data/sonarr.db
+# - The radarr.db file is usually directly inside the Radarr config folder.
+#   If not, browse the folder on your host and find it, then adjust DB_PATH.
+# - Common config locations:
+#   - Docker (LSIO/Hotio): the config directory you mapped to /config in Radarr
+#   - Windows (bare metal): C:/ProgramData/Radarr
+#   - Linux (bare metal): /home/user/.config/Radarr or /var/lib/radarr
 #
 # Emby Plugin Deployment:
 # - Uncomment the emby-plugins volume mount


### PR DESCRIPTION
Each Radarr/Sonarr instance now defines its own paths variable (RADARR_{NAME}_MOVIE_PATHS, SONARR_{NAME}_TV_PATHS). The global MOVIE_PATHS and TV_PATHS are no longer required at startup; they remain as optional fallbacks for single-instance setups.

When multiple instances share a global key in Docker env_file, last-definition-wins silently drops all earlier values. Per-instance vars are scoped to their block, so no instance can accidentally overwrite another's paths.

- settings.py: _load_paths() no longer raises on missing global vars; adds _warn_missing_instance_paths() to log clearly at startup if any configured instance has no paths at all
- .env.example: MOVIE_PATHS → RADARR_MOVIE_PATHS / TV_PATHS → SONARR_TV_PATHS; prominent warning in multi-instance blocks
- docker-compose.yml.example: per-instance SQLite volume mount examples for all instance types
- README.md: multi-instance config section rewritten to show complete per-instance blocks with paths and DB vars together