### PR TITLE
fix: cast SQLite hasFile to bool before episode insert

### DIFF
--- a/clients/sonarr_db_client.py
+++ b/clients/sonarr_db_client.py
@@ -239,7 +239,9 @@ class SonarrDbClient:
                 rows = cursor.fetchall()
 
                 if self.db_type == "sqlite":
-                    return [dict(row) for row in rows]
+                    # SQLite has no boolean type — the CASE WHEN above comes back as 1/0,
+                    # which Postgres refuses to insert into the boolean has_video_file column
+                    return [dict(row, hasFile=bool(row["hasFile"])) for row in rows]
                 else:
                     return rows
 


### PR DESCRIPTION
## Problem

Users with `SONARR_DB_TYPE=sqlite` configured (direct-DB read path instead of the API client) get zero TV episodes populated — series are found, but every episode insert fails silently from the caller's perspective (surfaced as errors in the populate logs):

```
ERROR: Error processing episode S01E01 of .hack: column "has_video_file" is of type boolean but expression is of type integer
```

## Root cause

`SonarrDbClient.get_all_episodes_for_series` computes `hasFile` with `CASE WHEN ... THEN true ELSE false END`. On a PostgreSQL Sonarr DB that's a real boolean. SQLite has no boolean type, so on a SQLite Sonarr DB the same expression comes back as integer `1`/`0`. That integer flows straight through to the INSERT into Chronarr's own `episodes` table, where `has_video_file` is a real `BOOLEAN` column — Postgres won't implicitly cast an integer literal there and rejects every insert.

Movies were unaffected — `radarr_db_client.py` has no matching CASE WHEN pattern.

## Fix

Cast to a real Python `bool` when building the row dict for SQLite, same as the rest of that code path already does for other fields.

## Scope note

Same fix also opened against `feature/v3` (PR #109) — this bug predates v3 and isn't multi-instance-specific, it's inherent to the SQLite direct-DB-read path which exists on both branches.