### PR TITLE
feat: setup wizard, per-instance health, and multi-instance webhook f…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,20 @@ DB_USER=chronarr
 TZ=America/New_York
 
 # Core API — handles webhooks and processing
+# This is the interface Chronarr's own core container listens ON. Leave it
+# at 0.0.0.0 unless you have a specific reason to change it — setting this
+# to a hostname will stop core listening on the addresses Docker healthchecks
+# and the web container's other internal calls use, breaking both.
 CORE_API_HOST=0.0.0.0
 CORE_API_PORT=8080
+
+# Where the WEB container reaches CORE internally — a different setting from
+# the pair above. Only needed if the default hostname "chronarr" is
+# ambiguous, e.g. running more than one Chronarr deployment on the same
+# Docker network (a production stack and a local-test stack, say) — point
+# this at your core container's actual name/service in that situation.
+# CORE_INTERNAL_HOST=chronarr
+# CORE_INTERNAL_PORT=8080
 
 # Web dashboard
 WEB_HOST=0.0.0.0

--- a/api/models.py
+++ b/api/models.py
@@ -49,7 +49,8 @@ class HealthResponse(BaseModel):
     version: str
     uptime: str
     database_status: str
-    radarr_database: Optional[Dict[str, Any]] = None
+    radarr_database: Optional[Dict[str, Any]] = None  # legacy — default Radarr instance only, kept for back-compat
+    instances: Optional[Dict[str, Dict[str, Any]]] = None  # {"radarr": {name: {connected, method}}, "sonarr": {...}} — every configured instance
 
 
 class TVSeasonRequest(BaseModel):
@@ -252,3 +253,77 @@ class CleanupExecutionResponse(BaseModel):
     error_message: Optional[str]
     report_json: Optional[str]
     triggered_by: Optional[str]
+
+
+class WizardConnectionTestRequest(BaseModel):
+    """Setup wizard: test a Radarr/Sonarr URL+API key or a direct DB connection.
+
+    Send either url+api_key, or a db_type block, or both — whatever the
+    form has filled in so far. Doesn't touch any files.
+    """
+    media_type: str  # "radarr" or "sonarr"
+    name: Optional[str] = None  # not validated here — just used to label log lines during the test
+    url: Optional[str] = None
+    api_key: Optional[str] = None
+    db_type: Optional[str] = None  # "sqlite" or "postgresql"
+    db_host: Optional[str] = None
+    db_port: Optional[int] = None
+    db_name: Optional[str] = None
+    db_user: Optional[str] = None
+    db_password: Optional[str] = None
+    db_path: Optional[str] = None
+
+
+class WizardSaveInstanceRequest(BaseModel):
+    """Setup wizard: write a Radarr/Sonarr instance to .env / .env.secrets.
+
+    `name` is the user-typed instance name (e.g. "4k" or "strm") — leave it
+    empty to configure the default instance. `force` skips the connection
+    test failing being a hard stop, for someone who knows the service is
+    just down right now and wants to save the config anyway. `edit_existing`
+    flips the name check: normally a name must NOT already exist (adding a
+    new instance); with edit_existing=True it must ALREADY exist instead —
+    editing something that was never configured isn't a valid request either.
+    """
+    media_type: str  # "radarr" or "sonarr"
+    name: str = ""
+    url: str
+    api_key: str
+    root_folders: Optional[List[str]] = None
+    movie_paths: Optional[List[str]] = None  # radarr instances only
+    tv_paths: Optional[List[str]] = None     # sonarr instances only
+    db_type: Optional[str] = None
+    db_host: Optional[str] = None
+    db_port: Optional[int] = None
+    db_name: Optional[str] = None
+    db_user: Optional[str] = None
+    db_password: Optional[str] = None
+    db_path: Optional[str] = None
+    force: bool = False
+    edit_existing: bool = False
+
+
+class WizardDeleteInstanceRequest(BaseModel):
+    """Setup wizard: remove a Radarr/Sonarr instance from .env / .env.secrets.
+
+    Removes every env var this instance's name segment owns. Same automatic
+    pre-write snapshot every other wizard write already takes.
+    """
+    media_type: str  # "radarr" or "sonarr"
+    name: str = ""   # "" targets the default (unprefixed) instance
+
+
+class WizardEnvRestoreRequest(BaseModel):
+    """Setup wizard: restore .env / .env.secrets from a backup file's contents.
+
+    `env` and `env_secrets` are the raw file text, exactly as
+    GET /api/wizard/env-backup produced them — this overwrites both files
+    verbatim, not a merge. `chronarr_version`/`exported_at` are informational
+    only, from the backup's own header; nothing currently rejects a restore
+    over a version mismatch, but they're captured in case that's worth
+    warning about later.
+    """
+    env: str
+    env_secrets: str
+    chronarr_version: Optional[str] = None
+    exported_at: Optional[str] = None

--- a/api/routes.py
+++ b/api/routes.py
@@ -16,7 +16,8 @@ from typing import Optional
 from api.models import (
     SonarrWebhook, RadarrWebhook, MaintainarrWebhook, HealthResponse, TVSeasonRequest, TVEpisodeRequest,
     MovieUpdateRequest, EpisodeUpdateRequest, BulkUpdateRequest, OrphanedCleanupRequest,
-    CreateScheduledCleanupRequest, UpdateScheduledCleanupRequest, ScheduledCleanupResponse, CleanupExecutionResponse
+    CreateScheduledCleanupRequest, UpdateScheduledCleanupRequest, ScheduledCleanupResponse, CleanupExecutionResponse,
+    WizardConnectionTestRequest, WizardSaveInstanceRequest, WizardEnvRestoreRequest, WizardDeleteInstanceRequest
 )
 # Import logging utility
 from utils.logging import _log
@@ -94,7 +95,7 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
             raise HTTPException(status_code=422, detail="Empty Sonarr payload")
         
         webhook = SonarrWebhook(**payload)
-        _log("INFO", f"Received Sonarr webhook: {webhook.eventType}")
+        _log("INFO", f"[{instance}] Received Sonarr webhook: {webhook.eventType}")
         
         if webhook.eventType not in ["Download", "Upgrade", "Rename"]:
             return {"status": "ignored", "reason": f"Event type {webhook.eventType} not processed"}
@@ -110,24 +111,25 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         sonarr_path = series_info.get("path", "")
         
         if not imdb_id:
-            _log("ERROR", f"No IMDb ID for series: {series_title}")
+            _log("ERROR", f"[{instance}] No IMDb ID for series: {series_title}")
             return {"status": "error", "reason": "No IMDb ID"}
-        
-        # Find series path
-        series_path = tv_processor.find_series_path(series_title, imdb_id, sonarr_path)
+
+        # Find series path — instance-aware so a named instance's own root
+        # folder mapping is used, not always the default instance's.
+        series_path = tv_processor.find_series_path(series_title, imdb_id, sonarr_path, instance=instance)
         if not series_path:
-            print(f"ERROR: Could not find series directory: {series_title} ({imdb_id})")
+            _log("ERROR", f"[{instance}] Could not find series directory: {series_title} ({imdb_id})")
             return {"status": "error", "reason": "Series directory not found"}
-        
+
         # Extract episode data for targeted processing
         episodes_data = webhook.episodes or []
-        _log("DEBUG", f"Initial episodes_data from webhook.episodes: {len(episodes_data)} episodes")
+        _log("DEBUG", f"[{instance}] Initial episodes_data from webhook.episodes: {len(episodes_data)} episodes")
         
         # For all webhook events, if no episodes in webhook.episodes, try to extract from episodeFile
         # This ensures targeted processing for single episode operations (Download, Rename, Upgrade)
-        _log("DEBUG", f"webhook.episodeFile present: {webhook.episodeFile is not None}")
+        _log("DEBUG", f"[{instance}] webhook.episodeFile present: {webhook.episodeFile is not None}")
         if webhook.episodeFile:
-            _log("DEBUG", f"episodeFile content: {webhook.episodeFile}")
+            _log("DEBUG", f"[{instance}] episodeFile content: {webhook.episodeFile}")
         
         if not episodes_data and webhook.episodeFile:
             episode_file = webhook.episodeFile
@@ -141,17 +143,17 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                 
                 # Try relativePath first, then path
                 file_path = episode_file.get("relativePath") or episode_file.get("path", "")
-                _log("DEBUG", f"Parsing episode info from path: {file_path}")
+                _log("DEBUG", f"[{instance}] Parsing episode info from path: {file_path}")
                 
                 episode_info = extract_episode_info_from_filename(file_path)
                 if episode_info:
                     season_num = episode_info["season"]
                     episode_num = episode_info["episode"]
-                    _log("DEBUG", f"Extracted from filename - Season: {season_num}, Episode: {episode_num}")
+                    _log("DEBUG", f"[{instance}] Extracted from filename - Season: {season_num}, Episode: {episode_num}")
                 else:
-                    _log("DEBUG", f"Could not extract season/episode from filename: {file_path}")
+                    _log("DEBUG", f"[{instance}] Could not extract season/episode from filename: {file_path}")
             
-            _log("DEBUG", f"episodeFile seasonNumber: {season_num}, episodeNumber: {episode_num}")
+            _log("DEBUG", f"[{instance}] episodeFile seasonNumber: {season_num}, episodeNumber: {episode_num}")
             if season_num and episode_num:
                 # Create episode data structure that matches what process_webhook_episodes expects
                 episodes_data = [{
@@ -161,37 +163,37 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                     "title": episode_file.get("title")
                     # Note: Not including dateAdded - we use database-first approach with Sonarr fallback
                 }]
-                _log("INFO", f"Extracted episode info from episodeFile for {webhook.eventType}: S{season_num:02d}E{episode_num:02d}")
+                _log("INFO", f"[{instance}] Extracted episode info from episodeFile for {webhook.eventType}: S{season_num:02d}E{episode_num:02d}")
             else:
-                _log("DEBUG", f"Missing season/episode numbers in episodeFile for {webhook.eventType}")
+                _log("DEBUG", f"[{instance}] Missing season/episode numbers in episodeFile for {webhook.eventType}")
         
         # Special handling for Rename events - Sonarr doesn't include episodeFile for renames
         # Try to find recently renamed episodes using Sonarr history API
         if not episodes_data and webhook.eventType == "Rename":
-            _log("DEBUG", f"Attempting to find recently renamed episode for series {imdb_id}")
+            _log("DEBUG", f"[{instance}] Attempting to find recently renamed episode for series {imdb_id}")
             try:
                 # Get series info from Sonarr to find series ID
                 series_lookup_url = f"{config.sonarr_url}/api/v3/series/lookup?term=imdbid:{imdb_id}"
-                _log("DEBUG", f"Sonarr lookup for rename: {series_lookup_url}")
+                _log("DEBUG", f"[{instance}] Sonarr lookup for rename: {series_lookup_url}")
                 
                 response = requests.get(series_lookup_url, headers={"X-Api-Key": os.environ.get("SONARR_API_KEY", "")}, timeout=10)
                 if response.status_code == 200:
                     series_results = response.json()
                     if series_results:
                         series_id = series_results[0].get("id")
-                        _log("DEBUG", f"Found series ID {series_id} for rename lookup")
+                        _log("DEBUG", f"[{instance}] Found series ID {series_id} for rename lookup")
                         
                         # Get recent history for the series and filter for rename events
                         from datetime import datetime, timedelta
                         since_date = (datetime.utcnow() - timedelta(hours=1)).strftime('%Y-%m-%dT%H:%M:%SZ')
                         history_url = f"{config.sonarr_url}/api/v3/history?seriesId={series_id}&sortKey=date&sortDir=desc&page=1&pageSize=50"
-                        _log("DEBUG", f"Checking recent rename history: {history_url}")
+                        _log("DEBUG", f"[{instance}] Checking recent rename history: {history_url}")
                         
                         history_response = requests.get(history_url, headers={"X-Api-Key": os.environ.get("SONARR_API_KEY", "")}, timeout=10)
                         if history_response.status_code == 200:
                             history_data = history_response.json()
                             all_records = history_data.get("records", [])
-                            _log("DEBUG", f"Got {len(all_records)} total history records")
+                            _log("DEBUG", f"[{instance}] Got {len(all_records)} total history records")
                             
                             # Filter for recent rename events
                             since_timestamp = datetime.utcnow() - timedelta(hours=1)
@@ -211,16 +213,16 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                                         # If datetime parsing fails, include it anyway
                                         recent_renames.append(record)
                             
-                            _log("DEBUG", f"Found {len(recent_renames)} recent rename events")
+                            _log("DEBUG", f"[{instance}] Found {len(recent_renames)} recent rename events")
                             
                             if recent_renames:
                                 # Take the most recent rename event
                                 latest_rename = recent_renames[0]
-                                _log("DEBUG", f"Processing latest rename event")
+                                _log("DEBUG", f"[{instance}] Processing latest rename event")
                                 
                                 # Extract episodeId directly from the rename event
                                 episode_id = latest_rename.get("episodeId")
-                                _log("DEBUG", f"Found episodeId {episode_id} in rename event")
+                                _log("DEBUG", f"[{instance}] Found episodeId {episode_id} in rename event")
                                 
                                 if episode_id:
                                     # Fetch episode details using the episodeId
@@ -233,7 +235,7 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                                         episode_num = episode_detail.get("episodeNumber")
                                         episode_title = episode_detail.get("title")
                                         
-                                        _log("DEBUG", f"Episode details - Season: {season_num}, Episode: {episode_num}, Title: {episode_title}")
+                                        _log("DEBUG", f"[{instance}] Episode details - Season: {season_num}, Episode: {episode_num}, Title: {episode_title}")
                                         
                                         if season_num is not None and episode_num is not None:
                                             episodes_data = [{
@@ -242,30 +244,30 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
                                                 "id": episode_id,
                                                 "title": episode_title
                                             }]
-                                            print(f"INFO: Successfully identified renamed episode: S{season_num:02d}E{episode_num:02d} - {episode_title}")
+                                            _log("INFO", f"[{instance}] Successfully identified renamed episode: S{season_num:02d}E{episode_num:02d} - {episode_title}")
                                         else:
-                                            _log("DEBUG", f"Episode details missing season/episode numbers")
+                                            _log("DEBUG", f"[{instance}] Episode details missing season/episode numbers")
                                     else:
-                                        _log("DEBUG", f"Failed to fetch episode details: {episode_response.status_code}")
+                                        _log("DEBUG", f"[{instance}] Failed to fetch episode details: {episode_response.status_code}")
                                 else:
-                                    _log("DEBUG", f"No episodeId found in rename event")
+                                    _log("DEBUG", f"[{instance}] No episodeId found in rename event")
                             else:
-                                _log("DEBUG", f"No recent rename events found in last hour")
+                                _log("DEBUG", f"[{instance}] No recent rename events found in last hour")
                         else:
-                            _log("DEBUG", f"Failed to get rename history: {history_response.status_code}")
+                            _log("DEBUG", f"[{instance}] Failed to get rename history: {history_response.status_code}")
                     else:
-                        _log("DEBUG", f"No series found for IMDb {imdb_id}")
+                        _log("DEBUG", f"[{instance}] No series found for IMDb {imdb_id}")
                 else:
-                    _log("DEBUG", f"Series lookup failed: {response.status_code}")
+                    _log("DEBUG", f"[{instance}] Series lookup failed: {response.status_code}")
             except Exception as e:
-                _log("DEBUG", f"Error finding renamed episode: {e}")
+                _log("DEBUG", f"[{instance}] Error finding renamed episode: {e}")
                 # Continue with series processing as fallback
         
         # Force targeted mode for single-episode webhooks to prevent full series processing
         processing_mode = config.tv_webhook_processing_mode
         if episodes_data and len(episodes_data) <= 3:  # Single episode or small batch
             processing_mode = "targeted"
-            _log("INFO", f"Forcing targeted mode for {len(episodes_data)} episode(s)")
+            _log("INFO", f"[{instance}] Forcing targeted mode for {len(episodes_data)} episode(s)")
         
         tv_batch_key = f"tv:{imdb_id}"
         webhook_dict = {
@@ -279,9 +281,9 @@ async def sonarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         batcher.add_webhook(tv_batch_key, webhook_dict, 'tv')
         
         return {"status": "accepted", "message": f"Sonarr webhook queued for {tv_batch_key}"}
-        
+
     except Exception as e:
-        _log("ERROR", f"Sonarr webhook error: {e}")
+        _log("ERROR", f"[{instance}] Sonarr webhook error: {e}")
         raise HTTPException(status_code=422, detail=f"Invalid webhook: {e}")
 
 
@@ -296,8 +298,8 @@ async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         body = await request.body()
         await _verify_webhook_signature(request, body, config.radarr_webhook_secret, "X-Radarr-Signature")
         payload = await _read_payload(request)
-        _log("INFO", f"Received Radarr webhook: {payload.get('eventType', 'Unknown')}")
-        _log("DEBUG", f"Full Radarr webhook payload: {payload}")
+        _log("INFO", f"[{instance}] Received Radarr webhook: {payload.get('eventType', 'Unknown')}")
+        _log("DEBUG", f"[{instance}] Full Radarr webhook payload: {payload}")
         
         # Filter supported event types (same as Sonarr: Download, Upgrade, Rename)
         event_type = payload.get('eventType', '')
@@ -307,29 +309,29 @@ async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         # Extract movie info
         movie_data = payload.get("movie", {})
         if not movie_data:
-            _log("WARNING", "No movie data in Radarr webhook")
+            _log("WARNING", f"[{instance}] No movie data in Radarr webhook")
             return {"status": "error", "message": "No movie data"}
         
         # Get IMDb ID for batching key
         imdb_id = movie_data.get("imdbId", "").lower()
         if not imdb_id:
-            _log("WARNING", "No IMDb ID in Radarr webhook movie data")
+            _log("WARNING", f"[{instance}] No IMDb ID in Radarr webhook movie data")
             return {"status": "error", "message": "No IMDb ID"}
         
         # Get movie path and map it
         movie_path = movie_data.get("folderPath") or movie_data.get("path", "")
         if not movie_path:
-            _log("ERROR", "No movie path in Radarr webhook")
+            _log("ERROR", f"[{instance}] No movie path in Radarr webhook")
             return {"status": "error", "message": "No movie path provided"}
         
         # Map the path to container path
         container_path = path_mapper.radarr_path_to_container_path(movie_path)
-        _log("DEBUG", f"Mapped Radarr path {movie_path} -> {container_path}")
+        _log("DEBUG", f"[{instance}] Mapped Radarr path {movie_path} -> {container_path}")
         
         # CRITICAL: Verify the mapped path actually exists
         if not Path(container_path).exists():
-            _log("ERROR", f"RADARR WEBHOOK REJECTED: Mapped path does not exist: {container_path}")
-            _log("ERROR", "This prevents processing wrong movies due to path mapping issues")
+            _log("ERROR", f"[{instance}] RADARR WEBHOOK REJECTED: Mapped path does not exist: {container_path}")
+            _log("ERROR", f"[{instance}] This prevents processing wrong movies due to path mapping issues")
             return {"status": "error", "message": f"Mapped movie path does not exist: {container_path}"}
         
         # IMDb ID won't be in the path for standard Radarr folder naming — omit the check
@@ -343,13 +345,13 @@ async def radarr_webhook(request: Request, background_tasks: BackgroundTasks, de
         }
 
         movie_batch_key = f"movie:{imdb_id}"
-        _log("DEBUG", f"Adding Radarr webhook to batch: key={movie_batch_key}, movie_title={movie_data.get('title', 'Unknown')}, instance={instance}")
+        _log("DEBUG", f"[{instance}] Adding Radarr webhook to batch: key={movie_batch_key}, movie_title={movie_data.get('title', 'Unknown')}, instance={instance}")
         batcher.add_webhook(movie_batch_key, movie_webhook_data, "movie")
         
         return {"status": "success", "message": f"Radarr webhook queued for {movie_batch_key}"}
         
     except Exception as e:
-        _log("ERROR", f"Radarr webhook error: {e}")
+        _log("ERROR", f"[{instance}] Radarr webhook error: {e}")
         return {"status": "error", "message": str(e)}
 
 
@@ -568,13 +570,27 @@ async def health(dependencies: dict) -> HealthResponse:
     except Exception as e:
         # If movie processor isn't available, skip database health check
         _log("DEBUG", f"Skipping Radarr database health check: {e}")
-    
+
+    # Per-instance status for every configured Radarr/Sonarr — not just the
+    # default instance the block above checks. This is what /setup already
+    # shows as connected/disconnected badges; /health was never updated to
+    # report the same thing when multi-instance landed, so a dual-instance
+    # user had no way to see a second instance's connection state from here.
+    registry = dependencies.get("registry")
+    instances = None
+    if registry:
+        instances = {
+            "radarr": registry.all_radarr_statuses(),
+            "sonarr": registry.all_sonarr_statuses(),
+        }
+
     return HealthResponse(
         status=overall_status,
         version=version,
         uptime=str(uptime),
         database_status=db_status,
-        radarr_database=radarr_db_health
+        radarr_database=radarr_db_health,
+        instances=instances,
     )
 
 
@@ -818,7 +834,7 @@ async def manual_scan(background_tasks: BackgroundTasks, path: Optional[str] = N
         sonarr_path_index = {}
 
         def _unc_basename(p):
-            """Return the last path component of p, handling both POSIX and
+            r"""Return the last path component of p, handling both POSIX and
             Windows/UNC paths (pathlib on Linux treats backslash as a literal
             character, so Path(r'\\NAS\share\Movie (2013)').name returns the
             whole string rather than 'Movie (2013)')."""
@@ -2988,6 +3004,79 @@ async def get_populate_status():
 # Initialize global populate status
 _populate_status = {"running": False, "completed": False}
 
+# Instance names the wizard has written to .env this process, but that aren't
+# live yet because chronarr-core hasn't been restarted to pick them up. The
+# InstanceRegistry alone can't catch "save the same new instance twice" —
+# from its point of view neither save happened. This resets naturally on the
+# next real restart, which is exactly when it should, since by then the
+# registry knows about them for real.
+_pending_wizard_instances: set = set()
+
+
+def _wizard_test_api(url: str, api_key: str) -> dict:
+    """Hit Radarr/Sonarr's system status endpoint to check the URL+key work.
+
+    Both apps expose the same path, so one function covers either. Returns
+    {"success": True} or {"success": False, "error": "..."} — never raises,
+    the wizard endpoints turn a failure into an HTTP error themselves.
+    """
+    try:
+        base = url.rstrip("/")
+        resp = requests.get(f"{base}/api/v3/system/status", headers={"X-Api-Key": api_key}, timeout=10)
+        resp.raise_for_status()
+        return {"success": True}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+def _wizard_fetch_root_folders(url: str, api_key: str) -> list:
+    """Ask Radarr/Sonarr for its configured root folders.
+
+    Both apps expose the same path. Only called once the API test above has
+    already passed, so a failure here is worth logging but not worth
+    failing the whole test over — the user typed a working URL+key, root
+    folders are a convenience on top of that, not a requirement.
+    """
+    try:
+        base = url.rstrip("/")
+        resp = requests.get(f"{base}/api/v3/rootfolder", headers={"X-Api-Key": api_key}, timeout=10)
+        resp.raise_for_status()
+        return [rf["path"] for rf in resp.json() if rf.get("path")]
+    except Exception as e:
+        _log("WARNING", f"Setup wizard: could not fetch root folders from {url}: {e}")
+        return []
+
+
+def _wizard_test_db(media_type, db_type, db_host, db_port, db_name, db_user, db_password, db_path, label="") -> dict:
+    """Try building a direct DB client — its constructor tests the connection itself.
+
+    Same {"success": ...} shape as _wizard_test_api(). The client is thrown
+    away either way; this only exists to find out if it *would* connect.
+    `label` (e.g. "sonarr_strm (testing)") is just for the log lines this
+    produces — the instance doesn't exist yet, so there's nothing to look up.
+    """
+    try:
+        if media_type == "radarr":
+            from clients.radarr_db_client import RadarrDbClient as DbClient
+        else:
+            from clients.sonarr_db_client import SonarrDbClient as DbClient
+
+        if db_type == "sqlite":
+            DbClient(db_type="sqlite", db_path=db_path, instance_name=label)
+        else:
+            DbClient(
+                db_type=db_type,
+                db_host=db_host,
+                db_port=db_port or 5432,
+                db_name=db_name,
+                db_user=db_user,
+                db_password=db_password,
+                instance_name=label,
+            )
+        return {"success": True}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
 
 def register_routes(app, dependencies: dict):
     """Register all routes. Webhook routes are registered per-instance dynamically."""
@@ -3063,6 +3152,298 @@ def register_routes(app, dependencies: dict):
             for inst in cfg.sonarr_instances
         ]
         return {"radarr": radarr_list, "sonarr": sonarr_list}
+
+    @app.get("/api/wizard/instance-details")
+    async def _wizard_instance_details(media_type: str, name: str = ""):
+        """Look up one instance's full config, for pre-filling the wizard's Edit form.
+
+        Returns the same fields the wizard form collects (url, api_key,
+        root_folders, paths, DB block) straight from the live config object
+        — no need to re-read or re-parse the env files, config already has
+        it resolved. Includes the API key and DB password: this endpoint
+        exists specifically so Edit doesn't make someone retype secrets
+        they've already set, and they're already visible to anyone who can
+        reach /api/wizard/env-backup anyway.
+        """
+        cfg = dependencies.get("config")
+        if not cfg:
+            raise HTTPException(status_code=503, detail="Config not initialised")
+
+        if media_type not in ("radarr", "sonarr"):
+            raise HTTPException(status_code=400, detail="media_type must be 'radarr' or 'sonarr'")
+
+        instance_name = f"{media_type}_{name.lower()}" if name else media_type
+        instances = cfg.radarr_instances if media_type == "radarr" else cfg.sonarr_instances
+        match = next((i for i in instances if i.name == instance_name), None)
+        if not match:
+            raise HTTPException(status_code=404, detail=f"No instance named '{instance_name}' found")
+
+        return {
+            "media_type": media_type,
+            "name": name,
+            "url": match.url,
+            "api_key": match.api_key,
+            "root_folders": match.root_folders,
+            "movie_paths": getattr(match, "movie_paths", None),
+            "tv_paths": getattr(match, "tv_paths", None),
+            "db_type": match.db_type or None,
+            "db_host": match.db_host or None,
+            "db_port": match.db_port or None,
+            "db_name": match.db_name or None,
+            "db_user": match.db_user or None,
+            "db_password": match.db_password or None,
+            "db_path": match.db_path or None,
+        }
+
+    @app.post("/api/wizard/test-connection")
+    async def _wizard_test_connection(payload: WizardConnectionTestRequest):
+        """Setup wizard: try connecting with whatever the user has typed so far.
+
+        Doesn't write anything or touch the registry — just reports whether
+        the API URL+key and/or the DB block actually work, so the wizard
+        can show a real pass/fail before the user hits Save.
+        """
+        label = f"{payload.media_type}_{payload.name.lower()} (testing)" if payload.name else f"{payload.media_type} (testing)"
+        result = {}
+        if payload.url and payload.api_key:
+            result["api"] = _wizard_test_api(payload.url, payload.api_key)
+            if result["api"]["success"]:
+                result["api"]["root_folders"] = _wizard_fetch_root_folders(payload.url, payload.api_key)
+        if payload.db_type:
+            result["db"] = _wizard_test_db(
+                payload.media_type, payload.db_type, payload.db_host, payload.db_port,
+                payload.db_name, payload.db_user, payload.db_password, payload.db_path,
+                label=label,
+            )
+        return result
+
+    @app.post("/api/wizard/save-instance")
+    async def _wizard_save_instance(payload: WizardSaveInstanceRequest):
+        """Setup wizard: validate, then write one instance to .env / .env.secrets.
+
+        Either every check below passes and both files get written, or
+        nothing gets written at all — no half-applied instance sitting in
+        the config. Restarting chronarr-core is still required to actually
+        pick the new instance up; that limitation is explained in the docs
+        rather than hidden from the caller.
+        """
+        from config.env_writer import (
+            build_env_updates, upsert_env_file, validate_name_segment, InstanceNameError, backup_env_files,
+        )
+
+        registry = dependencies.get("registry")
+        if not registry:
+            raise HTTPException(status_code=503, detail="Registry not initialised")
+
+        if payload.media_type not in ("radarr", "sonarr"):
+            raise HTTPException(status_code=400, detail="media_type must be 'radarr' or 'sonarr'")
+
+        # Check against what's actually running, not just what's in the file —
+        # someone may have hand-edited .env since the last restart.
+        existing_names = set(registry.radarr_names) | set(registry.sonarr_names)
+
+        if payload.name:
+            try:
+                name_segment = validate_name_segment(
+                    payload.name, existing_names, payload.media_type, require_exists=payload.edit_existing
+                )
+            except InstanceNameError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+        else:
+            # Empty name means "the default instance" — still needs the same
+            # existence check as a named one, just inline since there's no
+            # segment to run through validate_name_segment for.
+            name_segment = ""
+            default_exists = payload.media_type in existing_names
+            if payload.edit_existing and not default_exists:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"No default {payload.media_type} instance exists to edit.",
+                )
+            if not payload.edit_existing and default_exists:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"The default {payload.media_type} instance is already configured. "
+                        "Give this one a name to add it as an additional instance instead."
+                    ),
+                )
+
+        instance_name = f"{payload.media_type}_{name_segment.lower()}" if name_segment else payload.media_type
+        # The pending-instance guard only matters for adds — it exists to
+        # stop the same brand-new name being saved twice before a restart.
+        # Editing an already-live instance repeatedly before restarting is
+        # the normal workflow (fix a typo, test again), not a collision.
+        if not payload.edit_existing and instance_name in _pending_wizard_instances:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"'{instance_name}' was already saved by the wizard this session but hasn't "
+                    "gone live yet — restart chronarr-core to pick it up before adding it again."
+                ),
+            )
+
+        if payload.db_type == "sqlite" and payload.db_path and not Path(payload.db_path).exists():
+            raise HTTPException(
+                status_code=400,
+                detail=f"SQLite path '{payload.db_path}' doesn't exist in this container — check the volume mount",
+            )
+
+        if not payload.force:
+            api_result = _wizard_test_api(payload.url, payload.api_key)
+            if not api_result["success"]:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Connection test failed: {api_result['error']}. Save again with force=true to skip this check.",
+                )
+            if payload.db_type:
+                db_result = _wizard_test_db(
+                    payload.media_type, payload.db_type, payload.db_host, payload.db_port,
+                    payload.db_name, payload.db_user, payload.db_password, payload.db_path,
+                    label=f"{instance_name} (pre-save test)",
+                )
+                if not db_result["success"]:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Database connection test failed: {db_result['error']}. Save again with force=true to skip this check.",
+                    )
+
+        fields = payload.dict(exclude={"media_type", "name", "force", "edit_existing"})
+        env_updates, secret_updates = build_env_updates(payload.media_type, name_segment, fields)
+
+        # Cheap insurance — every wizard write gets a snapshot of what the
+        # files looked like just before, so a bad save is never a dead end.
+        # Same format /api/wizard/env-backup produces, restorable the same way.
+        backup_env_files(Path(".env"), Path(".env.secrets"), Path("backups"))
+
+        env_changed = upsert_env_file(Path(".env"), env_updates, instance_label=instance_name)
+        secrets_changed = upsert_env_file(Path(".env.secrets"), secret_updates, instance_label=instance_name)
+        _pending_wizard_instances.add(instance_name)
+
+        _log("INFO", f"Setup wizard: wrote instance '{instance_name}' to .env/.env.secrets — restart required to apply")
+
+        return {
+            "instance_name": instance_name,
+            "webhook_path": f"/{instance_name}/webhook",
+            "env_changed": env_changed,
+            "secrets_changed": secrets_changed,
+            "restart_required": True,
+            "restart_reason": (
+                "chronarr-core builds its instance registry once at startup — "
+                "restart it to pick up this instance."
+            ),
+        }
+
+    @app.post("/api/wizard/delete-instance")
+    async def _wizard_delete_instance(payload: WizardDeleteInstanceRequest):
+        """Setup wizard: remove one instance's env vars from .env / .env.secrets.
+
+        Same "must exist" name validation as editing, same automatic
+        pre-write snapshot as every other wizard write. Removing the vars
+        doesn't remove the instance from Docker's own baked-in environment
+        (if it was there before, e.g. present when the container was
+        created) — restart_reason says so explicitly rather than implying
+        a restart alone is always enough.
+        """
+        from config.env_writer import (
+            remove_instance_keys, validate_name_segment, InstanceNameError, backup_env_files,
+        )
+
+        registry = dependencies.get("registry")
+        if not registry:
+            raise HTTPException(status_code=503, detail="Registry not initialised")
+
+        if payload.media_type not in ("radarr", "sonarr"):
+            raise HTTPException(status_code=400, detail="media_type must be 'radarr' or 'sonarr'")
+
+        existing_names = set(registry.radarr_names) | set(registry.sonarr_names)
+
+        if payload.name:
+            try:
+                name_segment = validate_name_segment(payload.name, existing_names, payload.media_type, require_exists=True)
+            except InstanceNameError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+        else:
+            name_segment = ""
+            if payload.media_type not in existing_names:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"No default {payload.media_type} instance exists to delete.",
+                )
+
+        instance_name = f"{payload.media_type}_{name_segment.lower()}" if name_segment else payload.media_type
+        prefix = f"{payload.media_type.upper()}_{name_segment}_" if name_segment else f"{payload.media_type.upper()}_"
+
+        backup_env_files(Path(".env"), Path(".env.secrets"), Path("backups"))
+
+        env_changed = remove_instance_keys(Path(".env"), prefix, instance_label=instance_name)
+        secrets_changed = remove_instance_keys(Path(".env.secrets"), prefix, instance_label=instance_name)
+        _pending_wizard_instances.discard(instance_name)
+
+        _log("INFO", f"Setup wizard: removed instance '{instance_name}' from .env/.env.secrets — restart required to apply")
+
+        return {
+            "instance_name": instance_name,
+            "env_changed": env_changed,
+            "secrets_changed": secrets_changed,
+            "restart_required": True,
+            "restart_reason": (
+                "chronarr-core builds its instance registry once at startup. A plain restart "
+                "isn't always enough — if this instance's env vars were present when the "
+                "container was first created, Docker's own env_file injection baked them into "
+                "the container and a restart alone won't drop them. Recreate the container "
+                "(docker compose up -d --force-recreate, or down + up) to be sure they're gone."
+            ),
+        }
+
+    @app.get("/api/wizard/env-backup")
+    async def _wizard_env_backup():
+        """Download the current .env + .env.secrets as one backup file.
+
+        A literal snapshot of both files' raw text, comments and all —
+        restoring it writes them back byte-for-byte. This file contains real
+        API keys and database passwords in plain text, same as .env.secrets
+        itself does; store it somewhere as secure as that file.
+        """
+        from config.env_writer import read_env_files
+        from version_utils import get_version
+
+        content = read_env_files(Path(".env"), Path(".env.secrets"))
+        payload = {
+            "chronarr_version": get_version(),
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            **content,
+        }
+        filename = f"chronarr-env-backup-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}.json"
+        return Response(
+            content=json.dumps(payload, indent=2),
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    @app.post("/api/wizard/env-restore")
+    async def _wizard_env_restore(payload: WizardEnvRestoreRequest):
+        """Restore .env + .env.secrets from a backup produced by /api/wizard/env-backup.
+
+        The current files are snapshotted first, the same as every wizard
+        save already does — restoring the wrong file, or one from an
+        incompatible version, isn't a dead end either.
+        """
+        from config.env_writer import write_env_files, backup_env_files
+
+        pre_restore_backup = backup_env_files(Path(".env"), Path(".env.secrets"), Path("backups"))
+        write_env_files(Path(".env"), Path(".env.secrets"), payload.env, payload.env_secrets)
+
+        _log("INFO", f"Setup wizard: restored .env/.env.secrets from an uploaded backup (pre-restore snapshot: {pre_restore_backup})")
+
+        return {
+            "restored": True,
+            "pre_restore_backup": str(pre_restore_backup) if pre_restore_backup else None,
+            "restart_required": True,
+            "restart_reason": (
+                "Restored files only take effect after chronarr-core restarts and reloads its environment."
+            ),
+        }
 
     @app.get("/health")
     async def _health() -> HealthResponse:

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -66,9 +66,22 @@ def map_source_to_description(source: str) -> str:
     elif "omdb:" in source_lower:
         return "OMDb Release"
     
-    # Sonarr sources
-    elif "sonarr:" in source_lower:
+    # Sonarr sources — same granularity as Radarr above. This used to be a
+    # single catch-all ("Sonarr API") for every sonarr: source regardless of
+    # whether it actually came from direct DB history, the aired-date
+    # fallback, or a file date — genuinely misleading once instances started
+    # using direct DB access, since a DB-sourced date would still display
+    # as "Sonarr API".
+    elif "sonarr:db.history.import" in source_lower or "sonarr:db.bulk.import" in source_lower:
+        return "Sonarr Import History"
+    elif "sonarr:db.file.dateadded" in source_lower:
+        return "Sonarr File Date"
+    elif "sonarr:aired_fallback" in source_lower:
+        return "Sonarr Air Date"
+    elif "sonarr:api.import_history" in source_lower:
         return "Sonarr API"
+    elif "sonarr:" in source_lower:
+        return "Sonarr"
 
     # Manual and other sources
     elif "manual" in source_lower:
@@ -681,10 +694,18 @@ async def update_episode_date(dependencies: dict, imdb_id: str, season: int, epi
         import json
         import os
         
-        # Get core container connection details
-        core_host = os.environ.get("CORE_API_HOST", "chronarr")
-        core_port = os.environ.get("CORE_API_PORT", "8080")
-        
+        # Where THIS (web) container reaches core — deliberately not named
+        # CORE_API_HOST/CORE_API_PORT, which are a different pre-existing
+        # pair that control what interface core's own uvicorn binds to
+        # (config/settings.py, main.py). Those two settings look like they
+        # should be the same thing and aren't — setting CORE_API_HOST to a
+        # specific hostname to fix cross-stack DNS collisions (two chronarr
+        # deployments sharing a Docker network) breaks core's own healthcheck
+        # instead, since it stops binding to 0.0.0.0. Learned this the hard
+        # way once already; keep these names distinct.
+        core_host = os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = os.environ.get("CORE_INTERNAL_PORT", "8080")
+
         # Call core container to update NFO file
         nfo_update_url = f"http://{core_host}:{core_port}/api/episodes/{imdb_id}/{season}/{episode}/update-nfo"
         
@@ -1296,7 +1317,7 @@ async def get_episode_date_options(dependencies: dict, imdb_id: str, season: int
     }
 
 
-def _populate_worker_process(media_type: str, status_file: str):
+def _populate_worker_process(media_type: str, status_file: str, instance: str = "all"):
     """
     Worker process that runs database population in complete isolation.
     Runs in separate process - keeps web interface responsive.
@@ -1321,6 +1342,7 @@ def _populate_worker_process(media_type: str, status_file: str):
     status = {
         "running": True,
         "media_type": media_type,
+        "instance": instance,
         "start_time": datetime.now().isoformat(),
         "movies": {"status": "pending", "stats": None},
         "tv": {"status": "pending", "stats": None},
@@ -1357,9 +1379,38 @@ def _populate_worker_process(media_type: str, status_file: str):
                 merged['skipped_items'].extend(s.get('skipped_items', []))
             return merged
 
-        print(f"INFO: [Worker Process] Starting database population: {media_type}")
+        print(f"INFO: [Worker Process] Starting database population: {media_type} (instance: {instance})")
         radarr_instances = config.radarr_instances
         sonarr_instances = config.sonarr_instances
+
+        # A specific instance narrows the run to just that one, regardless of
+        # which media_type was picked — the instance's own type (it can only
+        # be a Radarr or a Sonarr instance) decides what actually runs. "all"
+        # (the default) keeps the original behavior: every configured
+        # instance of whichever media_type was selected.
+        if instance and instance != "all":
+            matched_radarr = [i for i in radarr_instances if i.name == instance]
+            matched_sonarr = [i for i in sonarr_instances if i.name == instance]
+            if not matched_radarr and not matched_sonarr:
+                known = [i.name for i in radarr_instances] + [i.name for i in sonarr_instances]
+                raise ValueError(f"Instance '{instance}' not found. Configured instances: {known}")
+            radarr_instances = matched_radarr
+            sonarr_instances = matched_sonarr
+            # The instance's own type is authoritative — a Radarr instance can
+            # only ever mean movies, a Sonarr instance only TV. Override
+            # whatever media_type the caller sent so a stale/mismatched value
+            # (e.g. the UI's Media Type dropdown left on the wrong setting)
+            # can't silently produce a no-op run: without this, an instance
+            # narrowed to (say) only Sonarr combined with media_type="movies"
+            # would iterate an empty radarr_instances list, skip the tv block
+            # entirely, and finish "successfully" having populated nothing.
+            effective_media_type = "movies" if matched_radarr else "tv"
+            if effective_media_type != media_type:
+                print(f"INFO: [Worker Process] media_type '{media_type}' overridden to '{effective_media_type}' — instance '{instance}' determines its own type")
+            media_type = effective_media_type
+            status["media_type"] = media_type
+            print(f"INFO: [Worker Process] Narrowed to instance '{instance}'")
+
         print(f"INFO: [Worker Process] Radarr instances: {[i.name for i in radarr_instances]}")
         print(f"INFO: [Worker Process] Sonarr instances: {[i.name for i in sonarr_instances]}")
 
@@ -1429,7 +1480,7 @@ def _populate_worker_process(media_type: str, status_file: str):
         update_status(status)
 
 
-async def populate_database(background_tasks: BackgroundTasks, media_type: str = "both", dependencies: dict = None):
+async def populate_database(background_tasks: BackgroundTasks, media_type: str = "both", dependencies: dict = None, instance: str = "all"):
     """
     Populate Chronarr database from Radarr/Sonarr sources in separate process.
     This keeps the web interface responsive during population.
@@ -1438,6 +1489,8 @@ async def populate_database(background_tasks: BackgroundTasks, media_type: str =
         background_tasks: FastAPI background tasks (not used - kept for compatibility)
         media_type: Type of media to populate ("movies", "tv", or "both")
         dependencies: Dictionary with dependencies (not used in multiprocessing mode)
+        instance: Specific instance name to populate (e.g. "sonarr_4k"), or "all"
+            (default) for every configured instance of the given media_type
 
     Returns:
         Status message indicating population has started
@@ -1458,6 +1511,7 @@ async def populate_database(background_tasks: BackgroundTasks, media_type: str =
     initial_status = {
         "running": True,
         "media_type": media_type,
+        "instance": instance,
         "start_time": datetime.now().isoformat(),
         "movies": {"status": "pending", "stats": None},
         "tv": {"status": "pending", "stats": None},
@@ -1475,16 +1529,17 @@ async def populate_database(background_tasks: BackgroundTasks, media_type: str =
     # Start population in separate process
     _populate_process = multiprocessing.Process(
         target=_populate_worker_process,
-        args=(media_type, POPULATE_STATUS_FILE),
+        args=(media_type, POPULATE_STATUS_FILE, instance),
         daemon=False  # Keep process alive even if parent exits
     )
     _populate_process.start()
 
-    _log("INFO", f"Database population process started for: {media_type}")
+    _log("INFO", f"Database population process started for: {media_type} (instance: {instance})")
     return {
         "status": "started",
         "media_type": media_type,
-        "message": f"Database population started for {media_type}"
+        "instance": instance,
+        "message": f"Database population started for {media_type}" + (f" ({instance})" if instance != "all" else "")
     }
 
 
@@ -1909,8 +1964,8 @@ def register_web_routes(app, dependencies):
         import socket
         
         # Get core container URL
-        core_host = os.environ.get("CORE_API_HOST", "chronarr")
-        core_port = os.environ.get("CORE_API_PORT", "8080")
+        core_host = os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = os.environ.get("CORE_INTERNAL_PORT", "8080")
         
         # Forward query parameters from the request
         query_string = str(request.url.query) if request.url.query else ""
@@ -1946,8 +2001,8 @@ def register_web_routes(app, dependencies):
         import socket
 
         # Get core container URL
-        core_host = os.environ.get("CORE_API_HOST", "chronarr")
-        core_port = os.environ.get("CORE_API_PORT", "8080")
+        core_host = os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = os.environ.get("CORE_INTERNAL_PORT", "8080")
         core_url = f"http://{core_host}:{core_port}/manual/cleanup-orphaned"
 
         try:
@@ -2066,8 +2121,8 @@ def register_web_routes(app, dependencies):
         import socket
         
         # Get core container connection details
-        core_host = os.environ.get("CORE_API_HOST", "chronarr")
-        core_port = os.environ.get("CORE_API_PORT", "8080")
+        core_host = os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = os.environ.get("CORE_INTERNAL_PORT", "8080")
         
         try:
             # Call core container's detailed scan status endpoint
@@ -2505,10 +2560,12 @@ def register_database_admin_routes(app, dependencies):
         try:
             data = await request.json()
             media_type = data.get("media_type", "both")
+            instance = data.get("instance", "all")
         except Exception:
-            # Fallback to query parameter if JSON parsing fails
+            # Fallback to query parameters if JSON parsing fails
             media_type = request.query_params.get("media_type", "both")
-        return await populate_database(background_tasks, media_type, dependencies)
+            instance = request.query_params.get("instance", "all")
+        return await populate_database(background_tasks, media_type, dependencies, instance)
 
     _log("DEBUG", "/admin/populate-database registered")
 
@@ -2527,8 +2584,8 @@ def register_database_admin_routes(app, dependencies):
         import os
         import socket
 
-        core_host = os.environ.get("CORE_API_HOST", "chronarr")
-        core_port = os.environ.get("CORE_API_PORT", "8080")
+        core_host = os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = os.environ.get("CORE_INTERNAL_PORT", "8080")
         core_url = f"http://{core_host}:{core_port}/api/instances"
 
         try:
@@ -2539,6 +2596,117 @@ def register_database_admin_routes(app, dependencies):
             raise HTTPException(status_code=e.code, detail=f"Core API error: {e.reason}")
         except (urllib.error.URLError, socket.timeout) as e:
             raise HTTPException(status_code=503, detail=f"Could not reach core container: {e}")
+
+    @app.get("/api/wizard/instance-details")
+    async def wizard_instance_details(request: Request):
+        """Proxy an instance's full config (for pre-filling Edit) from the core container."""
+        import urllib.request
+        import urllib.error
+        import json
+        import os
+        import socket
+
+        core_host = os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = os.environ.get("CORE_INTERNAL_PORT", "8080")
+        query = request.url.query
+        core_url = f"http://{core_host}:{core_port}/api/wizard/instance-details" + (f"?{query}" if query else "")
+
+        try:
+            req = urllib.request.Request(core_url)
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode("utf-8")
+            try:
+                detail = json.loads(detail).get("detail", detail)
+            except ValueError:
+                pass
+            raise HTTPException(status_code=e.code, detail=detail)
+        except (urllib.error.URLError, socket.timeout) as e:
+            raise HTTPException(status_code=503, detail=f"Could not reach core container: {e}")
+
+    async def _proxy_post_to_core(path: str, body: dict):
+        """Forward a wizard POST to the core container and hand back its response as-is.
+
+        Same host/port lookup and error handling as the /api/instances GET
+        proxy above — core owns the InstanceRegistry and the env files, so
+        every wizard write goes through it rather than the web container
+        touching config directly.
+        """
+        import urllib.request
+        import urllib.error
+        import json as _json
+        import os as _os
+        import socket
+
+        core_host = _os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = _os.environ.get("CORE_INTERNAL_PORT", "8080")
+        core_url = f"http://{core_host}:{core_port}{path}"
+
+        data = _json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(core_url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return _json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            # Core sends back a real error detail (bad name, failed test, etc.) —
+            # pass it through instead of flattening everything to a generic 500.
+            detail = e.read().decode("utf-8")
+            try:
+                detail = _json.loads(detail).get("detail", detail)
+            except ValueError:
+                pass
+            raise HTTPException(status_code=e.code, detail=detail)
+        except (urllib.error.URLError, socket.timeout) as e:
+            raise HTTPException(status_code=503, detail=f"Could not reach core container: {e}")
+
+    @app.post("/api/wizard/test-connection")
+    async def wizard_test_connection(request: Request):
+        """Proxy the wizard's connection test to the core container."""
+        return await _proxy_post_to_core("/api/wizard/test-connection", await request.json())
+
+    @app.post("/api/wizard/save-instance")
+    async def wizard_save_instance(request: Request):
+        """Proxy the wizard's save (writes .env/.env.secrets) to the core container."""
+        return await _proxy_post_to_core("/api/wizard/save-instance", await request.json())
+
+    @app.post("/api/wizard/delete-instance")
+    async def wizard_delete_instance(request: Request):
+        """Proxy the wizard's delete (removes .env/.env.secrets entries) to the core container."""
+        return await _proxy_post_to_core("/api/wizard/delete-instance", await request.json())
+
+    @app.get("/api/wizard/env-backup")
+    async def wizard_env_backup():
+        """Proxy the .env/.env.secrets backup download from the core container.
+
+        Passed through as raw bytes with the same Content-Disposition header
+        core set, rather than re-parsed as JSON — this is a file download,
+        not a data endpoint.
+        """
+        import urllib.request
+        import urllib.error
+        import os as _os
+        import socket
+
+        core_host = _os.environ.get("CORE_INTERNAL_HOST", "chronarr")
+        core_port = _os.environ.get("CORE_INTERNAL_PORT", "8080")
+        core_url = f"http://{core_host}:{core_port}/api/wizard/env-backup"
+
+        try:
+            req = urllib.request.Request(core_url)
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                body = resp.read()
+                disposition = resp.headers.get("Content-Disposition", "attachment; filename=chronarr-env-backup.json")
+                return Response(content=body, media_type="application/json", headers={"Content-Disposition": disposition})
+        except urllib.error.HTTPError as e:
+            raise HTTPException(status_code=e.code, detail=e.reason)
+        except (urllib.error.URLError, socket.timeout) as e:
+            raise HTTPException(status_code=503, detail=f"Could not reach core container: {e}")
+
+    @app.post("/api/wizard/env-restore")
+    async def wizard_env_restore(request: Request):
+        """Proxy the wizard's env-file restore (overwrites .env/.env.secrets) to core."""
+        return await _proxy_post_to_core("/api/wizard/env-restore", await request.json())
 
     @app.get("/setup")
     async def setup_page():

--- a/chronarr-web/static/index.html
+++ b/chronarr-web/static/index.html
@@ -444,6 +444,15 @@
                                     <option value="tv">TV Shows Only</option>
                                 </select>
                             </div>
+                            <div class="form-group">
+                                <label>Instance:</label>
+                                <select id="populate-instance" required>
+                                    <option value="all">All Instances</option>
+                                </select>
+                                <p class="field-hint" style="font-size: 0.78rem; color: var(--text-muted); margin-top: 0.25rem;">
+                                    Picking a specific instance populates only that one and sets Media Type for you (a Radarr instance is always movies, a Sonarr instance always TV).
+                                </p>
+                            </div>
                             <button type="submit" class="btn btn-primary">
                                 <i class="fas fa-play"></i> Start Population
                             </button>

--- a/chronarr-web/static/js/app.js
+++ b/chronarr-web/static/js/app.js
@@ -54,7 +54,7 @@ function switchTab(tabName) {
         case 'movies': loadMovies(); break;
         case 'tv': loadSeries(); break;
         case 'reports': loadReport(); break;
-        case 'tools': loadDetailedStats(); break;
+        case 'tools': loadDetailedStats(); loadPopulateInstanceOptions(); break;
     }
 }
 
@@ -139,6 +139,10 @@ function initializeEventListeners() {
     document.getElementById('bulk-update-form').addEventListener('submit', handleBulkUpdate);
     document.getElementById('manual-scan-form').addEventListener('submit', handleManualScan);
     document.getElementById('populate-form').addEventListener('submit', handlePopulateDatabase);
+    const populateInstanceSelect = document.getElementById('populate-instance');
+    if (populateInstanceSelect) {
+        populateInstanceSelect.addEventListener('change', syncPopulateMediaTypeToInstance);
+    }
 }
 
 // API calls
@@ -1867,10 +1871,86 @@ async function bulkDeleteSelected() {
 // Database Population Functions
 // ---------------------------
 
+// Fills the Instance dropdown on the Populate Database card from the same
+// /api/instances data the sidebar already uses — "All Instances" plus one
+// entry per configured Radarr/Sonarr instance, grouped by type so it's
+// obvious which is which once there's more than a couple.
+async function loadPopulateInstanceOptions() {
+    const select = document.getElementById('populate-instance');
+    if (!select) return;
+
+    try {
+        const data = await apiCall('/api/instances');
+        const radarrNames = (data.radarr || []).map(i => i.name);
+        const sonarrNames = (data.sonarr || []).map(i => i.name);
+
+        // Keep "All Instances", drop everything else and rebuild — this
+        // gets called every time the Tools tab is opened, so it has to be
+        // safe to run repeatedly without piling up duplicate options.
+        select.innerHTML = '<option value="all">All Instances</option>';
+
+        if (radarrNames.length) {
+            const group = document.createElement('optgroup');
+            group.label = 'Radarr';
+            radarrNames.forEach(name => {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                opt.dataset.mediaType = 'movies';
+                group.appendChild(opt);
+            });
+            select.appendChild(group);
+        }
+
+        if (sonarrNames.length) {
+            const group = document.createElement('optgroup');
+            group.label = 'Sonarr';
+            sonarrNames.forEach(name => {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                opt.dataset.mediaType = 'tv';
+                group.appendChild(opt);
+            });
+            select.appendChild(group);
+        }
+
+        // Reset in case the last selection here no longer exists (e.g. an
+        // instance was deleted since this was last loaded).
+        syncPopulateMediaTypeToInstance();
+    } catch (error) {
+        console.error('Failed to load instances for populate dropdown:', error);
+        // Leave just "All Instances" — populate still works, just without
+        // the ability to target a single instance until this loads.
+    }
+}
+
+function syncPopulateMediaTypeToInstance() {
+    const instanceSelect = document.getElementById('populate-instance');
+    const mediaTypeSelect = document.getElementById('populate-media-type');
+    if (!instanceSelect || !mediaTypeSelect) return;
+
+    const selectedOption = instanceSelect.options[instanceSelect.selectedIndex];
+    const mediaType = selectedOption ? selectedOption.dataset.mediaType : null;
+
+    if (instanceSelect.value !== 'all' && mediaType) {
+        // A specific instance can only ever be one media type — a Radarr
+        // instance is movies, a Sonarr instance is TV. Lock the Media Type
+        // dropdown to match instead of making the user keep the two in sync
+        // by hand (picking the wrong one used to silently populate nothing).
+        mediaTypeSelect.value = mediaType;
+        mediaTypeSelect.disabled = true;
+    } else {
+        mediaTypeSelect.disabled = false;
+    }
+}
+
 async function handlePopulateDatabase(event) {
     event.preventDefault();
 
     const mediaType = document.getElementById('populate-media-type').value;
+    const instanceSelect = document.getElementById('populate-instance');
+    const instance = instanceSelect ? instanceSelect.value : 'all';
 
     // Validate input
     if (!mediaType) {
@@ -1879,7 +1959,8 @@ async function handlePopulateDatabase(event) {
     }
 
     // Confirm with user
-    const confirmMsg = `Are you sure you want to populate the database with ${mediaType}? This will query Radarr/Sonarr and may take several minutes.`;
+    const target = instance !== 'all' ? `instance '${instance}'` : `${mediaType}`;
+    const confirmMsg = `Are you sure you want to populate the database with ${target}? This will query Radarr/Sonarr and may take several minutes.`;
     if (!confirm(confirmMsg)) {
         return;
     }
@@ -1890,7 +1971,7 @@ async function handlePopulateDatabase(event) {
 
         // Start the population
         showToast('🚀 Starting database population...', 'info');
-        const response = await fetch(`/admin/populate-database?media_type=${mediaType}`, {
+        const response = await fetch(`/admin/populate-database?media_type=${mediaType}&instance=${encodeURIComponent(instance)}`, {
             method: 'POST',
             credentials: 'include'
         });

--- a/clients/radarr_client.py
+++ b/clients/radarr_client.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode, urljoin
 from urllib.request import Request as UrlRequest, urlopen
 from urllib.error import URLError, HTTPError
 
-from core.logging import _log
+from core.logging import _log as _log_raw
 
 # Import path mapper for proper path handling
 try:
@@ -55,11 +55,12 @@ class RadarrClient:
         'usenet', 'torrent', 'radarr', 'completed', 'processing'
     ]
     
-    def __init__(self, base_url: str, api_key: str, timeout: int = 45, retries: int = 3):
+    def __init__(self, base_url: str, api_key: str, timeout: int = 45, retries: int = 3, instance_name: str = ""):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.timeout = timeout
         self.retries = max(0, retries)
+        self.instance_name = instance_name
         
         # Initialize database client - REQUIRED for operation
         self.db_client = None
@@ -67,14 +68,22 @@ class RadarrClient:
             try:
                 self.db_client = RadarrDbClient.from_env()
                 if self.db_client:
-                    _log("INFO", "✅ DATABASE ONLY MODE: Direct database access enabled")
+                    self._log("INFO", "✅ DATABASE ONLY MODE: Direct database access enabled")
                 else:
-                    _log("ERROR", "❌ DATABASE ONLY MODE: Database configuration required - API mode disabled")
+                    self._log("ERROR", "❌ DATABASE ONLY MODE: Database configuration required - API mode disabled")
             except Exception as e:
-                _log("ERROR", f"❌ DATABASE ONLY MODE: Failed to initialize database client: {e}")
+                self._log("ERROR", f"❌ DATABASE ONLY MODE: Failed to initialize database client: {e}")
                 self.db_client = None
         else:
-            _log("ERROR", "❌ DATABASE ONLY MODE: RadarrDbClient not available - check dependencies")
+            self._log("ERROR", "❌ DATABASE ONLY MODE: RadarrDbClient not available - check dependencies")
+
+    def _log(self, level: str, message: str) -> None:
+        """Log with this client's instance name prefixed, so a log line is
+        traceable back to which Radarr/Sonarr instance it came from — matters
+        as soon as there's more than one of the same type configured.
+        """
+        prefix = f"[{self.instance_name}] " if self.instance_name else ""
+        _log_raw(level, f"{prefix}{message}")
 
     def _get(self, path: str, params: Dict[str, Any] = None) -> Optional[Any]:
         """Make GET request to Radarr API with retries"""
@@ -93,7 +102,7 @@ class RadarrClient:
                 if params:
                     url = url + ("&" if "?" in url else "?") + urlencode(params)
                 
-                _log("DEBUG", f"Radarr API Request: {url}")
+                self._log("DEBUG", f"Radarr API Request: {url}")
                 req = UrlRequest(url, headers={"Accept": "application/json"})
                 
                 with urlopen(req, timeout=self.timeout) as resp:
@@ -103,34 +112,34 @@ class RadarrClient:
                     
             except (URLError, HTTPError, json.JSONDecodeError) as e:
                 last_err = e
-                _log("DEBUG", f"Radarr API attempt {attempt + 1} failed: {e}")
+                self._log("DEBUG", f"Radarr API attempt {attempt + 1} failed: {e}")
                 time.sleep(min(2 ** attempt, 5))  # Exponential backoff
                 attempt += 1
         
-        _log("WARNING", f"Radarr GET {path} failed after {self.retries + 1} attempts: {last_err}")
+        self._log("WARNING", f"Radarr GET {path} failed after {self.retries + 1} attempts: {last_err}")
         return None
 
     def movie_by_imdb(self, imdb_id: str) -> Optional[Dict[str, Any]]:
         """Find movie by IMDb ID - DATABASE ONLY mode"""
         imdb_id = imdb_id if imdb_id.startswith("tt") else f"tt{imdb_id}"
-        _log("DEBUG", f"Looking up movie by IMDb ID: {imdb_id}")
+        self._log("DEBUG", f"Looking up movie by IMDb ID: {imdb_id}")
         
         # Database required - no API fallback
         if self.db_client:
             try:
                 movie = self.db_client.get_movie_by_imdb(imdb_id)
                 if movie:
-                    _log("INFO", f"✅ Found via database: {movie.get('title')} (ID: {movie.get('id')})")
+                    self._log("INFO", f"✅ Found via database: {movie.get('title')} (ID: {movie.get('id')})")
                     return movie
                 else:
-                    _log("WARNING", f"Movie not found in database for IMDb ID: {imdb_id}")
+                    self._log("WARNING", f"Movie not found in database for IMDb ID: {imdb_id}")
                     return None
             except Exception as e:
-                _log("ERROR", f"Database lookup failed: {e}")
+                self._log("ERROR", f"Database lookup failed: {e}")
                 return None
         
         # No database client available
-        _log("ERROR", "Database client required for movie lookup - API mode disabled")
+        self._log("ERROR", "Database client required for movie lookup - API mode disabled")
         return None
 
     def _analyze_event_for_import(self, event: Dict[str, Any], movie_info: Dict[str, Any] = None) -> Tuple[bool, str, Optional[str]]:
@@ -202,15 +211,15 @@ class RadarrClient:
                 # Check if both title and year are in the source
                 if movie_title and movie_year:
                     if movie_title in source_clean and movie_year in source_clean:
-                        _log("DEBUG", f"✅ Match found - Title: {movie_title}, Year: {movie_year}")
+                        self._log("DEBUG", f"✅ Match found - Title: {movie_title}, Year: {movie_year}")
                         return True, "matched_title_and_year", date_iso
                         
                 # Also check for downloads path as secondary validation
                 if path_mapper.is_download_path(source):
-                    _log("DEBUG", f"Source is from downloads: {source}")
+                    self._log("DEBUG", f"Source is from downloads: {source}")
                     return True, "from_downloads_path", date_iso
                     
-            _log("DEBUG", f"⚠️ No match found in sources: {source_items}")
+            self._log("DEBUG", f"⚠️ No match found in sources: {source_items}")
             return False, "no_title_year_match", date_iso
         
         # Fallback to basic path validation if no movie info
@@ -225,12 +234,12 @@ class RadarrClient:
         Find earliest real import event with optimized querying.
         Stops as soon as we find valid import events instead of loading everything.
         """
-        _log("INFO", f"Finding earliest import for movie_id {movie_id}")
+        self._log("INFO", f"Finding earliest import for movie_id {movie_id}")
         
         # Get movie info for path validation
         movie_info = self._get(f"/api/v3/movie/{movie_id}")
         if not movie_info or not isinstance(movie_info, dict):
-            _log("ERROR", f"Could not get movie info for ID {movie_id}")
+            self._log("ERROR", f"Could not get movie info for ID {movie_id}")
             return None
         
         earliest_real_import = None
@@ -256,7 +265,7 @@ class RadarrClient:
             if not items:
                 break
             
-            _log("DEBUG", f"Page {page}: Processing {len(items)} events")
+            self._log("DEBUG", f"Page {page}: Processing {len(items)} events")
             
             for event in items:
                 total_processed += 1
@@ -280,7 +289,7 @@ class RadarrClient:
                     else:
                         event_type = int(event_type)
                 except (ValueError, TypeError):
-                    _log("DEBUG", f"Unknown event type: {event_type}")
+                    self._log("DEBUG", f"Unknown event type: {event_type}")
                     continue
                 
                 # Check for grab events (type 1) - but validate it's a real download
@@ -302,9 +311,9 @@ class RadarrClient:
                             # Only count grabs that have actual download metadata
                             if source_title or indexer:
                                 first_grab = datetime.fromisoformat(event["date"].replace("Z", "+00:00")).astimezone(timezone.utc).isoformat(timespec="seconds")
-                                _log("DEBUG", f"Found real grab event with source '{source_title}' from '{indexer}' at {first_grab}")
+                                self._log("DEBUG", f"Found real grab event with source '{source_title}' from '{indexer}' at {first_grab}")
                             else:
-                                _log("DEBUG", f"Skipping grab event without download info at {event.get('date')}")
+                                self._log("DEBUG", f"Skipping grab event without download info at {event.get('date')}")
                         except Exception:
                             pass
                 
@@ -321,7 +330,7 @@ class RadarrClient:
                     try:
                         event_data = json.loads(event_data)
                     except (json.JSONDecodeError, AttributeError) as e:
-                        _log("DEBUG", f"Failed to parse event data JSON: {e}")
+                        self._log("DEBUG", f"Failed to parse event data JSON: {e}")
                         continue
                 elif not isinstance(event_data, dict):
                     continue
@@ -343,9 +352,9 @@ class RadarrClient:
                     f"[{movie_imdb}]" in imported_path or
                     movie_imdb in imported_path
                 ):
-                    _log("INFO", f"Found potential IMDb match in {event_type} event: {imported_path}")
+                    self._log("INFO", f"Found potential IMDb match in {event_type} event: {imported_path}")
                     date_iso = datetime.fromisoformat(event["date"].replace("Z", "+00:00")).astimezone(timezone.utc).isoformat(timespec="seconds")
-                    _log("INFO", f"✅ FOUND IMPORT: exact IMDb match at {date_iso}")
+                    self._log("INFO", f"✅ FOUND IMPORT: exact IMDb match at {date_iso}")
                     earliest_real_import = date_iso
                     break
 
@@ -358,8 +367,8 @@ class RadarrClient:
                     # Look for both title and year in the path
                     if clean_title in clean_path and movie_year in clean_path:
                         date_iso = datetime.fromisoformat(event["date"].replace("Z", "+00:00")).astimezone(timezone.utc).isoformat(timespec="seconds")
-                        _log("INFO", f"Found potential title/year match for event type {event_type}: {clean_title} ({movie_year})")
-                        _log("INFO", f"✅ FOUND IMPORT at {date_iso}")
+                        self._log("INFO", f"Found potential title/year match for event type {event_type}: {clean_title} ({movie_year})")
+                        self._log("INFO", f"✅ FOUND IMPORT at {date_iso}")
                         earliest_real_import = date_iso
                         break
                             
@@ -380,7 +389,7 @@ class RadarrClient:
                             f"[{movie_imdb}]" in source_path or
                             movie_imdb in source_path
                         ):
-                            _log("INFO", f"✅ FOUND IMPORT: IMDb match in path at {date_iso}")
+                            self._log("INFO", f"✅ FOUND IMPORT: IMDb match in path at {date_iso}")
                             earliest_real_import = date_iso
                             break
                         
@@ -388,11 +397,11 @@ class RadarrClient:
                         movie_title = (movie_info.get("title", "") or "").lower().replace(":", ".").replace(" ", ".")
                         movie_year = str(movie_info.get("year", ""))
                         if movie_title and movie_year and movie_title in source_path and movie_year in source_path:
-                            _log("INFO", f"✅ FOUND IMPORT: Title/year match at {date_iso}")
+                            self._log("INFO", f"✅ FOUND IMPORT: Title/year match at {date_iso}")
                             earliest_real_import = date_iso
                             break
                 elif event_type == 3:
-                    _log("DEBUG", f"⚠️  Skipped import event: {reason}")
+                    self._log("DEBUG", f"⚠️  Skipped import event: {reason}")
             
             # If we found a real import, no need to continue
             if earliest_real_import:
@@ -404,27 +413,27 @@ class RadarrClient:
                 
             page += 1
         
-        _log("INFO", f"Processed {total_processed} events across {page-1} pages")
+        self._log("INFO", f"Processed {total_processed} events across {page-1} pages")
         
         if earliest_real_import:
-            _log("INFO", f"✅ Using earliest real import: {earliest_real_import}")
+            self._log("INFO", f"✅ Using earliest real import: {earliest_real_import}")
             return earliest_real_import
             
         if first_grab:
-            _log("WARNING", f"⚠️  No real imports found, using grab date: {first_grab}")
+            self._log("WARNING", f"⚠️  No real imports found, using grab date: {first_grab}")
             return first_grab
             
-        _log("ERROR", f"❌ No import or grab events found for movie_id {movie_id}")
+        self._log("ERROR", f"❌ No import or grab events found for movie_id {movie_id}")
         return None
 
     def movie_files(self, movie_id: int) -> List[Dict[str, Any]]:
         """Get movie files for a movie - DATABASE ONLY mode"""
         if self.db_client:
-            _log("INFO", "Using database for movie files lookup")
+            self._log("INFO", "Using database for movie files lookup")
             # Database handles this internally in get_movie_file_date()
             return []
         
-        _log("ERROR", "Database client required for movie files - API mode disabled")
+        self._log("ERROR", "Database client required for movie files - API mode disabled")
         return []
 
     def earliest_file_dateadded(self, movie_id: int) -> Optional[str]:
@@ -433,10 +442,10 @@ class RadarrClient:
             try:
                 return self.db_client.get_movie_file_date(movie_id)
             except Exception as e:
-                _log("ERROR", f"Database file date query failed: {e}")
+                self._log("ERROR", f"Database file date query failed: {e}")
                 return None
         
-        _log("ERROR", "Database client required for file dates - API mode disabled")
+        self._log("ERROR", "Database client required for file dates - API mode disabled")
         return None
 
     def get_movie_import_date(self, movie_id: int, fallback_to_file_date: bool = True) -> Tuple[Optional[str], str]:
@@ -453,19 +462,19 @@ class RadarrClient:
                 if date_iso:
                     return date_iso, source
                 else:
-                    _log("WARNING", f"No import date found in database for movie_id {movie_id}")
+                    self._log("WARNING", f"No import date found in database for movie_id {movie_id}")
                     return None, "radarr:db.no_date_found"
             except Exception as e:
-                _log("ERROR", f"Database import date query failed: {e}")
+                self._log("ERROR", f"Database import date query failed: {e}")
                 return None, "radarr:db.error"
         
         # No database client available
-        _log("ERROR", "Database client required for import date detection - API mode disabled")
+        self._log("ERROR", "Database client required for import date detection - API mode disabled")
         return None, "radarr:db.not_configured"
 
     def _get_earliest_import_date(self, movie_id: int, movie_info: Dict) -> Optional[str]:
         """Get the earliest import date from Radarr history."""
-        _log("INFO", f"Finding earliest import for movie_id {movie_id}")
+        self._log("INFO", f"Finding earliest import for movie_id {movie_id}")
         
         earliest_real_import = None
         earliest_grab_date = None
@@ -492,7 +501,7 @@ class RadarrClient:
                 # Track earliest grab date as fallback (EventType 1)
                 if event_type == 1 and not earliest_grab_date:
                     earliest_grab_date = event_date
-                    _log("DEBUG", f"Found first grab event at {earliest_grab_date}")
+                    self._log("DEBUG", f"Found first grab event at {earliest_grab_date}")
                     continue
                 
                 # Look for import events (EventType 3)
@@ -500,7 +509,7 @@ class RadarrClient:
                     try:
                         data = json.loads(event.get("data", "{}"))
                         if data.get("importedPath"):
-                            _log("INFO", f"✅ FOUND IMPORT at {event_date}")
+                            self._log("INFO", f"✅ FOUND IMPORT at {event_date}")
                             earliest_real_import = event_date
                             break
                     except (json.JSONDecodeError, AttributeError):
@@ -513,12 +522,12 @@ class RadarrClient:
             total_events += len(history_data)
             page += 1
 
-        _log("INFO", f"Processed {total_events} events across {page}")
+        self._log("INFO", f"Processed {total_events} events across {page}")
 
         if earliest_real_import:
             return earliest_real_import
         if earliest_grab_date:
-            _log("WARNING", f"⚠️  No EventType 3 (import) found, using grab date: {earliest_grab_date}")
+            self._log("WARNING", f"⚠️  No EventType 3 (import) found, using grab date: {earliest_grab_date}")
             return earliest_grab_date
         return None
 

--- a/clients/radarr_db_client.py
+++ b/clients/radarr_db_client.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-from core.logging import _log
+from core.logging import _log as _log_raw
 
 
 class RadarrDbClient:
@@ -26,7 +26,8 @@ class RadarrDbClient:
                  db_port: Optional[int] = None,
                  db_name: Optional[str] = None,
                  db_user: Optional[str] = None,
-                 db_password: Optional[str] = None):
+                 db_password: Optional[str] = None,
+                 instance_name: str = ""):
         """
         Initialize Radarr database client
         
@@ -38,6 +39,8 @@ class RadarrDbClient:
             db_name: PostgreSQL database name
             db_user: PostgreSQL username
             db_password: PostgreSQL password
+            instance_name: label prefixed onto every log line from this client
+                (e.g. "radarr_4k") — leave blank for the unlabeled default instance
         """
         self.db_type = db_type.lower()
         self.db_path = db_path
@@ -46,7 +49,8 @@ class RadarrDbClient:
         self.db_name = db_name
         self.db_user = db_user
         self.db_password = db_password
-        
+        self.instance_name = instance_name
+
         self._test_connection()
         
     @classmethod
@@ -60,10 +64,10 @@ class RadarrDbClient:
         if db_type == "sqlite":
             db_path = os.environ.get("RADARR_DB_PATH")
             if not db_path or not Path(db_path).exists():
-                _log("WARNING", f"RADARR_DB_PATH not found or invalid: {db_path}")
+                _log_raw("WARNING", f"RADARR_DB_PATH not found or invalid: {db_path}")
                 return None
-            return cls(db_type="sqlite", db_path=db_path)
-            
+            return cls(db_type="sqlite", db_path=db_path, instance_name="radarr")
+
         elif db_type == "postgresql":
             # Support both individual vars and connection string
             db_url = os.environ.get("RADARR_DB_URL")
@@ -75,7 +79,8 @@ class RadarrDbClient:
                     db_port=parsed.port or 5432,
                     db_name=parsed.path.lstrip('/'),
                     db_user=parsed.username,
-                    db_password=parsed.password
+                    db_password=parsed.password,
+                    instance_name="radarr",
                 )
             else:
                 return cls(
@@ -84,23 +89,32 @@ class RadarrDbClient:
                     db_port=int(os.environ.get("RADARR_DB_PORT", "5432")),
                     db_name=os.environ.get("RADARR_DB_NAME"),
                     db_user=os.environ.get("RADARR_DB_USER"),
-                    db_password=os.environ.get("RADARR_DB_PASSWORD")
+                    db_password=os.environ.get("RADARR_DB_PASSWORD"),
+                    instance_name="radarr",
                 )
         else:
-            _log("ERROR", f"Unsupported database type: {db_type}")
+            _log_raw("ERROR", f"Unsupported database type: {db_type}")
             return None
     
+    def _log(self, level: str, message: str) -> None:
+        """Log with this client's instance name prefixed, so a log line is
+        traceable back to which Radarr/Sonarr instance it came from — matters
+        as soon as there's more than one of the same type configured.
+        """
+        prefix = f"[{self.instance_name}] " if self.instance_name else ""
+        _log_raw(level, f"{prefix}{message}")
+
     def _test_connection(self) -> None:
         """Test database connection on initialization"""
         try:
             conn = self._get_connection()
             if conn:
                 conn.close()
-                _log("INFO", f"Connected to Radarr {self.db_type} database successfully")
+                self._log("INFO", f"Connected to Radarr {self.db_type} database successfully")
             else:
                 raise Exception("Failed to create connection")
         except Exception as e:
-            _log("ERROR", f"Failed to connect to Radarr database: {e}")
+            self._log("ERROR", f"Failed to connect to Radarr database: {e}")
             raise
     
     def _get_connection(self) -> Union[sqlite3.Connection, psycopg2.extensions.connection]:
@@ -169,7 +183,7 @@ class RadarrDbClient:
                     return dict(row) if self.db_type == "sqlite" else row
                     
         except Exception as e:
-            _log("ERROR", f"Database query error for IMDb {imdb_id}: {e}")
+            self._log("ERROR", f"Database query error for IMDb {imdb_id}: {e}")
             
         return None
 
@@ -226,7 +240,7 @@ class RadarrDbClient:
                 return []
 
         except Exception as e:
-            _log("ERROR", f"Database query error getting all movies: {e}")
+            self._log("ERROR", f"Database query error getting all movies: {e}")
             return []
 
     def get_earliest_import_date(self, movie_id: int) -> Tuple[Optional[str], str]:
@@ -241,7 +255,7 @@ class RadarrDbClient:
         """
         # If first event is rename, all subsequent imports are upgrades - skip them
         if self.is_first_event_rename_based(movie_id):
-            _log("INFO", f"Movie {movie_id} has rename-first history - all imports are upgrades, skipping")
+            self._log("INFO", f"Movie {movie_id} has rename-first history - all imports are upgrades, skipping")
             return None, "radarr:db.upgrade_imports_skipped"
         
         # Query for earliest import event - PostgreSQL uses INTEGER EventType (3 = import)
@@ -295,7 +309,7 @@ class RadarrDbClient:
                         dt = event_date.replace(tzinfo=timezone.utc)
                     
                     date_iso = dt.astimezone(timezone.utc).isoformat(timespec="seconds")
-                    _log("INFO", f"✅ Found import event ({event_type}) for movie {movie_id} at {date_iso}")
+                    self._log("INFO", f"✅ Found import event ({event_type}) for movie {movie_id} at {date_iso}")
                     return date_iso, "radarr:db.history.import"
                 
                 # Fallback to grab events
@@ -311,11 +325,11 @@ class RadarrDbClient:
                         dt = event_date.replace(tzinfo=timezone.utc)
                     
                     date_iso = dt.astimezone(timezone.utc).isoformat(timespec="seconds")
-                    _log("WARNING", f"⚠️ Using grab event ({event_type}) for movie {movie_id} at {date_iso}")
+                    self._log("WARNING", f"⚠️ Using grab event ({event_type}) for movie {movie_id} at {date_iso}")
                     return date_iso, "radarr:db.history.grab"
                     
         except Exception as e:
-            _log("ERROR", f"Database query error for movie {movie_id}: {e}")
+            self._log("ERROR", f"Database query error for movie {movie_id}: {e}")
             
         return None, "radarr:db.no_date_found"
 
@@ -351,27 +365,27 @@ class RadarrDbClient:
                 rows = cursor.fetchall()
                 
                 if rows:
-                    _log("INFO", f"Movie {movie_id} history debug - first 5 events:")
+                    self._log("INFO", f"Movie {movie_id} history debug - first 5 events:")
                     for i, row in enumerate(rows):
                         event_type = row['event_type'] if self.db_type == "postgresql" else row[0] 
                         event_date = row['event_date'] if self.db_type == "postgresql" else row[1]
-                        _log("INFO", f"  Event {i+1}: Type={event_type}, Date={event_date}")
+                        self._log("INFO", f"  Event {i+1}: Type={event_type}, Date={event_date}")
                     
                     first_event_type = rows[0]['event_type'] if self.db_type == "postgresql" else rows[0][0]
                     # EventType 8 = movieFileRenamed
                     # Also check for EventType 7 = movieFileRenamed in some Radarr versions
                     is_rename_first = first_event_type in [7, 8]
-                    _log("INFO", f"Movie {movie_id}: First event type={first_event_type}, is_rename_first={is_rename_first}")
+                    self._log("INFO", f"Movie {movie_id}: First event type={first_event_type}, is_rename_first={is_rename_first}")
                     
                     if is_rename_first:
-                        _log("INFO", f"🎯 Movie {movie_id} detected as rename-first scenario - will prefer release dates over import dates")
+                        self._log("INFO", f"🎯 Movie {movie_id} detected as rename-first scenario - will prefer release dates over import dates")
                     
                     return is_rename_first
                 else:
-                    _log("WARNING", f"Movie {movie_id}: No history events found - this could indicate missing data")
+                    self._log("WARNING", f"Movie {movie_id}: No history events found - this could indicate missing data")
                     
         except Exception as e:
-            _log("ERROR", f"Error checking first event type for movie {movie_id}: {e}")
+            self._log("ERROR", f"Error checking first event type for movie {movie_id}: {e}")
             
         return False
     
@@ -415,7 +429,7 @@ class RadarrDbClient:
                         return dt.astimezone(timezone.utc).isoformat(timespec="seconds")
                         
         except Exception as e:
-            _log("ERROR", f"Database query error for movie file date {movie_id}: {e}")
+            self._log("ERROR", f"Database query error for movie file date {movie_id}: {e}")
             
         return None
     
@@ -437,14 +451,14 @@ class RadarrDbClient:
         
         # Check if we skipped upgrades and should prefer release dates
         if source == "radarr:db.upgrade_imports_skipped":
-            _log("INFO", f"Movie {movie_id} upgrade scenario detected - signaling to prefer release dates")
+            self._log("INFO", f"Movie {movie_id} upgrade scenario detected - signaling to prefer release dates")
             return None, "radarr:db.prefer_release_dates"
         
         # Fallback to file date if requested
         if fallback_to_file_date:
             file_date = self.get_movie_file_date(movie_id)
             if file_date:
-                _log("WARNING", f"Using file dateAdded as fallback for movie_id {movie_id}")
+                self._log("WARNING", f"Using file dateAdded as fallback for movie_id {movie_id}")
                 return file_date, "radarr:db.file.dateAdded"
 
         return None, "radarr:db.no_date_found"
@@ -517,7 +531,7 @@ class RadarrDbClient:
                         results[imdb_id] = (None, "radarr:db.bulk.no_import")
                 
         except Exception as e:
-            _log("ERROR", f"Bulk query error: {e}")
+            self._log("ERROR", f"Bulk query error: {e}")
             # Return empty results for failed queries
             for imdb_id in clean_imdb_ids:
                 if imdb_id not in results:
@@ -547,7 +561,7 @@ class RadarrDbClient:
                     stats[stat_name] = result[0] if result else 0
                     
         except Exception as e:
-            _log("ERROR", f"Stats query error: {e}")
+            self._log("ERROR", f"Stats query error: {e}")
             stats["error"] = str(e)
             
         return stats
@@ -669,7 +683,7 @@ class RadarrDbClient:
             health["status"] = "error"
             health["connection"] = "failed"
             health["issues"].append(f"Connection failed: {e}")
-            _log("ERROR", f"Database health check failed: {e}")
+            self._log("ERROR", f"Database health check failed: {e}")
         
         # Overall status determination
         if health["issues"]:

--- a/clients/sonarr_client.py
+++ b/clients/sonarr_client.py
@@ -10,18 +10,27 @@ from urllib.parse import urlencode
 from urllib.request import Request as UrlRequest, urlopen
 from urllib.error import URLError, HTTPError
 
-from core.logging import _log
+from core.logging import _log as _log_raw
 
 
 class SonarrClient:
     """Enhanced Sonarr API client for TV series and episode management"""
     
-    def __init__(self, base_url: str, api_key: str, timeout: int = 45, retries: int = 3):
+    def __init__(self, base_url: str, api_key: str, timeout: int = 45, retries: int = 3, instance_name: str = ""):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.timeout = timeout
         self.retries = max(0, retries)
         self.enabled = bool(self.base_url and self.api_key)
+        self.instance_name = instance_name
+
+    def _log(self, level: str, message: str) -> None:
+        """Log with this client's instance name prefixed, so a log line is
+        traceable back to which Radarr/Sonarr instance it came from — matters
+        as soon as there's more than one of the same type configured.
+        """
+        prefix = f"[{self.instance_name}] " if self.instance_name else ""
+        _log_raw(level, f"{prefix}{message}")
 
     def _get(self, path: str, params: Dict[str, Any] = None) -> Optional[Any]:
         """Make GET request to Sonarr API with retries"""
@@ -36,7 +45,7 @@ class SonarrClient:
         
         for attempt in range(self.retries):
             try:
-                _log("DEBUG", f"Sonarr API Request: {url}")
+                self._log("DEBUG", f"Sonarr API Request: {url}")
                 req = UrlRequest(url, headers=headers)
                 
                 with urlopen(req, timeout=self.timeout) as resp:
@@ -46,71 +55,71 @@ class SonarrClient:
                     
             except HTTPError as e:
                 if e.code == 401:
-                    _log("ERROR", "Sonarr authentication failed - check API key")
+                    self._log("ERROR", "Sonarr authentication failed - check API key")
                     return None
                 elif e.code == 429:
                     wait_time = (attempt + 1) * 2
-                    _log("WARNING", f"Sonarr rate limited, waiting {wait_time}s (attempt {attempt+1}/{self.retries})")
+                    self._log("WARNING", f"Sonarr rate limited, waiting {wait_time}s (attempt {attempt+1}/{self.retries})")
                     time.sleep(wait_time)
                 else:
-                    _log("WARNING", f"Sonarr HTTP {e.code} error on attempt {attempt+1}/{self.retries}: {e.reason}")
+                    self._log("WARNING", f"Sonarr HTTP {e.code} error on attempt {attempt+1}/{self.retries}: {e.reason}")
                     
             except Exception as e:
-                _log("WARNING", f"Sonarr API attempt {attempt+1}/{self.retries} failed: {e}")
+                self._log("WARNING", f"Sonarr API attempt {attempt+1}/{self.retries} failed: {e}")
             
             if attempt < self.retries - 1:
                 time.sleep(0.5 * (attempt + 1))
         
-        _log("ERROR", f"Sonarr API failed after {self.retries} attempts: {url}")
+        self._log("ERROR", f"Sonarr API failed after {self.retries} attempts: {url}")
         return None
 
     def series_by_imdb(self, imdb_id: str) -> Optional[Dict[str, Any]]:
         """Find series by IMDb ID using lookup endpoint"""
         search_term = f"imdbid:{imdb_id}"
-        _log("DEBUG", f"Searching Sonarr with term: {search_term}")
+        self._log("DEBUG", f"Searching Sonarr with term: {search_term}")
         
         result = self._get("/series/lookup", {"term": search_term})
         if not result:
-            _log("WARNING", f"No results from Sonarr lookup for: {search_term}")
+            self._log("WARNING", f"No results from Sonarr lookup for: {search_term}")
             return None
             
-        _log("DEBUG", f"Sonarr lookup returned {len(result)} results")
+        self._log("DEBUG", f"Sonarr lookup returned {len(result)} results")
         
         # Log all results for debugging
         for i, series in enumerate(result):
             series_imdb = series.get("imdbId", "")
             series_title = series.get("title", "")
             series_id = series.get("id", "")
-            _log("DEBUG", f"Result {i+1}: Title='{series_title}', IMDb='{series_imdb}', ID={series_id}")
+            self._log("DEBUG", f"Result {i+1}: Title='{series_title}', IMDb='{series_imdb}', ID={series_id}")
         
         # Find exact IMDb match (case insensitive)
         target_imdb = imdb_id.lower()
         for series in result:
             series_imdb = (series.get("imdbId") or "").lower()
             if series_imdb == target_imdb:
-                _log("INFO", f"Found exact IMDb match: {series.get('title')} (ID: {series.get('id')})")
+                self._log("INFO", f"Found exact IMDb match: {series.get('title')} (ID: {series.get('id')})")
                 return series
                 
         # Try partial match as fallback
         for series in result:
             series_imdb = (series.get("imdbId") or "").lower()
             if target_imdb in series_imdb or series_imdb in target_imdb:
-                _log("WARNING", f"Found partial IMDb match: {series.get('title')} (Expected: {imdb_id}, Found: {series.get('imdbId')})")
+                self._log("WARNING", f"Found partial IMDb match: {series.get('title')} (Expected: {imdb_id}, Found: {series.get('imdbId')})")
                 return series
         
-        _log("WARNING", f"No IMDb match found in {len(result)} results for {imdb_id}")
+        self._log("WARNING", f"No IMDb match found in {len(result)} results for {imdb_id}")
         return None
 
     def series_by_title(self, title: str) -> Optional[Dict[str, Any]]:
         """Search for series by title as fallback when IMDb lookup fails"""
-        _log("DEBUG", f"Searching Sonarr by title: {title}")
+        self._log("DEBUG", f"Searching Sonarr by title: {title}")
         
         result = self._get("/series/lookup", {"term": title})
         if not result:
-            _log("WARNING", f"No results from Sonarr title search for: {title}")
+            self._log("WARNING", f"No results from Sonarr title search for: {title}")
             return None
             
-        _log("DEBUG", f"Sonarr title search returned {len(result)} results")
+        self._log("DEBUG", f"Sonarr title search returned {len(result)} results")
         
         title_lower = title.lower()
         
@@ -118,17 +127,17 @@ class SonarrClient:
         for series in result:
             series_title = (series.get("title") or "").lower()
             if series_title == title_lower:
-                _log("INFO", f"Found exact title match: {series.get('title')} (ID: {series.get('id')})")
+                self._log("INFO", f"Found exact title match: {series.get('title')} (ID: {series.get('id')})")
                 return series
         
         # Look for partial title match
         for series in result:
             series_title = (series.get("title") or "").lower()
             if title_lower in series_title or series_title in title_lower:
-                _log("INFO", f"Found partial title match: '{series.get('title')}' for search '{title}' (ID: {series.get('id')})")
+                self._log("INFO", f"Found partial title match: '{series.get('title')}' for search '{title}' (ID: {series.get('id')})")
                 return series
         
-        _log("WARNING", f"No title match found for: {title}")
+        self._log("WARNING", f"No title match found for: {title}")
         return None
 
     def get_all_series(self) -> List[Dict[str, Any]]:
@@ -137,17 +146,17 @@ class SonarrClient:
 
     def series_by_imdb_direct(self, imdb_id: str) -> Optional[Dict[str, Any]]:
         """Find series by scanning all series for IMDb match (slower but more reliable)"""
-        _log("DEBUG", f"Direct series lookup for IMDb: {imdb_id}")
+        self._log("DEBUG", f"Direct series lookup for IMDb: {imdb_id}")
         all_series = self.get_all_series()
         
         target_imdb = imdb_id.lower()
         for series in all_series:
             series_imdb = (series.get("imdbId") or "").lower()
             if series_imdb == target_imdb:
-                _log("INFO", f"Found series via direct lookup: {series.get('title')} (ID: {series.get('id')})")
+                self._log("INFO", f"Found series via direct lookup: {series.get('title')} (ID: {series.get('id')})")
                 return series
         
-        _log("WARNING", f"No series found with IMDb ID via direct lookup: {imdb_id}")
+        self._log("WARNING", f"No series found with IMDb ID via direct lookup: {imdb_id}")
         return None
 
     def get_series_by_id(self, series_id: int) -> Optional[Dict[str, Any]]:
@@ -197,7 +206,7 @@ class SonarrClient:
             if page > 10:  # Safety valve
                 break
         
-        _log("DEBUG", f"Got {len(all_records)} history records for episode {episode_id}")
+        self._log("DEBUG", f"Got {len(all_records)} history records for episode {episode_id}")
         
         # Categorize events
         import_events = []
@@ -211,7 +220,7 @@ class SonarrClient:
             if not date:
                 continue
             
-            _log("DEBUG", f"History event: {event_type} at {date}")
+            self._log("DEBUG", f"History event: {event_type} at {date}")
             
             if event_type == "downloadfolderimported":
                 import_events.append({"date": date, "event": event})
@@ -224,7 +233,7 @@ class SonarrClient:
         if import_events:
             earliest_import = min(import_events, key=lambda x: x["date"])
             import_date = earliest_import["date"]
-            _log("INFO", f"Found import date: {import_date} for episode {episode_id}")
+            self._log("INFO", f"Found import date: {import_date} for episode {episode_id}")
             
             # Check chronological order of events
             if rename_events:
@@ -237,26 +246,26 @@ class SonarrClient:
                     
                     # If import happened BEFORE rename, it's valid original import
                     if import_dt <= rename_dt:
-                        _log("INFO", f"Import {import_date} happened before/during rename {rename_date} - using import date")
+                        self._log("INFO", f"Import {import_date} happened before/during rename {rename_date} - using import date")
                         return import_date
                     
                     # If rename happened BEFORE import - always use aired date fallback
                     else:
-                        _log("WARNING", f"Rename {rename_date} happened before import {import_date} - using aired date fallback")
+                        self._log("WARNING", f"Rename {rename_date} happened before import {import_date} - using aired date fallback")
                         return None  # Trigger aired date fallback
                         
                 except Exception as e:
-                    _log("DEBUG", f"Error comparing dates: {e}")
+                    self._log("DEBUG", f"Error comparing dates: {e}")
             
             return import_date
         
         # Fallback to grab event
         if grabbed_events:
             earliest_grab = min(grabbed_events, key=lambda x: x["date"])
-            _log("WARNING", f"No import events, using grab date: {earliest_grab['date']} for episode {episode_id}")
+            self._log("WARNING", f"No import events, using grab date: {earliest_grab['date']} for episode {episode_id}")
             return earliest_grab["date"]
         
-        _log("WARNING", f"No reliable import events found for episode {episode_id} - should use air date instead")
+        self._log("WARNING", f"No reliable import events found for episode {episode_id} - should use air date instead")
         return None
 
 

--- a/clients/sonarr_db_client.py
+++ b/clients/sonarr_db_client.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-from core.logging import _log
+from core.logging import _log as _log_raw
 
 
 class SonarrDbClient:
@@ -26,7 +26,8 @@ class SonarrDbClient:
                  db_port: Optional[int] = None,
                  db_name: Optional[str] = None,
                  db_user: Optional[str] = None,
-                 db_password: Optional[str] = None):
+                 db_password: Optional[str] = None,
+                 instance_name: str = ""):
         """
         Initialize Sonarr database client
 
@@ -38,6 +39,8 @@ class SonarrDbClient:
             db_name: PostgreSQL database name
             db_user: PostgreSQL username
             db_password: PostgreSQL password
+            instance_name: label prefixed onto every log line from this client
+                (e.g. "sonarr_strm") — leave blank for the unlabeled default instance
         """
         self.db_type = db_type.lower()
         self.db_path = db_path
@@ -46,6 +49,7 @@ class SonarrDbClient:
         self.db_name = db_name
         self.db_user = db_user
         self.db_password = db_password
+        self.instance_name = instance_name
 
         self._test_connection()
 
@@ -60,9 +64,9 @@ class SonarrDbClient:
         if db_type == "sqlite":
             db_path = os.environ.get("SONARR_DB_PATH")
             if not db_path or not Path(db_path).exists():
-                _log("WARNING", f"SONARR_DB_PATH not found or invalid: {db_path}")
+                _log_raw("WARNING", f"SONARR_DB_PATH not found or invalid: {db_path}")
                 return None
-            return cls(db_type="sqlite", db_path=db_path)
+            return cls(db_type="sqlite", db_path=db_path, instance_name="sonarr")
 
         elif db_type == "postgresql":
             # Support both individual vars and connection string
@@ -75,7 +79,8 @@ class SonarrDbClient:
                     db_port=parsed.port or 5432,
                     db_name=parsed.path.lstrip('/'),
                     db_user=parsed.username,
-                    db_password=parsed.password
+                    db_password=parsed.password,
+                    instance_name="sonarr",
                 )
             else:
                 return cls(
@@ -84,11 +89,20 @@ class SonarrDbClient:
                     db_port=int(os.environ.get("SONARR_DB_PORT", "5432")),
                     db_name=os.environ.get("SONARR_DB_NAME"),
                     db_user=os.environ.get("SONARR_DB_USER"),
-                    db_password=os.environ.get("SONARR_DB_PASSWORD")
+                    db_password=os.environ.get("SONARR_DB_PASSWORD"),
+                    instance_name="sonarr",
                 )
         else:
-            _log("ERROR", f"Unsupported database type: {db_type}")
+            _log_raw("ERROR", f"Unsupported database type: {db_type}")
             return None
+
+    def _log(self, level: str, message: str) -> None:
+        """Log with this client's instance name prefixed, so a log line is
+        traceable back to which Radarr/Sonarr instance it came from — matters
+        as soon as there's more than one of the same type configured.
+        """
+        prefix = f"[{self.instance_name}] " if self.instance_name else ""
+        _log_raw(level, f"{prefix}{message}")
 
     def _test_connection(self) -> None:
         """Test database connection on initialization"""
@@ -96,11 +110,11 @@ class SonarrDbClient:
             conn = self._get_connection()
             if conn:
                 conn.close()
-                _log("INFO", f"Connected to Sonarr {self.db_type} database successfully")
+                self._log("INFO", f"Connected to Sonarr {self.db_type} database successfully")
             else:
                 raise Exception("Failed to create connection")
         except Exception as e:
-            _log("ERROR", f"Failed to connect to Sonarr database: {e}")
+            self._log("ERROR", f"Failed to connect to Sonarr database: {e}")
             raise
 
     def _get_connection(self) -> Union[sqlite3.Connection, psycopg2.extensions.connection]:
@@ -166,7 +180,7 @@ class SonarrDbClient:
                     return dict(row) if self.db_type == "sqlite" else row
 
         except Exception as e:
-            _log("ERROR", f"Database query error for IMDb {imdb_id}: {e}")
+            self._log("ERROR", f"Database query error for IMDb {imdb_id}: {e}")
 
         return None
 
@@ -205,7 +219,7 @@ class SonarrDbClient:
                     return rows
 
         except Exception as e:
-            _log("ERROR", f"Database query error getting all series: {e}")
+            self._log("ERROR", f"Database query error getting all series: {e}")
             return []
 
     def get_all_episodes_for_series(self, series_id: int) -> List[Dict[str, Any]]:
@@ -253,7 +267,7 @@ class SonarrDbClient:
                     return rows
 
         except Exception as e:
-            _log("ERROR", f"Database query error for series {series_id}: {e}")
+            self._log("ERROR", f"Database query error for series {series_id}: {e}")
             return []
 
     def get_episode_import_date(self, episode_id: int) -> Tuple[Optional[str], str]:
@@ -303,7 +317,7 @@ class SonarrDbClient:
                     return date_iso, "sonarr:db.history.import"
 
         except Exception as e:
-            _log("ERROR", f"Database query error for episode {episode_id}: {e}")
+            self._log("ERROR", f"Database query error for episode {episode_id}: {e}")
 
         return None, "sonarr:db.no_import_found"
 
@@ -368,7 +382,7 @@ class SonarrDbClient:
                             return dt.astimezone(timezone.utc).isoformat(timespec="seconds")
 
         except Exception as e:
-            _log("ERROR", f"Database query error for episode file: {e}")
+            self._log("ERROR", f"Database query error for episode file: {e}")
 
         return None
 
@@ -428,7 +442,7 @@ class SonarrDbClient:
                         results[(season, episode)] = (None, "sonarr:db.bulk.no_import")
 
         except Exception as e:
-            _log("ERROR", f"Bulk query error for series {series_id}: {e}")
+            self._log("ERROR", f"Bulk query error for series {series_id}: {e}")
 
         return results
 
@@ -455,7 +469,7 @@ class SonarrDbClient:
                     stats[stat_name] = result[0] if result else 0
 
         except Exception as e:
-            _log("ERROR", f"Stats query error: {e}")
+            self._log("ERROR", f"Stats query error: {e}")
             stats["error"] = str(e)
 
         return stats
@@ -578,7 +592,7 @@ class SonarrDbClient:
             health["status"] = "error"
             health["connection"] = "failed"
             health["issues"].append(f"Connection failed: {e}")
-            _log("ERROR", f"Database health check failed: {e}")
+            self._log("ERROR", f"Database health check failed: {e}")
 
         # Overall status
         if health["issues"]:

--- a/config/env_writer.py
+++ b/config/env_writer.py
@@ -1,0 +1,278 @@
+"""
+Env file writer for the setup wizard.
+
+Everything the wizard adds goes through here — turning a form submission
+into env var names, and writing those into .env / .env.secrets a few keys
+at a time without disturbing anything else already in either file. Nothing
+in this module talks to the network or a database; it's just the
+file-writing half of "add an instance". The actual connection testing and
+name-collision checks against the live registry happen in the route
+handler, before build_env_updates()/upsert_env_file() are ever called —
+by the time we're writing, everything should already be validated.
+"""
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# Env var suffixes that are secrets and always belong in .env.secrets,
+# never .env. Keep this in sync with what _load_radarr_instance /
+# _load_sonarr_instance in config/settings.py actually read — if a new
+# secret-shaped field gets added there, it needs to be added here too.
+SECRET_SUFFIXES = ("API_KEY", "DB_PASSWORD")
+
+# Same reserved segments settings.py already refuses to treat as instance
+# names (RADARR_DB_* and RADARR_WEBHOOK_* aren't instances called "DB" or
+# "WEBHOOK"). Duplicated here rather than imported so this module has no
+# dependency on settings.py loading environment variables at import time.
+RESERVED_NAME_SEGMENTS = {"DB", "WEBHOOK"}
+
+# Letters, digits, underscores only — no hyphens. This becomes part of an
+# env var name and a URL path segment (the webhook route), so it has to be
+# shell- and URL-safe. Same rule the multi-instance docs already spell out
+# for people naming instances by hand.
+_NAME_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+class InstanceNameError(ValueError):
+    """A user-supplied instance name isn't safe to use as an env var segment."""
+
+
+def validate_name_segment(raw_name: str, existing_names: set, media_type: str, require_exists: bool = False) -> str:
+    """Turn a user-typed instance name into a validated env var name segment.
+
+    Uppercases it (env vars are conventionally upper-case), then checks the
+    character set, the reserved-word list, and whether it collides with an
+    instance that's already running.
+
+    existing_names should come from the live InstanceRegistry, not just
+    whatever's currently in .env — someone may have hand-edited the file
+    since the last restart, and the registry is what's actually in use.
+    Those are full instance names (e.g. "sonarr_strm"), not bare segments
+    (e.g. "strm") — media_type is what lets this function build the same
+    full name to compare against, the way instance_name is built everywhere
+    else in the wizard (f"{media_type}_{segment.lower()}").
+
+    require_exists flips the collision check: normally a name must NOT
+    already exist (adding a new instance is the default assumption); with
+    require_exists=True it must ALREADY exist instead — used when editing
+    or deleting a specific instance, where the opposite mistake (a typo'd
+    name matching nothing) is the one worth catching.
+    """
+    name_segment = raw_name.strip().upper()
+
+    if not name_segment:
+        raise InstanceNameError("Instance name can't be empty")
+
+    if not _NAME_SEGMENT_RE.match(name_segment):
+        raise InstanceNameError(
+            "Instance name can only contain letters, numbers, and underscores — "
+            "no hyphens or spaces. This becomes part of an env var name and a "
+            "webhook URL, so it has to stay simple."
+        )
+
+    if name_segment in RESERVED_NAME_SEGMENTS:
+        raise InstanceNameError(f"'{name_segment}' is a reserved word and can't be used as an instance name")
+
+    full_name = f"{media_type}_{name_segment.lower()}"
+    exists = full_name in existing_names
+    if require_exists and not exists:
+        raise InstanceNameError(f"No instance named '{full_name}' exists to edit or delete")
+    if not require_exists and exists:
+        raise InstanceNameError(f"An instance named '{full_name}' already exists")
+
+    return name_segment
+
+
+def build_env_updates(
+    media_type: str, name_segment: str, fields: Dict[str, object]
+) -> Tuple[Dict[str, str], Dict[str, str]]:
+    """Turn a wizard form submission into the env vars it becomes.
+
+    media_type is "radarr" or "sonarr". fields is whatever the form
+    collected — only the known field names below are ever read, so a stray
+    key in the request body can't sneak an arbitrary env var into either
+    file. name_segment == "" means the default instance (RADARR_URL rather
+    than RADARR_4K_URL).
+
+    Returns (env_updates, secret_updates), two plain {KEY: value} dicts
+    ready to hand to upsert_env_file() — one per file.
+    """
+    prefix = f"{media_type.upper()}_{name_segment}_" if name_segment else f"{media_type.upper()}_"
+
+    # Radarr and Sonarr each only have one of these — asking for both would
+    # be a caller bug, not something worth silently tolerating.
+    path_field = "movie_paths" if media_type == "radarr" else "tv_paths"
+    path_var = "MOVIE_PATHS" if media_type == "radarr" else "TV_PATHS"
+
+    field_to_suffix = {
+        "url": "URL",
+        "api_key": "API_KEY",
+        "root_folders": "ROOT_FOLDERS",
+        path_field: path_var,
+        "db_type": "DB_TYPE",
+        "db_host": "DB_HOST",
+        "db_port": "DB_PORT",
+        "db_name": "DB_NAME",
+        "db_user": "DB_USER",
+        "db_password": "DB_PASSWORD",
+        "db_path": "DB_PATH",
+    }
+
+    env_updates: Dict[str, str] = {}
+    secret_updates: Dict[str, str] = {}
+
+    for field_name, suffix in field_to_suffix.items():
+        value = fields.get(field_name)
+        if value in (None, ""):
+            continue
+        if isinstance(value, list):
+            value = ",".join(str(v).strip() for v in value if str(v).strip())
+            if not value:
+                continue
+        key = f"{prefix}{suffix}"
+        target = secret_updates if suffix in SECRET_SUFFIXES else env_updates
+        target[key] = str(value)
+
+    return env_updates, secret_updates
+
+
+def upsert_env_file(path: Path, updates: Dict[str, str], instance_label: str = "") -> bool:
+    """Write `updates` into the env file at `path`, touching only those keys.
+
+    An existing KEY=value line gets its value replaced in place — every
+    comment, blank line, and unrelated var is left exactly as it was. Keys
+    that don't already exist are appended at the end under a small header
+    comment, so it's obvious later which lines the wizard added versus
+    what was hand-written.
+
+    Returns True if the file was created or changed, False if every
+    requested value already matched what was on disk.
+    """
+    if not updates:
+        return False
+
+    remaining = dict(updates)  # don't mutate the caller's dict as we consume it
+    lines: List[str] = path.read_text().splitlines() if path.exists() else []
+    changed = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in line:
+            continue
+        key = line.split("=", 1)[0].strip()
+        if key in remaining:
+            new_line = f"{key}={remaining.pop(key)}"
+            if new_line != line:
+                lines[i] = new_line
+                changed = True
+
+    # Anything still left in `remaining` wasn't in the file at all — append it.
+    if remaining:
+        if lines and lines[-1].strip():
+            lines.append("")
+        if instance_label:
+            lines.append(f"# --- {instance_label} (added via setup wizard) ---")
+        for key, value in remaining.items():
+            lines.append(f"{key}={value}")
+        changed = True
+
+    if changed:
+        path.write_text("\n".join(lines) + "\n")
+
+    return changed
+
+
+def remove_instance_keys(path: Path, prefix: str, instance_label: str = "") -> bool:
+    """Remove every KEY=value line whose key starts with `prefix` from the file.
+
+    This is the delete half of the wizard — the mirror of upsert_env_file().
+    `prefix` is the same "SONARR_STRM_" shape build_env_updates() already
+    builds keys with, so a delete removes exactly what an add would have
+    written, no more. Also drops the wizard's own "# --- name (added via
+    setup wizard) ---" header line for this instance if present — anything
+    else in the file, including other comments, is left untouched.
+
+    Returns True if anything was actually removed, False if the file had
+    nothing matching (deleting an instance that was never in this file, or
+    was hand-written under a different naming convention).
+    """
+    if not path.exists():
+        return False
+
+    lines = path.read_text().splitlines()
+    kept: List[str] = []
+    changed = False
+    header_marker = f"# --- {instance_label} (" if instance_label else None
+
+    for line in lines:
+        stripped = line.strip()
+        if header_marker and stripped.startswith(header_marker):
+            changed = True
+            continue
+        if stripped and not stripped.startswith("#") and "=" in line:
+            key = line.split("=", 1)[0].strip()
+            if key.startswith(prefix):
+                changed = True
+                continue
+        kept.append(line)
+
+    if changed:
+        path.write_text("\n".join(kept) + ("\n" if kept else ""))
+
+    return changed
+
+
+def read_env_files(env_path: Path, secrets_path: Path) -> Dict[str, str]:
+    """Read both files' raw text, for a backup. A missing file comes back as "".
+
+    Deliberately just the raw text, not parsed key/value pairs — a backup
+    should round-trip exactly, comments and formatting included, not just
+    the values.
+    """
+    return {
+        "env": env_path.read_text() if env_path.exists() else "",
+        "env_secrets": secrets_path.read_text() if secrets_path.exists() else "",
+    }
+
+
+def write_env_files(env_path: Path, secrets_path: Path, env_content: str, secrets_content: str) -> None:
+    """Overwrite both files verbatim — this is what restoring a backup does.
+
+    Unlike upsert_env_file(), nothing is merged here: whatever text is
+    passed in becomes the entire file. Call backup_env_files() first if
+    the current content is worth keeping, which the wizard's restore
+    endpoint always does.
+    """
+    env_path.write_text(env_content)
+    secrets_path.write_text(secrets_content)
+
+
+def backup_env_files(env_path: Path, secrets_path: Path, backups_dir: Path) -> Optional[Path]:
+    """Snapshot both files' current content into backups_dir, before something overwrites them.
+
+    Same JSON shape a manual backup download uses, so a snapshot taken here
+    can be fed straight back into a restore if needed. Returns the path to
+    the snapshot, or None if neither file exists yet — nothing to back up
+    on a fresh install.
+    """
+    if not env_path.exists() and not secrets_path.exists():
+        return None
+
+    backups_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    snapshot_path = backups_dir / f"env-backup-{timestamp}.json"
+
+    # Two snapshots requested in the same second would collide — add a
+    # counter suffix rather than silently overwriting an earlier one.
+    counter = 1
+    while snapshot_path.exists():
+        snapshot_path = backups_dir / f"env-backup-{timestamp}-{counter}.json"
+        counter += 1
+
+    snapshot = {"exported_at": datetime.now(timezone.utc).isoformat(), **read_env_files(env_path, secrets_path)}
+    snapshot_path.write_text(json.dumps(snapshot, indent=2))
+
+    return snapshot_path

--- a/core/database_populator.py
+++ b/core/database_populator.py
@@ -67,7 +67,8 @@ class DatabasePopulator:
             except Exception:
                 self.radarr_api = radarr_client if radarr_client else RadarrClient(
                     os.environ.get("RADARR_URL", ""),
-                    os.environ.get("RADARR_API_KEY", "")
+                    os.environ.get("RADARR_API_KEY", ""),
+                    instance_name="radarr",
                 )
                 self.radarr = self.radarr_api
                 _log("INFO", "DatabasePopulator: Using Radarr API client")
@@ -96,7 +97,8 @@ class DatabasePopulator:
             except Exception:
                 self.sonarr_api = sonarr_client if sonarr_client else SonarrClient(
                     os.environ.get("SONARR_URL", ""),
-                    os.environ.get("SONARR_API_KEY", "")
+                    os.environ.get("SONARR_API_KEY", ""),
+                    instance_name="sonarr",
                 )
                 self.sonarr = self.sonarr_api
                 _log("INFO", "DatabasePopulator: Using Sonarr API client")
@@ -120,10 +122,11 @@ class DatabasePopulator:
                 db_name=inst.db_name or None,
                 db_user=inst.db_user or None,
                 db_password=inst.db_password or None,
+                instance_name=inst.name,
             )
             _log("INFO", f"DatabasePopulator: DB access configured for Radarr instance '{inst.name}'")
             return cls(db, _radarr_db_override=client)
-        client = RadarrClient(inst.url, inst.api_key)
+        client = RadarrClient(inst.url, inst.api_key, instance_name=inst.name)
         return cls(db, _radarr_db_override=client)
 
     @classmethod
@@ -141,26 +144,32 @@ class DatabasePopulator:
                 db_name=inst.db_name or None,
                 db_user=inst.db_user or None,
                 db_password=inst.db_password or None,
+                instance_name=inst.name,
             )
             _log("INFO", f"DatabasePopulator: DB access configured for Sonarr instance '{inst.name}'")
             return cls(db, _sonarr_db_override=client)
-        client = SonarrClient(inst.url, inst.api_key)
+        client = SonarrClient(inst.url, inst.api_key, instance_name=inst.name)
         return cls(db, _sonarr_db_override=client)
 
-    def get_episode_import_history(self, episode_id: int) -> Optional[str]:
+    def get_episode_import_history(self, episode_id: int) -> Tuple[Optional[str], Optional[str]]:
         """
-        Get episode import history from either database or API
-        Wraps both SonarrDbClient.get_episode_import_date and SonarrClient.get_episode_import_history
+        Get episode import history from either database or API.
+        Wraps both SonarrDbClient.get_episode_import_date and SonarrClient.get_episode_import_history.
+
+        Always returns (date_iso, source) now — this used to discard the DB
+        client's real source string ("sonarr:db.history.import") and let the
+        caller hardcode "sonarr:api.import_history" regardless of which path
+        actually ran, mislabeling every DB-sourced date as API-sourced.
         """
         if self.using_sonarr_db and self.sonarr_db:
-            # Database client returns (date_iso, source)
-            date_iso, source = self.sonarr_db.get_episode_import_date(episode_id)
-            return date_iso
+            # Database client already returns (date_iso, source)
+            return self.sonarr_db.get_episode_import_date(episode_id)
         elif self.sonarr_api:
-            # API client returns Optional[str]
-            return self.sonarr_api.get_episode_import_history(episode_id)
+            # API client returns just the date — the source is always the same for it
+            date_iso = self.sonarr_api.get_episode_import_history(episode_id)
+            return date_iso, ('sonarr:api.import_history' if date_iso else None)
         else:
-            return None
+            return None, None
 
     def populate_movies(self, instance: str = 'radarr') -> Dict[str, any]:
         """
@@ -547,10 +556,10 @@ class DatabasePopulator:
                             else:
                                 episode_id = episode.get('id')
                                 if episode_id:
-                                    import_date = self.get_episode_import_history(episode_id)
+                                    import_date, import_source = self.get_episode_import_history(episode_id)
                                     if import_date:
                                         dateadded = import_date
-                                        source = 'sonarr:api.import_history'
+                                        source = import_source or 'sonarr:api.import_history'
 
                             # Fallback to air date if no import date
                             if not dateadded and aired:

--- a/core/instance_registry.py
+++ b/core/instance_registry.py
@@ -32,6 +32,7 @@ def _build_radarr_client(instance: RadarrInstance) -> Optional[AnyRadarrClient]:
                 client = RadarrDbClient(
                     db_type="sqlite",
                     db_path=instance.db_path or None,
+                    instance_name=instance.name,
                 )
             else:
                 client = RadarrDbClient(
@@ -41,6 +42,7 @@ def _build_radarr_client(instance: RadarrInstance) -> Optional[AnyRadarrClient]:
                     db_name=instance.db_name or None,
                     db_user=instance.db_user or None,
                     db_password=instance.db_password or None,
+                    instance_name=instance.name,
                 )
             _log("INFO", f"[{instance.name}] Using Radarr direct database access")
             return client
@@ -52,6 +54,7 @@ def _build_radarr_client(instance: RadarrInstance) -> Optional[AnyRadarrClient]:
         return RadarrClient(
             base_url=instance.url,
             api_key=instance.api_key,
+            instance_name=instance.name,
         )
 
     _log("WARNING", f"[{instance.name}] No Radarr client available — no DB or API configured")
@@ -66,6 +69,7 @@ def _build_sonarr_client(instance: SonarrInstance) -> Optional[AnySonarrClient]:
                 client = SonarrDbClient(
                     db_type="sqlite",
                     db_path=instance.db_path or None,
+                    instance_name=instance.name,
                 )
             else:
                 client = SonarrDbClient(
@@ -75,6 +79,7 @@ def _build_sonarr_client(instance: SonarrInstance) -> Optional[AnySonarrClient]:
                     db_name=instance.db_name or None,
                     db_user=instance.db_user or None,
                     db_password=instance.db_password or None,
+                    instance_name=instance.name,
                 )
             _log("INFO", f"[{instance.name}] Using Sonarr direct database access")
             return client
@@ -86,6 +91,7 @@ def _build_sonarr_client(instance: SonarrInstance) -> Optional[AnySonarrClient]:
         return SonarrClient(
             base_url=instance.url,
             api_key=instance.api_key,
+            instance_name=instance.name,
         )
 
     _log("WARNING", f"[{instance.name}] No Sonarr client available — no DB or API configured")

--- a/main.py
+++ b/main.py
@@ -10,11 +10,17 @@ from datetime import datetime, timezone
 import uvicorn
 from fastapi import FastAPI
 
-# Import configuration first
-from config.settings import config
-
-# Authentication removed - handled by separate web container
+# utils.logging has to be imported before config.settings — importing it is
+# what actually loads .env/.env.secrets into the process (a side effect at
+# the bottom of that module). config.settings builds its module-level
+# `config` singleton, including instance discovery, the moment it's
+# imported — if that happens first, any instance whose env vars only live
+# in the file (not already in the container's OS environment from Docker's
+# own env_file injection at container creation) gets silently missed.
 from utils.logging import _log
+
+# Import configuration — after logging, see above
+from config.settings import config
 
 # Import core components
 from core.database import ChronarrDatabase
@@ -92,9 +98,12 @@ def initialize_components(registry=None):
     if registry is None:
         registry = build_registry(config)
 
-    # Processors get the default instance's client and mapper. Multi-instance
-    # requests pass instance name explicitly at process time; the processors look
-    # up the right client from the registry during their DB writes.
+    # Processors are constructed with the default instance's client and mapper
+    # (used as a fallback when no registry is available, e.g. in tests), but
+    # also get the InstanceRegistry itself — every per-call `instance` param
+    # they take is resolved against it, so a named instance actually gets its
+    # own client and path mapper instead of silently falling back to whatever
+    # was wired in here.
     default_radarr_mapper = registry.radarr_mapper("radarr")
     default_sonarr_mapper = registry.sonarr_mapper("sonarr")
 
@@ -102,11 +111,13 @@ def initialize_components(registry=None):
         db, None,
         default_sonarr_mapper or _noop_mapper(),
         sonarr_client=registry.sonarr("sonarr"),
+        registry=registry,
     )
     movie_processor = MovieProcessor(
         db, None,
         default_radarr_mapper or _noop_mapper(),
         radarr_client=registry.radarr("radarr"),
+        registry=registry,
     )
 
     batcher = WebhookBatcher(nfo_manager=None)

--- a/processors/movie_processor.py
+++ b/processors/movie_processor.py
@@ -65,10 +65,14 @@ def convert_utc_to_local(utc_iso_string: str) -> str:
 
 class MovieProcessor:
 
-    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper, radarr_client=None):
+    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper, radarr_client=None, registry=None):
         # nfo_manager kept for call-site compat but is unused
         self.db = db
         self.path_mapper = path_mapper
+        # InstanceRegistry — lets per-call `instance` params resolve the right
+        # client/mapper instead of always using the default instance below.
+        # None in the legacy single-instance/test construction path.
+        self.registry = registry
 
         if radarr_client:
             # Pre-built client from InstanceRegistry (preferred path)
@@ -91,15 +95,33 @@ class MovieProcessor:
                 _log("INFO", "Using Radarr API client (database not configured)")
 
         self.external_clients = ExternalClientManager()
-    
-    def find_movie_path(self, movie_title: str, imdb_id: str, radarr_path: str = None) -> Optional[Path]:
+
+    def _resolve_radarr(self, instance: str):
+        """Return (client, using_db, path_mapper) for a named instance.
+
+        Looks the instance up in the InstanceRegistry so per-call `instance`
+        params actually pick the right Radarr server instead of every call
+        silently using whichever instance was wired in at construction time.
+        Falls back to the default-instance attributes when there's no
+        registry (legacy/test construction) or the instance isn't found.
+        """
+        if self.registry:
+            client = self.registry.radarr(instance)
+            if client is not None:
+                mapper = self.registry.radarr_mapper(instance) or self.path_mapper
+                return client, isinstance(client, RadarrDbClient), mapper
+            _log("WARNING", f"[{instance}] No Radarr client in registry — falling back to default instance")
+        return self.radarr, self.using_db, self.path_mapper
+
+    def find_movie_path(self, movie_title: str, imdb_id: str, radarr_path: str = None, instance: str = 'radarr') -> Optional[Path]:
         """Find movie directory path using unified file utilities"""
+        _, _, path_mapper = self._resolve_radarr(instance)
         return find_media_path_by_imdb_and_title(
             title=movie_title,
             imdb_id=imdb_id,
             search_paths=config.movie_paths,
             webhook_path=radarr_path,
-            path_mapper=self.path_mapper
+            path_mapper=path_mapper
         )
     
     def should_skip_movie(self, imdb_id: str, movie_name: str = "", instance: str = 'radarr') -> Tuple[bool, str]:
@@ -135,34 +157,34 @@ class MovieProcessor:
         if not imdb_id:
             imdb_id = find_imdb_in_directory(movie_path)
         if not imdb_id:
-            _log("ERROR", f"No IMDb ID found in movie directory, filenames, or NFO file: {movie_path}")
+            _log("ERROR", f"[{instance}] No IMDb ID found in movie directory, filenames, or NFO file: {movie_path}")
             return "error"
         
         # Handle TMDB ID fallback case
         is_tmdb_fallback = imdb_id.startswith("tmdb-")
         if is_tmdb_fallback:
-            _log("INFO", f"Processing movie: {movie_path.name} (TMDB: {imdb_id})")
+            _log("INFO", f"[{instance}] Processing movie: {movie_path.name} (TMDB: {imdb_id})")
         else:
-            _log("INFO", f"Processing movie: {movie_path.name} (IMDb: {imdb_id})")
+            _log("INFO", f"[{instance}] Processing movie: {movie_path.name} (IMDb: {imdb_id})")
         
         # Check if we should skip this movie (unless forced, webhook mode, or incomplete mode)
         # Skip database optimization for incomplete mode since we need to check NFO files first
         if not force_scan and not webhook_mode and scan_mode != "incomplete":
             should_skip, reason = self.should_skip_movie(imdb_id, movie_path.name, instance=instance)
             if should_skip:
-                _log("INFO", f"⏭️ SKIPPING MOVIE: {movie_path.name} [{imdb_id}] - {reason}")
+                _log("INFO", f"[{instance}] ⏭️ SKIPPING MOVIE: {movie_path.name} [{imdb_id}] - {reason}")
                 self.db.upsert_movie(imdb_id, str(movie_path), instance=instance)
                 return "skipped"
             else:
-                _log("INFO", f"🎬 PROCESSING MOVIE: {movie_path.name} [{imdb_id}] - {reason}")
+                _log("INFO", f"[{instance}] 🎬 PROCESSING MOVIE: {movie_path.name} [{imdb_id}] - {reason}")
         elif force_scan:
-            _log("INFO", f"🔄 FORCE PROCESSING MOVIE: {movie_path.name} [{imdb_id}] - Force scan enabled")
+            _log("INFO", f"[{instance}] 🔄 FORCE PROCESSING MOVIE: {movie_path.name} [{imdb_id}] - Force scan enabled")
         else:
-            _log("INFO", f"📥 WEBHOOK PROCESSING MOVIE: {movie_path.name} [{imdb_id}] - Webhook mode")
+            _log("INFO", f"[{instance}] 📥 WEBHOOK PROCESSING MOVIE: {movie_path.name} [{imdb_id}] - Webhook mode")
         
         # Check for shutdown signal early in processing
         if shutdown_event and shutdown_event.is_set():
-            _log("INFO", f"⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing: {movie_path.name}")
+            _log("INFO", f"[{instance}] ⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing: {movie_path.name}")
             return "shutdown"
         
         # Update database
@@ -173,7 +195,7 @@ class MovieProcessor:
         has_video = any(f.is_file() and f.suffix.lower() in video_exts for f in movie_path.iterdir())
         
         if not has_video:
-            _log("WARNING", f"No video files found in: {movie_path} - skipping database entry")
+            _log("WARNING", f"[{instance}] No video files found in: {movie_path} - skipping database entry")
             return "no_video_files"
         
         if scan_mode == "incomplete":
@@ -182,19 +204,19 @@ class MovieProcessor:
         # For smart/full modes: Use database-first optimization
         # TIER 1: Check database first (fastest - local lookup)
         existing = self.db.get_movie_dates(imdb_id, instance)
-        _log("DEBUG", f"Database lookup for {imdb_id}: {existing}")
+        _log("DEBUG", f"[{instance}] Database lookup for {imdb_id}: {existing}")
         
         # Enhanced debug for database state
         if existing:
             has_dateadded = bool(existing.get("dateadded"))
             source_value = existing.get("source")
-            _log("INFO", f"🔍 TIER 1 DEBUG - {imdb_id}: has_dateadded={has_dateadded}, source='{source_value}', dateadded='{existing.get('dateadded')}'")
+            _log("INFO", f"[{instance}] 🔍 TIER 1 DEBUG - {imdb_id}: has_dateadded={has_dateadded}, source='{source_value}', dateadded='{existing.get('dateadded')}'")
         else:
-            _log("INFO", f"🔍 TIER 1 DEBUG - {imdb_id}: No database record found")
+            _log("INFO", f"[{instance}] 🔍 TIER 1 DEBUG - {imdb_id}: No database record found")
         
         # If we have complete data in database, use it and skip all other checks
         if existing and existing.get("dateadded") and existing.get("source") != "no_valid_date_source":
-            _log("INFO", f"✅ TIER 1 - Using complete database data for {imdb_id}: {existing['dateadded']} (source: {existing['source']})")
+            _log("INFO", f"[{instance}] ✅ TIER 1 - Using complete database data for {imdb_id}: {existing['dateadded']} (source: {existing['source']})")
             dateadded, source, released = existing["dateadded"], existing["source"], existing.get("released")
             
             # Convert datetime objects to strings for NFO manager
@@ -206,43 +228,44 @@ class MovieProcessor:
             # NFO file operations removed - database is now the single source of truth
             # (Phase 1: Remove NFO file write operations)
             
-            _log("INFO", f"Completed processing movie: {movie_path.name} (source: {source}) [database-cached]")
+            _log("INFO", f"[{instance}] Completed processing movie: {movie_path.name} (source: {source}) [database-cached]")
             return "processed"
         else:
-            _log("INFO", f"🔍 TIER 1 SKIP - {imdb_id}: Database incomplete, proceeding to Tier 2")
+            _log("INFO", f"[{instance}] 🔍 TIER 1 SKIP - {imdb_id}: Database incomplete, proceeding to Tier 2")
         
         # TIER 2: Query external APIs directly (NFO layer removed in Phase 2)
-        _log("INFO", f"🔍 TIER 2 - No database cache, querying external APIs")
+        _log("INFO", f"[{instance}] 🔍 TIER 2 - No database cache, querying external APIs")
 
         # Fetch title/year from Radarr now so we can store them alongside dates
-        radarr_meta = self.radarr.movie_by_imdb(imdb_id) if self.radarr else None
+        radarr_client, _, _ = self._resolve_radarr(instance)
+        radarr_meta = radarr_client.movie_by_imdb(imdb_id) if radarr_client else None
         title = radarr_meta.get("title") if radarr_meta else None
         year = radarr_meta.get("year") if radarr_meta else None
 
         # Check for shutdown signal before expensive API operations
         if shutdown_event and shutdown_event.is_set():
-            _log("INFO", f"⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing before API calls: {movie_path.name}")
+            _log("INFO", f"[{instance}] ⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing before API calls: {movie_path.name}")
             return "shutdown"
 
         # TIER 3: No cached data found - determine if we should query APIs
         if webhook_mode:
-            _log("INFO", f"Webhook processing - no cached data found, using full date decision logic")
+            _log("INFO", f"[{instance}] Webhook processing - no cached data found, using full date decision logic")
             should_query = True  # Always query for webhooks when no cached data exists
         else:
             # Manual scan mode - determine if we should query APIs
             should_query = config.movie_poll_mode == "always"
-            _log("DEBUG", f"Movie {imdb_id}: should_query={should_query}, poll_mode={config.movie_poll_mode}")
+            _log("DEBUG", f"[{instance}] Movie {imdb_id}: should_query={should_query}, poll_mode={config.movie_poll_mode}")
         
         # Use existing movie date decision logic
         # Pass NFO fallback data if available for cases where external APIs don't have import history
         nfo_fallback = locals().get('nfo_fallback_data', None)
-        dateadded, source, released = self._decide_movie_dates(imdb_id, movie_path, should_query, nfo_fallback)
+        dateadded, source, released = self._decide_movie_dates(imdb_id, movie_path, should_query, nfo_fallback, instance=instance)
         
         # Webhook fallback: if ALL date sources fail, use current timestamp
         if webhook_mode and dateadded is None:
             local_tz = _get_local_timezone()
             current_time = datetime.now(local_tz).isoformat(timespec="seconds")
-            _log("INFO", f"Webhook processing - all date sources failed, using current timestamp as last resort: {current_time}")
+            _log("INFO", f"[{instance}] Webhook processing - all date sources failed, using current timestamp as last resort: {current_time}")
             dateadded, source = current_time, "webhook:fallback_timestamp"
         
         # If we don't have an import/download date but we have a release date, use it as dateadded
@@ -253,14 +276,14 @@ class MovieProcessor:
         if dateadded is None and released is not None:
             final_dateadded = released
             final_source = f"{source}_as_dateadded" if source else "release_date_fallback"
-            _log("INFO", f"Using release date as dateadded: {final_dateadded} (source: {final_source})")
+            _log("INFO", f"[{instance}] Using release date as dateadded: {final_dateadded} (source: {final_source})")
         
         # NFO file operations removed - database is now the single source of truth
         # (Phase 1: Remove NFO file write operations)
         
         # Skip remaining processing if no valid date found and file dates disabled
         if final_dateadded is None:
-            _log("WARNING", f"Movie {movie_path.name} - no valid date source available, but NFO was still processed")
+            _log("WARNING", f"[{instance}] Movie {movie_path.name} - no valid date source available, but NFO was still processed")
             self.db.upsert_movie_dates(imdb_id, released, None, source, True, title=title, year=year, instance=instance)
             return "processed"
             
@@ -268,39 +291,39 @@ class MovieProcessor:
         dateadded = final_dateadded
         source = final_source
         
-        _log("DEBUG", f"Movie {movie_path.name} proceeding to save: dateadded={dateadded}, source={source}")
+        _log("DEBUG", f"[{instance}] Movie {movie_path.name} proceeding to save: dateadded={dateadded}, source={source}")
         
         # File mtime operations removed - database is now the single source of truth
         # (Phase 1: Remove NFO file write operations)
         
-        _log("DEBUG", f"Movie processing reached file mtime section: fix_dir_mtimes={config.fix_dir_mtimes}, dateadded={dateadded}")
+        _log("DEBUG", f"[{instance}] Movie processing reached file mtime section: fix_dir_mtimes={config.fix_dir_mtimes}, dateadded={dateadded}")
         
         
         # Save to database
-        _log("DEBUG", f"About to save to database: imdb_id={imdb_id}, dateadded={dateadded}")
+        _log("DEBUG", f"[{instance}] About to save to database: imdb_id={imdb_id}, dateadded={dateadded}")
         try:
             self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year, instance=instance)
-            _log("DEBUG", f"Database save completed for {imdb_id}")
+            _log("DEBUG", f"[{instance}] Database save completed for {imdb_id}")
         except Exception as e:
-            _log("ERROR", f"Database save failed for {imdb_id}: {e}")
+            _log("ERROR", f"[{instance}] Database save failed for {imdb_id}: {e}")
             raise
         
-        _log("INFO", f"Completed processing movie: {movie_path.name} (source: {source})")
+        _log("INFO", f"[{instance}] Completed processing movie: {movie_path.name} (source: {source})")
         return "processed"
     
     def _process_movie_nfo_first(self, movie_path: Path, imdb_id: str, shutdown_event=None, instance: str = 'radarr') -> str:
         """Process movie for incomplete mode: Database-first then API (NFO checks removed in Phase 2)"""
-        _log("INFO", f"🔍 INCOMPLETE MODE: Checking movie for missing data: {movie_path.name}")
+        _log("INFO", f"[{instance}] 🔍 INCOMPLETE MODE: Checking movie for missing data: {movie_path.name}")
 
         if shutdown_event and shutdown_event.is_set():
-            _log("INFO", f"⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing: {movie_path.name}")
+            _log("INFO", f"[{instance}] ⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping movie processing: {movie_path.name}")
             return "shutdown"
 
         existing = self.db.get_movie_dates(imdb_id, instance)
 
         if existing and existing.get("dateadded") and existing.get("source") != "no_valid_date_source":
             # Found in database - data is complete
-            _log("INFO", f"✅ Database has dateadded={existing['dateadded']}")
+            _log("INFO", f"[{instance}] ✅ Database has dateadded={existing['dateadded']}")
             dateadded, source, released = existing["dateadded"], existing["source"], existing.get("released")
 
             # Convert datetime objects to strings
@@ -309,15 +332,15 @@ class MovieProcessor:
             if released and hasattr(released, 'isoformat'):
                 released = released.isoformat()
 
-            _log("INFO", f"Completed processing movie: {movie_path.name} (source: {source}) [database-cached]")
+            _log("INFO", f"[{instance}] Completed processing movie: {movie_path.name} (source: {source}) [database-cached]")
             return "processed"
 
         # STEP 2: Database incomplete or missing, query APIs
-        _log("DEBUG", f"STEP 2 - Querying APIs for missing data")
+        _log("DEBUG", f"[{instance}] STEP 2 - Querying APIs for missing data")
         
         # Check for shutdown signal before API calls
         if shutdown_event and shutdown_event.is_set():
-            _log("INFO", f"⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping before API calls: {movie_path.name}")
+            _log("INFO", f"[{instance}] ⚠️ SHUTDOWN SIGNAL RECEIVED - Stopping before API calls: {movie_path.name}")
             return "shutdown"
         
         # Handle TMDB ID fallback case
@@ -325,9 +348,9 @@ class MovieProcessor:
         
         if is_tmdb_fallback:
             # TMDB fallback processing - use file modification time
-            _log("INFO", f"🔍 TMDB fallback processing for {imdb_id}")
+            _log("INFO", f"[{instance}] 🔍 TMDB fallback processing for {imdb_id}")
             dateadded, source, released = self._get_file_mtime_date(movie_path)
-            _log("INFO", f"Using file mtime for TMDB movie: {dateadded}")
+            _log("INFO", f"[{instance}] Using file mtime for TMDB movie: {dateadded}")
         else:
             # Standard IMDb processing
             # Try to get digital release date from external APIs
@@ -337,38 +360,41 @@ class MovieProcessor:
                 dateadded = digital_date
                 source = digital_source
                 released = digital_date  # For movies, digital release is often the key date
-                _log("INFO", f"Got digital release date from APIs: {dateadded} (source: {source})")
+                _log("INFO", f"[{instance}] Got digital release date from APIs: {dateadded} (source: {source})")
             else:
                 # Last resort: file modification time
                 dateadded, source, released = self._get_file_mtime_date(movie_path)
-                _log("INFO", f"Using file mtime as fallback: {dateadded}")
+                _log("INFO", f"[{instance}] Using file mtime as fallback: {dateadded}")
         
         if dateadded:
-            radarr_meta = self.radarr.movie_by_imdb(imdb_id) if self.radarr else None
+            radarr_client, _, _ = self._resolve_radarr(instance)
+            radarr_meta = radarr_client.movie_by_imdb(imdb_id) if radarr_client else None
             title = radarr_meta.get("title") if radarr_meta else None
             year = radarr_meta.get("year") if radarr_meta else None
             self.db.upsert_movie_dates(imdb_id, released, dateadded, source, True, title=title, year=year, instance=instance)
 
-            _log("INFO", f"🔍 INCOMPLETE MODE COMPLETE: {movie_path.name} (source: {source})")
+            _log("INFO", f"[{instance}] 🔍 INCOMPLETE MODE COMPLETE: {movie_path.name} (source: {source})")
             return "processed"
         else:
-            _log("WARNING", f"Could not determine dateadded for movie: {movie_path.name}")
+            _log("WARNING", f"[{instance}] Could not determine dateadded for movie: {movie_path.name}")
             return "error"
     
     # NFO helper methods removed in Phase 2 - database is the single source of truth
 
-    def _decide_movie_dates(self, imdb_id: str, movie_path: Path, should_query: bool, existing: Optional[Dict]) -> Tuple[str, str, Optional[str]]:
+    def _decide_movie_dates(self, imdb_id: str, movie_path: Path, should_query: bool, existing: Optional[Dict], instance: str = 'radarr') -> Tuple[str, str, Optional[str]]:
         """Decide movie dates based on configuration and available data"""
-        _log("DEBUG", f"_decide_movie_dates for {imdb_id}: should_query={should_query}, existing={existing}")
-        
+        _log("DEBUG", f"[{instance}] _decide_movie_dates for {imdb_id}: should_query={should_query}, existing={existing}")
+
         if not should_query and existing:
-            _log("DEBUG", f"Using existing data without querying: dateadded={existing.get('dateadded')}, source={existing.get('source')}")
+            _log("DEBUG", f"[{instance}] Using existing data without querying: dateadded={existing.get('dateadded')}, source={existing.get('source')}")
             return existing["dateadded"], existing["source"], existing.get("released")
-        
+
+        radarr_client, _, _ = self._resolve_radarr(instance)
+
         # Query Radarr for movie info (database or API client)
         radarr_movie = None
-        if should_query and self.radarr:
-            radarr_movie = self.radarr.movie_by_imdb(imdb_id)
+        if should_query and radarr_client:
+            radarr_movie = radarr_client.movie_by_imdb(imdb_id)
         
         released = None
         if radarr_movie:
@@ -380,50 +406,50 @@ class MovieProcessor:
             if radarr_movie:
                 movie_id = radarr_movie.get("id")
                 if movie_id:
-                    import_date, import_source = self.radarr.get_movie_import_date(movie_id, fallback_to_file_date=config.allow_file_date_fallback)
-                    _log("INFO", f"Movie {imdb_id}: Radarr import result: date={import_date}, source={import_source}")
+                    import_date, import_source = radarr_client.get_movie_import_date(movie_id, fallback_to_file_date=config.allow_file_date_fallback)
+                    _log("INFO", f"[{instance}] Movie {imdb_id}: Radarr import result: date={import_date}, source={import_source}")
             
             # Check for special case: rename-first scenario (should prefer release dates)
             if import_source == "radarr:db.prefer_release_dates":
-                _log("INFO", f"🎯 Movie {imdb_id} has rename-first history - skipping import, preferring release dates")
+                _log("INFO", f"[{instance}] 🎯 Movie {imdb_id} has rename-first history - skipping import, preferring release dates")
                 # Fall through to release date logic below
             # Check if we got a real import date or just file date fallback
             elif import_date and import_source != "radarr:db.file.dateAdded":
                 # Convert import date to local timezone for NFO files
                 local_import_date = convert_utc_to_local(import_date)
-                _log("INFO", f"✅ Movie {imdb_id}: Using import date {local_import_date} from {import_source}")
+                _log("INFO", f"[{instance}] ✅ Movie {imdb_id}: Using import date {local_import_date} from {import_source}")
                 return local_import_date, import_source, released
             
             # Get digital release date for comparison/fallback
-            _log("INFO", f"🔍 Movie {imdb_id}: Trying digital release date fallback...")
+            _log("INFO", f"[{instance}] 🔍 Movie {imdb_id}: Trying digital release date fallback...")
             digital_date, digital_source = self._get_digital_release_date(imdb_id)
-            _log("INFO", f"Movie {imdb_id}: Digital release result: date={digital_date}, source={digital_source}")
+            _log("INFO", f"[{instance}] Movie {imdb_id}: Digital release result: date={digital_date}, source={digital_source}")
             
             # If we only have file date and release date exists, prefer it if reasonable and enabled
             if import_date and import_source == "radarr:db.file.dateAdded" and digital_date and config.prefer_release_dates_over_file_dates:
                 # Compare dates - prefer release date if it's reasonable
                 if self._should_prefer_release_over_file_date(digital_date, digital_source, released, imdb_id):
-                    _log("INFO", f"✅ Movie {imdb_id}: Preferring digital release date {digital_date} over file date")
+                    _log("INFO", f"[{instance}] ✅ Movie {imdb_id}: Preferring digital release date {digital_date} over file date")
                     # When using digital release date, store it as both dateadded and released
                     return digital_date, digital_source, digital_date
                 else:
                     # Convert file date to local timezone for NFO files
                     local_file_date = convert_utc_to_local(import_date)
-                    _log("INFO", f"✅ Movie {imdb_id}: Keeping file date {local_file_date} - digital date not reasonable")
+                    _log("INFO", f"[{instance}] ✅ Movie {imdb_id}: Keeping file date {local_file_date} - digital date not reasonable")
                     return local_file_date, import_source, released
             
             # Use whichever we have
             if import_date:
                 # Convert import date to local timezone for NFO files
                 local_import_date = convert_utc_to_local(import_date)
-                _log("INFO", f"✅ Movie {imdb_id}: Using import date {local_import_date} from {import_source}")
+                _log("INFO", f"[{instance}] ✅ Movie {imdb_id}: Using import date {local_import_date} from {import_source}")
                 return local_import_date, import_source, released
             elif digital_date:
-                _log("INFO", f"✅ Movie {imdb_id}: Using digital release date {digital_date} from {digital_source}")
+                _log("INFO", f"[{instance}] ✅ Movie {imdb_id}: Using digital release date {digital_date} from {digital_source}")
                 # When using digital release date, store it as both dateadded and released
                 return digital_date, digital_source, digital_date
             else:
-                _log("WARNING", f"⚠️ Movie {imdb_id}: No import date OR digital release date found")
+                _log("WARNING", f"[{instance}] ⚠️ Movie {imdb_id}: No import date OR digital release date found")
         
         else:  # digital_then_import
             # Try digital release first
@@ -436,7 +462,7 @@ class MovieProcessor:
             if radarr_movie:
                 movie_id = radarr_movie.get("id")
                 if movie_id:
-                    import_date, import_source = self.radarr.get_movie_import_date(movie_id, fallback_to_file_date=config.allow_file_date_fallback)
+                    import_date, import_source = radarr_client.get_movie_import_date(movie_id, fallback_to_file_date=config.allow_file_date_fallback)
                     if import_date:
                         # Convert import date to local timezone for NFO files
                         local_import_date = convert_utc_to_local(import_date)
@@ -444,14 +470,14 @@ class MovieProcessor:
         
         # Last resort: check if we have NFO fallback data (when external APIs don't have import history)
         if existing and existing.get('dateadded'):
-            _log("INFO", f"✅ Movie {imdb_id}: External APIs don't have import history, using NFO fallback date: {existing['dateadded']} (source: {existing['source']})")
+            _log("INFO", f"[{instance}] ✅ Movie {imdb_id}: External APIs don't have import history, using NFO fallback date: {existing['dateadded']} (source: {existing['source']})")
             return existing["dateadded"], f"nfo_fallback:{existing['source']}", existing.get("released")
         
         # Last resort: file mtime (if allowed)
         if config.allow_file_date_fallback:
             return self._get_file_mtime_date(movie_path)
         else:
-            _log("INFO", f"No valid dates found for {imdb_id} and file date fallback disabled - skipping NFO creation")
+            _log("INFO", f"[{instance}] No valid dates found for {imdb_id} and file date fallback disabled - skipping NFO creation")
             
             # Log to failed movies debug file for troubleshooting
             self._log_failed_movie(movie_path, imdb_id, "No import date, no release date, file date fallback disabled")

--- a/processors/tv_processor.py
+++ b/processors/tv_processor.py
@@ -28,10 +28,14 @@ from utils.async_file_utils import (
 
 class TVProcessor:
 
-    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper, sonarr_client=None):
+    def __init__(self, db: ChronarrDatabase, nfo_manager, path_mapper: PathMapper, sonarr_client=None, registry=None):
         # nfo_manager kept for call-site compat but is unused
         self.db = db
         self.path_mapper = path_mapper
+        # InstanceRegistry — lets per-call `instance` params resolve the right
+        # client/mapper instead of always using the default instance below.
+        # None in the legacy single-instance/test construction path.
+        self.registry = registry
 
         if sonarr_client:
             # Pre-built client from InstanceRegistry (preferred path)
@@ -61,29 +65,48 @@ class TVProcessor:
 
         self.external_clients = ExternalClientManager()
 
-    def get_episode_import_history(self, episode_id: int) -> Optional[str]:
+    def _resolve_sonarr(self, instance: str):
+        """Return (client, using_db, path_mapper) for a named instance.
+
+        Looks the instance up in the InstanceRegistry so per-call `instance`
+        params actually pick the right Sonarr server instead of every call
+        silently using whichever instance was wired in at construction time.
+        Falls back to the default-instance attributes when there's no
+        registry (legacy/test construction) or the instance isn't found.
+        """
+        if self.registry:
+            client = self.registry.sonarr(instance)
+            if client is not None:
+                mapper = self.registry.sonarr_mapper(instance) or self.path_mapper
+                return client, isinstance(client, SonarrDbClient), mapper
+            _log("WARNING", f"[{instance}] No Sonarr client in registry — falling back to default instance")
+        return self.sonarr, self.using_db, self.path_mapper
+
+    def get_episode_import_history(self, episode_id: int, instance: str = 'sonarr') -> Optional[str]:
         """
         Get episode import history from either database or API
         Wraps both SonarrDbClient.get_episode_import_date and SonarrClient.get_episode_import_history
         """
-        if self.using_db and self.sonarr_db:
+        client, using_db, _ = self._resolve_sonarr(instance)
+        if using_db and client:
             # Database client returns (date_iso, source)
-            date_iso, source = self.sonarr_db.get_episode_import_date(episode_id)
+            date_iso, source = client.get_episode_import_date(episode_id)
             return date_iso
-        elif self.sonarr_api:
+        elif client:
             # API client returns Optional[str]
-            return self.sonarr_api.get_episode_import_history(episode_id)
+            return client.get_episode_import_history(episode_id)
         else:
             return None
 
-    def find_series_path(self, series_title: str, imdb_id: str, sonarr_path: str = None) -> Optional[Path]:
+    def find_series_path(self, series_title: str, imdb_id: str, sonarr_path: str = None, instance: str = 'sonarr') -> Optional[Path]:
         """Find series directory path using unified file utilities"""
+        _, _, path_mapper = self._resolve_sonarr(instance)
         return find_media_path_by_imdb_and_title(
             title=series_title,
             imdb_id=imdb_id,
             search_paths=config.tv_paths,
             webhook_path=sonarr_path,
-            path_mapper=self.path_mapper
+            path_mapper=path_mapper
         )
     
     def _episode_completion_counts(self, imdb_id: str, instance: str) -> Tuple[int, int]:
@@ -225,7 +248,7 @@ class TVProcessor:
         episodes_needing_lookup = episodes_needing_nfo_check  # Renamed for clarity
         if episodes_needing_lookup:
             _log("DEBUG", f"TIER 2 - Querying Sonarr for {len(episodes_needing_lookup)} episodes missing from database")
-            sonarr_episodes = self._get_sonarr_episodes(imdb_id, episodes_needing_lookup)
+            sonarr_episodes = self._get_sonarr_episodes(imdb_id, episodes_needing_lookup, instance=instance)
             
             # Process episodes that needed lookup
             for (season, episode) in episodes_needing_lookup:
@@ -320,7 +343,7 @@ class TVProcessor:
         # STEP 2: For episodes missing from database, query Sonarr
         if episodes_needing_api_lookup:
             _log("DEBUG", f"STEP 2 - Querying Sonarr for {len(episodes_needing_api_lookup)} episodes missing from database")
-            sonarr_episodes = self._get_sonarr_episodes(imdb_id, episodes_needing_api_lookup)
+            sonarr_episodes = self._get_sonarr_episodes(imdb_id, episodes_needing_api_lookup, instance=instance)
             
             for (season, episode) in episodes_needing_api_lookup:
                 aired = None
@@ -372,24 +395,23 @@ class TVProcessor:
         
         return episode_dates
     
-    def _get_sonarr_episodes(self, imdb_id: str, episodes_filter: List[Tuple[int, int]] = None) -> Dict[Tuple[int, int], Dict[str, Any]]:
+    def _get_sonarr_episodes(self, imdb_id: str, episodes_filter: List[Tuple[int, int]] = None, instance: str = 'sonarr') -> Dict[Tuple[int, int], Dict[str, Any]]:
         """Get episode information from Sonarr including import history - optimized to only fetch needed episodes"""
         try:
+            client, using_db, _ = self._resolve_sonarr(instance)
+
             # Handle different method names for DB vs API client
-            if self.using_db:
-                series_data = self.sonarr.get_series_by_imdb(imdb_id)
+            if using_db:
+                series_data = client.get_series_by_imdb(imdb_id)
             else:
-                series_data = self.sonarr.series_by_imdb(imdb_id)
+                series_data = client.series_by_imdb(imdb_id)
 
             if not series_data:
                 # Try fuzzy matching if exact IMDb lookup fails
                 _log("DEBUG", f"Exact IMDb lookup failed for {imdb_id}, trying fuzzy matching")
 
                 # Get all series and try fuzzy matching
-                if self.using_db:
-                    all_series = self.sonarr.get_all_series()
-                else:
-                    all_series = self.sonarr.get_all_series()
+                all_series = client.get_all_series()
 
                 if all_series:
                     _log("DEBUG", f"Found {len(all_series)} total series in Sonarr")
@@ -423,11 +445,11 @@ class TVProcessor:
                 return {}
 
             # Handle different method names for DB vs API client
-            if self.using_db:
-                episodes = self.sonarr.get_all_episodes_for_series(series_id)
+            if using_db:
+                episodes = client.get_all_episodes_for_series(series_id)
             else:
-                episodes = self.sonarr.episodes_for_series(series_id)
-            
+                episodes = client.episodes_for_series(series_id)
+
             # Convert episodes_filter to set for faster lookup
             filter_set = set(episodes_filter) if episodes_filter else None
             
@@ -460,7 +482,7 @@ class TVProcessor:
                     # First try to get import date from history (more accurate)
                     episode_id = episode.get('id')
                     if episode_id and episode.get('hasFile'):
-                        import_date = self.get_episode_import_history(episode_id)
+                        import_date = self.get_episode_import_history(episode_id, instance=instance)
                         api_calls_made += 1
                         if import_date:
                             episode_data['dateAdded'] = import_date
@@ -680,20 +702,20 @@ class TVProcessor:
         if not imdb_id:
             imdb_id = parse_imdb_from_path(series_path)
         if not imdb_id:
-            _log("ERROR", f"No IMDb ID found in series path: {series_path}")
+            _log("ERROR", f"[{instance}] No IMDb ID found in series path: {series_path}")
             return
 
         if not webhook_episodes:
-            _log("WARNING", f"No episodes in webhook, falling back to series processing: {series_path}")
+            _log("WARNING", f"[{instance}] No episodes in webhook, falling back to series processing: {series_path}")
             self.process_series(series_path, instance=instance)
             return
 
-        _log("INFO", f"Processing {len(webhook_episodes)} webhook episodes for: {series_path.name} (IMDb: {imdb_id})")
+        _log("INFO", f"[{instance}] Processing {len(webhook_episodes)} webhook episodes for: {series_path.name} (IMDb: {imdb_id})")
 
         self.db.upsert_series(imdb_id, str(series_path), instance=instance)
         
         # Get enhanced metadata from Sonarr
-        series_metadata = self._get_sonarr_series_metadata(imdb_id)
+        series_metadata = self._get_sonarr_series_metadata(imdb_id, instance=instance)
         
         episodes_processed = 0
         for webhook_episode in webhook_episodes:
@@ -701,15 +723,15 @@ class TVProcessor:
             episode_num = webhook_episode.get("episodeNumber")
             
             if not season_num or not episode_num:
-                _log("WARNING", f"Invalid episode data in webhook: {webhook_episode}")
+                _log("WARNING", f"[{instance}] Invalid episode data in webhook: {webhook_episode}")
                 continue
-            
+
             # Check if episode file exists on disk
             season_dir = series_path / config.get_season_dir_name(season_num)
             if not season_dir.exists():
-                _log("WARNING", f"Season directory not found: {season_dir}")
+                _log("WARNING", f"[{instance}] Season directory not found: {season_dir}")
                 continue
-                
+
             # Find matching episode files
             episode_files = []
             for file_path in season_dir.iterdir():
@@ -717,27 +739,27 @@ class TVProcessor:
                     parsed = self._parse_episode_from_filename(file_path.name)
                     if parsed and parsed == (season_num, episode_num):
                         episode_files.append(file_path)
-            
+
             if not episode_files:
-                _log("WARNING", f"No video files found for S{season_num:02d}E{episode_num:02d}")
+                _log("WARNING", f"[{instance}] No video files found for S{season_num:02d}E{episode_num:02d}")
                 continue
-                
+
             # Get episode date information - webhook processing prioritizes existing DB entries
-            _log("DEBUG", f"Processing webhook episode: IMDb={imdb_id}, S{season_num:02d}E{episode_num:02d}")
+            _log("DEBUG", f"[{instance}] Processing webhook episode: IMDb={imdb_id}, S{season_num:02d}E{episode_num:02d}")
             aired, dateadded, source = self._get_webhook_episode_date(imdb_id, season_num, episode_num, series_metadata, webhook_episode, instance=instance)
-            enhanced_metadata = self._get_episode_metadata(series_metadata, season_num, episode_num, season_dir) if series_metadata else self._get_episode_metadata(None, season_num, episode_num, season_dir)
-            
+            enhanced_metadata = self._get_episode_metadata(series_metadata, season_num, episode_num, season_dir, instance=instance) if series_metadata else self._get_episode_metadata(None, season_num, episode_num, season_dir, instance=instance)
+
             # NFO file operations removed - database is now the single source of truth
             # (Phase 1: Remove NFO file write operations)
-            
+
             self.db.upsert_episode_date(imdb_id, season_num, episode_num, aired, dateadded, source, True, instance=instance)
 
             verification = self.db.get_episode_date(imdb_id, season_num, episode_num, instance)
             if verification:
-                _log("DEBUG", f"Verified database entry saved: S{season_num:02d}E{episode_num:02d} -> {verification['dateadded']}")
+                _log("DEBUG", f"[{instance}] Verified database entry saved: S{season_num:02d}E{episode_num:02d} -> {verification['dateadded']}")
             else:
-                _log("ERROR", f"Failed to save episode to database: S{season_num:02d}E{episode_num:02d}")
-            
+                _log("ERROR", f"[{instance}] Failed to save episode to database: S{season_num:02d}E{episode_num:02d}")
+
             episodes_processed += 1
         
         # DISABLED: Skip creating season.nfo and tvshow.nfo files (user only wants episode NFOs)
@@ -755,7 +777,7 @@ class TVProcessor:
         #     tvdb_id = self.external_clients.get_tvdb_series_id(imdb_id)
         #     self.nfo_manager.create_tvshow_nfo(series_path, imdb_id, tvdb_id)
         
-        _log("INFO", f"Completed targeted processing: {episodes_processed}/{len(webhook_episodes)} episodes processed")
+        _log("INFO", f"[{instance}] Completed targeted processing: {episodes_processed}/{len(webhook_episodes)} episodes processed")
     
     def _parse_episode_from_filename(self, filename: str) -> Optional[Tuple[int, int]]:
         """Parse season and episode numbers from filename"""
@@ -771,17 +793,18 @@ class TVProcessor:
         
         return None
     
-    def _get_sonarr_series_metadata(self, imdb_id: str) -> Optional[Dict[str, Any]]:
+    def _get_sonarr_series_metadata(self, imdb_id: str, instance: str = 'sonarr') -> Optional[Dict[str, Any]]:
         """Get enhanced series metadata from Sonarr (database or API)"""
         try:
-            if not self.sonarr:
+            client, using_db, _ = self._resolve_sonarr(instance)
+            if not client:
                 return None
 
             # Handle different method names for DB vs API client
-            if self.using_db:
-                series_data = self.sonarr.get_series_by_imdb(imdb_id)
+            if using_db:
+                series_data = client.get_series_by_imdb(imdb_id)
             else:
-                series_data = self.sonarr.series_by_imdb(imdb_id)
+                series_data = client.series_by_imdb(imdb_id)
 
             if not series_data:
                 return None
@@ -791,10 +814,10 @@ class TVProcessor:
                 return None
 
             # Get all episodes for this series
-            if self.using_db:
-                episodes = self.sonarr.get_all_episodes_for_series(series_id)
+            if using_db:
+                episodes = client.get_all_episodes_for_series(series_id)
             else:
-                episodes = self.sonarr.episodes_for_series(series_id)
+                episodes = client.episodes_for_series(series_id)
 
             # Organize episodes by season/episode
             episode_map = {}
@@ -811,15 +834,15 @@ class TVProcessor:
             }
 
         except Exception as e:
-            _log("ERROR", f"Failed to get Sonarr series metadata for {imdb_id}: {e}")
+            _log("ERROR", f"[{instance}] Failed to get Sonarr series metadata for {imdb_id}: {e}")
             return None
-    
-    def _get_episode_metadata(self, series_metadata: Optional[Dict[str, Any]], season_num: int, episode_num: int, season_dir: Optional[Path] = None) -> Optional[Dict[str, Any]]:
+
+    def _get_episode_metadata(self, series_metadata: Optional[Dict[str, Any]], season_num: int, episode_num: int, season_dir: Optional[Path] = None, instance: str = 'sonarr') -> Optional[Dict[str, Any]]:
         """Get enhanced episode metadata including title extraction from filename"""
-        _log("DEBUG", f"Getting episode metadata for S{season_num:02d}E{episode_num:02d}, season_dir: {season_dir}")
-        
+        _log("DEBUG", f"[{instance}] Getting episode metadata for S{season_num:02d}E{episode_num:02d}, season_dir: {season_dir}")
+
         metadata = {}
-        
+
         # Try to get title from Sonarr first
         if series_metadata and 'episodes' in series_metadata:
             episode_data = series_metadata['episodes'].get((season_num, episode_num))
@@ -827,27 +850,27 @@ class TVProcessor:
                 title = episode_data.get('title')
                 if title and title != 'TBA':
                     metadata['title'] = title
-                    _log("DEBUG", f"Got title from Sonarr for S{season_num:02d}E{episode_num:02d}: {title}")
-        
+                    _log("DEBUG", f"[{instance}] Got title from Sonarr for S{season_num:02d}E{episode_num:02d}: {title}")
+
         # If no title from Sonarr, try to extract from filename
         if 'title' not in metadata and season_dir:
-            title = self._extract_title_from_filename(season_num, episode_num, season_dir)
+            title = self._extract_title_from_filename(season_num, episode_num, season_dir, instance=instance)
             if title:
                 metadata['title'] = title
-                _log("DEBUG", f"Extracted title from filename for S{season_num:02d}E{episode_num:02d}: {title}")
-        
+                _log("DEBUG", f"[{instance}] Extracted title from filename for S{season_num:02d}E{episode_num:02d}: {title}")
+
         return metadata if metadata else None
-    
-    def _extract_title_from_filename(self, season_num: int, episode_num: int, season_dir: Path) -> Optional[str]:
+
+    def _extract_title_from_filename(self, season_num: int, episode_num: int, season_dir: Path, instance: str = 'sonarr') -> Optional[str]:
         """Extract episode title from video filename using regex pattern"""
         season_pattern = f"S{season_num:02d}E{episode_num:02d}"
-        
+
         try:
             # Look for video files in the season directory
             for file_path in season_dir.iterdir():
                 if file_path.is_file() and file_path.suffix.lower() in ('.mkv', '.mp4', '.avi', '.mov', '.m4v'):
                     filename = file_path.name
-                    
+
                     # Check if this file matches our season/episode
                     if season_pattern in filename.upper():
                         # Extract title using regex pattern: S01E01-Title[WEBDL-1080p]
@@ -857,12 +880,12 @@ class TVProcessor:
                             # Clean up the title
                             title = title.replace('-', ' ').strip()
                             if title:
-                                _log("DEBUG", f"Extracted title '{title}' from filename: {filename}")
+                                _log("DEBUG", f"[{instance}] Extracted title '{title}' from filename: {filename}")
                                 return title
-                            
+
         except Exception as e:
-            _log("ERROR", f"Error extracting title from filename for S{season_num:02d}E{episode_num:02d}: {e}")
-        
+            _log("ERROR", f"[{instance}] Error extracting title from filename for S{season_num:02d}E{episode_num:02d}: {e}")
+
         return None
     
     def _get_webhook_episode_date(self, imdb_id: str, season_num: int, episode_num: int, series_metadata: Optional[Dict[str, Any]] = None, webhook_episode: Optional[Dict[str, Any]] = None, instance: str = 'sonarr') -> Tuple[Optional[str], Optional[str], str]:
@@ -887,7 +910,7 @@ class TVProcessor:
             existing_entry = self.db.get_episode_date(imdb_id, season_num, episode_num, instance)
             if existing_entry and existing_entry.get('dateadded'):
                 existing_date = existing_entry['dateadded']
-                _log("INFO", f"Found existing date in database for S{season_num:02d}E{episode_num:02d}: {existing_date}")
+                _log("INFO", f"[{instance}] Found existing date in database for S{season_num:02d}E{episode_num:02d}: {existing_date}")
                 
                 # For webhook processing, use existing data (fast path)
                 # Manual scans will validate below
@@ -901,10 +924,10 @@ class TVProcessor:
                 return aired, str(existing_date), "database:existing"
                 
         except Exception as e:
-            _log("DEBUG", f"Database check failed for S{season_num:02d}E{episode_num:02d}: {e}")
-        
-        _log("INFO", f"No existing date in database for S{season_num:02d}E{episode_num:02d}, checking Sonarr import history")
-        
+            _log("DEBUG", f"[{instance}] Database check failed for S{season_num:02d}E{episode_num:02d}: {e}")
+
+        _log("INFO", f"[{instance}] No existing date in database for S{season_num:02d}E{episode_num:02d}, checking Sonarr import history")
+
         # Get aired date and episode ID from Sonarr
         aired = None
         episode_id = None
@@ -913,53 +936,54 @@ class TVProcessor:
             if episode_data:
                 aired = episode_data.get('airDate')
                 episode_id = episode_data.get('id')
-                _log("DEBUG", f"Got aired date from Sonarr for S{season_num:02d}E{episode_num:02d}: {aired}")
-        
+                _log("DEBUG", f"[{instance}] Got aired date from Sonarr for S{season_num:02d}E{episode_num:02d}: {aired}")
+
         # STEP 2: Check Sonarr import history (authoritative source)
-        _log("INFO", f"Checking Sonarr import history for S{season_num:02d}E{episode_num:02d}")
-        
-        if episode_id and hasattr(self, 'sonarr'):
+        _log("INFO", f"[{instance}] Checking Sonarr import history for S{season_num:02d}E{episode_num:02d}")
+
+        client, _, _ = self._resolve_sonarr(instance)
+        if episode_id and client:
             try:
-                _log("DEBUG", f"Calling get_episode_import_history for episode_id: {episode_id}")
-                import_history = self.get_episode_import_history(episode_id)
-                _log("DEBUG", f"Import history result: {import_history}")
-                
+                _log("DEBUG", f"[{instance}] Calling get_episode_import_history for episode_id: {episode_id}")
+                import_history = self.get_episode_import_history(episode_id, instance=instance)
+                _log("DEBUG", f"[{instance}] Import history result: {import_history}")
+
                 if import_history:
                     # Found actual import event from Sonarr
-                    _log("INFO", f"Found Sonarr import event for S{season_num:02d}E{episode_num:02d}: {import_history}")
+                    _log("INFO", f"[{instance}] Found Sonarr import event for S{season_num:02d}E{episode_num:02d}: {import_history}")
                     return aired, import_history, "sonarr:import_history"
                 else:
                     # No import events found - this means only renames/moves exist in history
                     # The episode was already in Sonarr, just being managed/renamed
-                    _log("INFO", f"No import events found for S{season_num:02d}E{episode_num:02d} - only renames/moves in history")
-                    
+                    _log("INFO", f"[{instance}] No import events found for S{season_num:02d}E{episode_num:02d} - only renames/moves in history")
+
                     if aired:
-                        _log("INFO", f"Using air date for existing episode (rename-only history): {aired}")
+                        _log("INFO", f"[{instance}] Using air date for existing episode (rename-only history): {aired}")
                         return aired, aired + "T20:00:00", "airdate"
                     else:
-                        _log("DEBUG", f"No air date available for rename-only episode S{season_num:02d}E{episode_num:02d}")
-                    
+                        _log("DEBUG", f"[{instance}] No air date available for rename-only episode S{season_num:02d}E{episode_num:02d}")
+
             except Exception as e:
-                _log("ERROR", f"Error checking Sonarr import history for S{season_num:02d}E{episode_num:02d}: {e}")
+                _log("ERROR", f"[{instance}] Error checking Sonarr import history for S{season_num:02d}E{episode_num:02d}: {e}")
                 import traceback
                 _log("ERROR", traceback.format_exc())
         else:
             if not episode_id:
-                _log("DEBUG", f"No episode_id found for S{season_num:02d}E{episode_num:02d}")
-            if not hasattr(self, 'sonarr'):
-                _log("DEBUG", f"No sonarr client available")
-        
+                _log("DEBUG", f"[{instance}] No episode_id found for S{season_num:02d}E{episode_num:02d}")
+            if not client:
+                _log("DEBUG", f"[{instance}] No sonarr client available")
+
         # Check our database to avoid duplicates
         existing = self.db.get_episode_date(imdb_id, season_num, episode_num, instance)
         if existing and existing.get('dateadded'):
-            _log("INFO", f"Episode S{season_num:02d}E{episode_num:02d} already exists in our database: {existing['dateadded']}")
+            _log("INFO", f"[{instance}] Episode S{season_num:02d}E{episode_num:02d} already exists in our database: {existing['dateadded']}")
             return existing.get('aired'), existing.get('dateadded'), existing.get('source', 'chronarr:database')
-        
+
         # STEP 3: Truly new episode - use webhook date
         dateadded = datetime.now().isoformat()
         source = "sonarr:webhook"
-        
-        _log("INFO", f"No import history and not in database - using webhook date for genuinely new episode S{season_num:02d}E{episode_num:02d}: {dateadded}")
+
+        _log("INFO", f"[{instance}] No import history and not in database - using webhook date for genuinely new episode S{season_num:02d}E{episode_num:02d}: {dateadded}")
         
         return aired, dateadded, source
     

--- a/start_web.py
+++ b/start_web.py
@@ -11,6 +11,12 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 
+# utils.logging has to be imported before config.settings — importing it is
+# what actually loads .env/.env.secrets into the process (a side effect at
+# the bottom of that module). See the same note in main.py for the full
+# explanation of why this ordering matters.
+from utils.logging import _log
+
 # Import existing configuration (keep using core config for simplicity)
 from config.settings import config
 

--- a/static/index.html
+++ b/static/index.html
@@ -444,6 +444,15 @@
                                     <option value="tv">TV Shows Only</option>
                                 </select>
                             </div>
+                            <div class="form-group">
+                                <label>Instance:</label>
+                                <select id="populate-instance" required>
+                                    <option value="all">All Instances</option>
+                                </select>
+                                <p class="field-hint" style="font-size: 0.78rem; color: var(--text-muted); margin-top: 0.25rem;">
+                                    Picking a specific instance populates only that one and sets Media Type for you (a Radarr instance is always movies, a Sonarr instance always TV).
+                                </p>
+                            </div>
                             <button type="submit" class="btn btn-primary">
                                 <i class="fas fa-play"></i> Start Population
                             </button>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -54,7 +54,7 @@ function switchTab(tabName) {
         case 'movies': loadMovies(); break;
         case 'tv': loadSeries(); break;
         case 'reports': loadReport(); break;
-        case 'tools': loadDetailedStats(); break;
+        case 'tools': loadDetailedStats(); loadPopulateInstanceOptions(); break;
     }
 }
 
@@ -139,6 +139,10 @@ function initializeEventListeners() {
     document.getElementById('bulk-update-form').addEventListener('submit', handleBulkUpdate);
     document.getElementById('manual-scan-form').addEventListener('submit', handleManualScan);
     document.getElementById('populate-form').addEventListener('submit', handlePopulateDatabase);
+    const populateInstanceSelect = document.getElementById('populate-instance');
+    if (populateInstanceSelect) {
+        populateInstanceSelect.addEventListener('change', syncPopulateMediaTypeToInstance);
+    }
 }
 
 // API calls
@@ -1867,10 +1871,86 @@ async function bulkDeleteSelected() {
 // Database Population Functions
 // ---------------------------
 
+// Fills the Instance dropdown on the Populate Database card from the same
+// /api/instances data the sidebar already uses — "All Instances" plus one
+// entry per configured Radarr/Sonarr instance, grouped by type so it's
+// obvious which is which once there's more than a couple.
+async function loadPopulateInstanceOptions() {
+    const select = document.getElementById('populate-instance');
+    if (!select) return;
+
+    try {
+        const data = await apiCall('/api/instances');
+        const radarrNames = (data.radarr || []).map(i => i.name);
+        const sonarrNames = (data.sonarr || []).map(i => i.name);
+
+        // Keep "All Instances", drop everything else and rebuild — this
+        // gets called every time the Tools tab is opened, so it has to be
+        // safe to run repeatedly without piling up duplicate options.
+        select.innerHTML = '<option value="all">All Instances</option>';
+
+        if (radarrNames.length) {
+            const group = document.createElement('optgroup');
+            group.label = 'Radarr';
+            radarrNames.forEach(name => {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                opt.dataset.mediaType = 'movies';
+                group.appendChild(opt);
+            });
+            select.appendChild(group);
+        }
+
+        if (sonarrNames.length) {
+            const group = document.createElement('optgroup');
+            group.label = 'Sonarr';
+            sonarrNames.forEach(name => {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                opt.dataset.mediaType = 'tv';
+                group.appendChild(opt);
+            });
+            select.appendChild(group);
+        }
+
+        // Reset in case the last selection here no longer exists (e.g. an
+        // instance was deleted since this was last loaded).
+        syncPopulateMediaTypeToInstance();
+    } catch (error) {
+        console.error('Failed to load instances for populate dropdown:', error);
+        // Leave just "All Instances" — populate still works, just without
+        // the ability to target a single instance until this loads.
+    }
+}
+
+function syncPopulateMediaTypeToInstance() {
+    const instanceSelect = document.getElementById('populate-instance');
+    const mediaTypeSelect = document.getElementById('populate-media-type');
+    if (!instanceSelect || !mediaTypeSelect) return;
+
+    const selectedOption = instanceSelect.options[instanceSelect.selectedIndex];
+    const mediaType = selectedOption ? selectedOption.dataset.mediaType : null;
+
+    if (instanceSelect.value !== 'all' && mediaType) {
+        // A specific instance can only ever be one media type — a Radarr
+        // instance is movies, a Sonarr instance is TV. Lock the Media Type
+        // dropdown to match instead of making the user keep the two in sync
+        // by hand (picking the wrong one used to silently populate nothing).
+        mediaTypeSelect.value = mediaType;
+        mediaTypeSelect.disabled = true;
+    } else {
+        mediaTypeSelect.disabled = false;
+    }
+}
+
 async function handlePopulateDatabase(event) {
     event.preventDefault();
 
     const mediaType = document.getElementById('populate-media-type').value;
+    const instanceSelect = document.getElementById('populate-instance');
+    const instance = instanceSelect ? instanceSelect.value : 'all';
 
     // Validate input
     if (!mediaType) {
@@ -1879,7 +1959,8 @@ async function handlePopulateDatabase(event) {
     }
 
     // Confirm with user
-    const confirmMsg = `Are you sure you want to populate the database with ${mediaType}? This will query Radarr/Sonarr and may take several minutes.`;
+    const target = instance !== 'all' ? `instance '${instance}'` : `${mediaType}`;
+    const confirmMsg = `Are you sure you want to populate the database with ${target}? This will query Radarr/Sonarr and may take several minutes.`;
     if (!confirm(confirmMsg)) {
         return;
     }
@@ -1890,7 +1971,7 @@ async function handlePopulateDatabase(event) {
 
         // Start the population
         showToast('🚀 Starting database population...', 'info');
-        const response = await fetch(`/admin/populate-database?media_type=${mediaType}`, {
+        const response = await fetch(`/admin/populate-database?media_type=${mediaType}&instance=${encodeURIComponent(instance)}`, {
             method: 'POST',
             credentials: 'include'
         });

--- a/static/setup.html
+++ b/static/setup.html
@@ -157,6 +157,20 @@
             background: var(--success-color);
         }
 
+        .instance-row-actions {
+            display: flex;
+            gap: 0.4rem;
+            flex-wrap: wrap;
+        }
+
+        .btn-danger {
+            background: var(--danger-color);
+        }
+
+        .btn-danger:hover {
+            background: #c0392b;
+        }
+
         .empty-note {
             color: var(--text-muted);
             font-size: 0.9rem;
@@ -208,6 +222,170 @@
                 grid-template-columns: 1fr;
             }
         }
+
+        /* --- Add Instance wizard --- */
+
+        .btn-add-instance {
+            margin-top: 0.75rem;
+            padding: 0.45rem 0.9rem;
+            background: none;
+            border: 1px dashed var(--border-color);
+            border-radius: 6px;
+            color: #667eea;
+            font-size: 0.85rem;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4rem;
+        }
+
+        .btn-add-instance:hover {
+            background: var(--light-color);
+        }
+
+        .add-instance-form {
+            margin-top: 1rem;
+            padding-top: 1rem;
+            border-top: 1px solid var(--border-color);
+        }
+
+        .form-row {
+            margin-bottom: 0.85rem;
+        }
+
+        .form-row label {
+            display: block;
+            font-size: 0.85rem;
+            font-weight: 500;
+            color: var(--dark-color);
+            margin-bottom: 0.3rem;
+        }
+
+        .form-row input,
+        .form-row select {
+            width: 100%;
+            padding: 0.45rem 0.7rem;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            font-size: 0.9rem;
+            font-family: inherit;
+            box-sizing: border-box;
+        }
+
+        .form-row input:focus,
+        .form-row select:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.15);
+        }
+
+        .field-hint {
+            font-size: 0.78rem;
+            color: var(--text-muted);
+            margin-top: 0.25rem;
+        }
+
+        .db-toggle-row {
+            margin: 1rem 0 0.5rem;
+            font-size: 0.88rem;
+        }
+
+        .db-toggle-row label {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            cursor: pointer;
+            font-weight: 500;
+        }
+
+        .db-fields {
+            margin-top: 0.75rem;
+            padding: 0.85rem;
+            background: var(--light-color);
+            border-radius: 6px;
+        }
+
+        .wizard-actions {
+            display: flex;
+            gap: 0.6rem;
+            margin-top: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .wizard-actions button {
+            padding: 0.5rem 1rem;
+            border-radius: 5px;
+            font-size: 0.88rem;
+            cursor: pointer;
+            border: none;
+        }
+
+        .btn-primary {
+            background: #667eea;
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: #5a6fd6;
+        }
+
+        .btn-primary:disabled {
+            background: #a9b4e8;
+            cursor: not-allowed;
+        }
+
+        .btn-secondary {
+            background: var(--light-color);
+            color: var(--dark-color);
+            border: 1px solid var(--border-color) !important;
+        }
+
+        .btn-secondary:hover {
+            background: #e9ecef;
+        }
+
+        .btn-cancel {
+            background: none;
+            color: var(--text-muted);
+        }
+
+        .btn-cancel:hover {
+            text-decoration: underline;
+        }
+
+        .wizard-result {
+            margin-top: 0.85rem;
+            font-size: 0.85rem;
+            line-height: 1.5;
+        }
+
+        .wizard-result:empty {
+            margin-top: 0;
+        }
+
+        .wizard-result .result-success {
+            color: #155724;
+            background: #d4edda;
+            border-radius: 6px;
+            padding: 0.65rem 0.85rem;
+        }
+
+        .wizard-result .result-error {
+            color: #721c24;
+            background: #f8d7da;
+            border-radius: 6px;
+            padding: 0.65rem 0.85rem;
+        }
+
+        .wizard-result .result-testing {
+            color: var(--text-muted);
+        }
+
+        .test-badge {
+            display: inline-block;
+            font-size: 0.8rem;
+            margin-right: 0.75rem;
+        }
     </style>
 </head>
 <body>
@@ -253,6 +431,36 @@
                     <span class="loading-note">Loading&hellip;</span>
                 </div>
             </div>
+
+            <!-- Add Instance wizard -->
+            <div class="setup-section">
+                <h2><i class="fas fa-plus-circle"></i> Add Instance</h2>
+                <button class="btn-add-instance" onclick="toggleAddForm()" id="instance-add-toggle">
+                    <i class="fas fa-plus"></i> Add Radarr or Sonarr Instance
+                </button>
+                <div id="instance-add-form"></div>
+            </div>
+
+            <!-- Backup & Restore -->
+            <div class="setup-section">
+                <h2><i class="fas fa-database"></i> Backup &amp; Restore Config</h2>
+                <p class="hint-text" style="margin-top: 0;">
+                    A snapshot of <code>.env</code> and <code>.env.secrets</code> exactly as they are right now —
+                    every comment and setting, byte for byte. The downloaded file contains your real API keys and
+                    database passwords in plain text, so store it the same way you'd store either of those files.
+                    Every wizard save above also takes an automatic snapshot first, so a bad save is never a dead end.
+                </p>
+                <div class="wizard-actions">
+                    <a class="btn-secondary" href="/api/wizard/env-backup" style="text-decoration: none; display: inline-flex; align-items: center; gap: 0.4rem;">
+                        <i class="fas fa-download"></i> Download Backup
+                    </a>
+                    <button class="btn-secondary" onclick="document.getElementById('restore-file-input').click()">
+                        <i class="fas fa-upload"></i> Restore from Backup&hellip;
+                    </button>
+                    <input type="file" id="restore-file-input" accept="application/json" hidden onchange="handleRestoreFileChosen(event)" />
+                </div>
+                <div class="wizard-result" id="restore-result"></div>
+            </div>
         </div>
     </div>
 
@@ -273,7 +481,15 @@
             return base + path;
         }
 
-        function renderInstances(containerId, instances, serviceLabel) {
+        // The full instance name (e.g. "sonarr_strm") minus its media-type
+        // prefix is the bare segment the wizard's name field wants (e.g.
+        // "strm"). The default instance (name == media type exactly) has
+        // no segment at all.
+        function bareNameSegment(mediaType, fullName) {
+            return fullName === mediaType ? '' : fullName.slice(mediaType.length + 1);
+        }
+
+        function renderInstances(containerId, instances, serviceLabel, mediaType) {
             const container = document.getElementById(containerId);
             if (!instances || instances.length === 0) {
                 container.innerHTML = `<span class="empty-note">No ${serviceLabel} instances configured.</span>`;
@@ -295,6 +511,7 @@
                     : '';
 
                 const webhookUrl = buildWebhookUrl(inst.webhook_path);
+                const segment = bareNameSegment(mediaType, inst.name);
 
                 row.innerHTML = `
                     <div class="instance-meta">
@@ -304,9 +521,17 @@
                     <div class="webhook-url-cell">
                         <input type="text" class="url-field" value="${escHtml(webhookUrl)}" readonly />
                     </div>
-                    <button class="btn-copy" onclick="copyUrl(this)">
-                        <i class="fas fa-copy"></i> Copy
-                    </button>
+                    <div class="instance-row-actions">
+                        <button class="btn-copy" onclick="copyUrl(this)">
+                            <i class="fas fa-copy"></i> Copy
+                        </button>
+                        <button class="btn-copy" onclick="startEditInstance('${mediaType}', '${escHtml(segment)}')">
+                            <i class="fas fa-pen"></i> Edit
+                        </button>
+                        <button class="btn-copy btn-danger" onclick="deleteInstance('${mediaType}', '${escHtml(segment)}', '${escHtml(inst.name)}')">
+                            <i class="fas fa-trash"></i> Delete
+                        </button>
+                    </div>
                 `;
                 container.appendChild(row);
             }
@@ -322,23 +547,46 @@
             });
         }
 
+        function showCopied(btn) {
+            btn.classList.add('copied');
+            const originalHtml = btn.innerHTML;
+            btn.innerHTML = '<i class="fas fa-check"></i> Copied';
+            setTimeout(() => {
+                btn.innerHTML = originalHtml;
+                btn.classList.remove('copied');
+            }, 1800);
+        }
+
         function copyUrl(btn) {
             const input = btn.closest('.instance-row').querySelector('.url-field');
             if (!input) return;
-            navigator.clipboard.writeText(input.value).then(() => {
-                btn.classList.add('copied');
-                const icon = btn.querySelector('i');
-                const originalHtml = btn.innerHTML;
-                btn.innerHTML = '<i class="fas fa-check"></i> Copied';
-                setTimeout(() => {
-                    btn.innerHTML = originalHtml;
-                    btn.classList.remove('copied');
-                }, 1800);
-            }).catch(() => {
-                // Fallback for older browsers / HTTP contexts
+
+            // navigator.clipboard doesn't just reject on an insecure origin
+            // (plain HTTP on anything but localhost) — it's often undefined
+            // entirely, so accessing .writeText() throws synchronously,
+            // before a .then()/.catch() chain ever gets attached. Most
+            // people reaching this page over their LAN are on plain HTTP,
+            // so check for the API rather than assuming it exists.
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(input.value).then(() => {
+                    showCopied(btn);
+                }).catch(() => {
+                    fallbackCopy(input, btn);
+                });
+            } else {
+                fallbackCopy(input, btn);
+            }
+        }
+
+        function fallbackCopy(input, btn) {
+            try {
                 input.select();
+                input.setSelectionRange(0, input.value.length);
                 document.execCommand('copy');
-            });
+                showCopied(btn);
+            } catch (err) {
+                alert(`Could not copy automatically — select and copy manually:\n\n${input.value}`);
+            }
         }
 
         function escHtml(str) {
@@ -354,8 +602,8 @@
                 const resp = await fetch('/api/instances');
                 if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
                 const data = await resp.json();
-                renderInstances('radarr-list', data.radarr || [], 'Radarr');
-                renderInstances('sonarr-list', data.sonarr || [], 'Sonarr');
+                renderInstances('radarr-list', data.radarr || [], 'Radarr', 'radarr');
+                renderInstances('sonarr-list', data.sonarr || [], 'Sonarr', 'sonarr');
             } catch (err) {
                 const msg = `<span class="error-note"><i class="fas fa-times-circle"></i> Could not load instance data: ${escHtml(err.message)}</span>`;
                 document.getElementById('radarr-list').innerHTML = msg;
@@ -364,6 +612,454 @@
         }
 
         loadInstances();
+
+        // --- Add Instance wizard ---
+        //
+        // One form template shared by both Radarr and Sonarr — the only real
+        // difference between the two is the paths field label (movies vs TV)
+        // and a couple of placeholder strings, so it's simpler to generate
+        // the HTML once per media type than to keep two near-identical forms
+        // in sync by hand.
+
+        // FastAPI's own detail is a plain string, but a Pydantic validation
+        // error (a required field missing, wrong type, etc.) comes back as a
+        // list of {msg, loc, ...} objects instead — stringify that properly
+        // rather than letting it print as "[object Object]".
+        function formatErrorDetail(detail) {
+            if (!detail) return null;
+            if (typeof detail === 'string') return detail;
+            if (Array.isArray(detail)) {
+                return detail.map(d => d.msg || JSON.stringify(d)).join('; ');
+            }
+            return JSON.stringify(detail);
+        }
+
+        // One form for both Radarr and Sonarr — a Media Type dropdown at the
+        // top drives which labels/placeholders show and which payload field
+        // (movie_paths vs tv_paths) the paths box maps to. Fixed "instance-add-*"
+        // ids throughout since there's only ever one copy of this form now;
+        // switching the dropdown re-labels in place rather than rebuilding
+        // the form, so nothing already typed gets lost by picking the wrong
+        // type first.
+
+        function addFormTemplate() {
+            return `
+                <div class="add-instance-form">
+                    <div class="form-row">
+                        <label>Media Type</label>
+                        <select id="instance-add-type" onchange="onInstanceTypeChange()">
+                            <option value="radarr">Radarr</option>
+                            <option value="sonarr">Sonarr</option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <label>Instance Name</label>
+                        <input type="text" id="instance-add-name" placeholder="e.g. 4k, strm — leave blank for the default instance" />
+                        <p class="field-hint">Letters, numbers, and underscores only — it becomes part of an env var name and the webhook URL.</p>
+                    </div>
+                    <div class="form-row">
+                        <label id="instance-add-url-label">Radarr URL</label>
+                        <input type="text" id="instance-add-url" placeholder="http://radarr:7878" />
+                    </div>
+                    <div class="form-row">
+                        <label>API Key</label>
+                        <input type="text" id="instance-add-api-key" placeholder="Found in Radarr → Settings → General" />
+                    </div>
+                    <div class="form-row">
+                        <label>Root Folders</label>
+                        <input type="text" id="instance-add-root-folders" placeholder="What Radarr sees on its side, comma-separated for more than one" />
+                        <p class="field-hint">Leave blank and hit Test Connection — filled in automatically from Radarr/Sonarr's own root folders.</p>
+                    </div>
+                    <div class="form-row">
+                        <label id="instance-add-paths-label">Movie Paths</label>
+                        <input type="text" id="instance-add-paths" placeholder="Container paths where movies live, comma-separated (e.g. /data/movies)" />
+                    </div>
+
+                    <div class="db-toggle-row">
+                        <label>
+                            <input type="checkbox" id="instance-add-db-enable" onchange="toggleDbFields()" />
+                            <span id="instance-add-db-toggle-label">Connect directly to Radarr's database (faster than the API, optional)</span>
+                        </label>
+                    </div>
+                    <div class="db-fields" id="instance-add-db-fields" hidden>
+                        <div class="form-row">
+                            <label>Database Type</label>
+                            <select id="instance-add-db-type" onchange="toggleDbTypeFields()">
+                                <option value="sqlite">SQLite</option>
+                                <option value="postgresql">PostgreSQL</option>
+                            </select>
+                        </div>
+                        <div class="form-row" id="instance-add-db-path-row">
+                            <label>SQLite Path</label>
+                            <input type="text" id="instance-add-db-path" placeholder="/radarr-4k-data/radarr.db" />
+                        </div>
+                        <div id="instance-add-db-pg-fields" hidden>
+                            <div class="form-row"><label>DB Host</label><input type="text" id="instance-add-db-host" /></div>
+                            <div class="form-row"><label>DB Port</label><input type="text" id="instance-add-db-port" placeholder="5432" /></div>
+                            <div class="form-row"><label>DB Name</label><input type="text" id="instance-add-db-name" /></div>
+                            <div class="form-row"><label>DB User</label><input type="text" id="instance-add-db-user" /></div>
+                            <div class="form-row"><label>DB Password</label><input type="password" id="instance-add-db-password" /></div>
+                        </div>
+                    </div>
+
+                    <div class="wizard-actions">
+                        <button class="btn-secondary" onclick="testWizardConnection()" id="instance-add-test-btn">Test Connection</button>
+                        <button class="btn-primary" onclick="saveWizardInstance()" id="instance-add-save-btn">Save Instance</button>
+                        <button class="btn-cancel" onclick="toggleAddForm()">Cancel</button>
+                    </div>
+                    <div class="wizard-result" id="instance-add-result"></div>
+                </div>
+            `;
+        }
+
+        function toggleAddForm() {
+            const container = document.getElementById('instance-add-form');
+            const toggleBtn = document.getElementById('instance-add-toggle');
+            if (container.innerHTML.trim()) {
+                // Already open — collapse it back to the "+ Add" button.
+                container.innerHTML = '';
+                toggleBtn.hidden = false;
+                return;
+            }
+            container.innerHTML = addFormTemplate();
+            // container itself survives innerHTML swaps, so any leftover
+            // editMode flag from a previous Edit needs clearing here —
+            // opening via the plain "+ Add Instance" button always means a
+            // real add, never a continuation of an earlier edit.
+            container.dataset.editMode = 'false';
+            toggleBtn.hidden = true;
+        }
+
+        // Opens the Add Instance form pre-filled with one instance's current
+        // settings and switches it into edit mode — Name and Media Type get
+        // locked (editing doesn't rename or retype an instance), everything
+        // else stays editable. mediaType/segment identify which instance;
+        // segment is "" for the default (unprefixed) instance.
+        async function startEditInstance(mediaType, segment) {
+            const container = document.getElementById('instance-add-form');
+            container.innerHTML = addFormTemplate();
+            document.getElementById('instance-add-toggle').hidden = true;
+
+            const resultEl = document.getElementById('instance-add-result');
+            resultEl.innerHTML = `<span class="result-testing">Loading current settings&hellip;</span>`;
+
+            try {
+                const resp = await fetch(
+                    `/api/wizard/instance-details?media_type=${encodeURIComponent(mediaType)}&name=${encodeURIComponent(segment)}`
+                );
+                const data = await resp.json();
+                if (!resp.ok) throw new Error(formatErrorDetail(data.detail) || `HTTP ${resp.status}`);
+
+                document.getElementById('instance-add-type').value = mediaType;
+                document.getElementById('instance-add-type').disabled = true;
+                onInstanceTypeChange();
+
+                document.getElementById('instance-add-name').value = segment;
+                document.getElementById('instance-add-name').disabled = true;
+                document.getElementById('instance-add-url').value = data.url || '';
+                document.getElementById('instance-add-api-key').value = data.api_key || '';
+                document.getElementById('instance-add-root-folders').value = (data.root_folders || []).join(',');
+
+                const paths = mediaType === 'radarr' ? data.movie_paths : data.tv_paths;
+                document.getElementById('instance-add-paths').value = (paths || []).join(',');
+
+                if (data.db_type) {
+                    document.getElementById('instance-add-db-enable').checked = true;
+                    toggleDbFields();
+                    document.getElementById('instance-add-db-type').value = data.db_type;
+                    toggleDbTypeFields();
+                    if (data.db_type === 'sqlite') {
+                        document.getElementById('instance-add-db-path').value = data.db_path || '';
+                    } else {
+                        document.getElementById('instance-add-db-host').value = data.db_host || '';
+                        document.getElementById('instance-add-db-port').value = data.db_port || '';
+                        document.getElementById('instance-add-db-name').value = data.db_name || '';
+                        document.getElementById('instance-add-db-user').value = data.db_user || '';
+                        document.getElementById('instance-add-db-password').value = data.db_password || '';
+                    }
+                }
+
+                container.dataset.editMode = 'true';
+                document.getElementById('instance-add-save-btn').textContent = 'Save Changes';
+
+                const fullName = segment ? `${mediaType}_${segment}` : mediaType;
+                resultEl.innerHTML = `<div class="result-success">Editing <strong>${escHtml(fullName)}</strong> — change what you need, then Save Changes.</div>`;
+                container.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            } catch (err) {
+                resultEl.innerHTML = `<div class="result-error">Could not load current settings: ${escHtml(err.message)}</div>`;
+            }
+        }
+
+        async function deleteInstance(mediaType, segment, fullName) {
+            const confirmed = confirm(
+                `Delete ${fullName}? This removes it from .env and .env.secrets.\n\n` +
+                `A snapshot of the current files is taken first, so this can be undone by restoring ` +
+                `that backup from the Backup & Restore section below.\n\n` +
+                `Note: if this instance's env vars were already present when the container was created, ` +
+                `a plain restart may not fully remove it — you may need to recreate the container ` +
+                `(docker compose up -d --force-recreate).`
+            );
+            if (!confirmed) return;
+
+            try {
+                const resp = await fetch('/api/wizard/delete-instance', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ media_type: mediaType, name: segment }),
+                });
+                const data = await resp.json();
+                if (!resp.ok) throw new Error(formatErrorDetail(data.detail) || `HTTP ${resp.status}`);
+
+                alert(`Removed ${data.instance_name} from the config files.\n\n${data.restart_reason}`);
+                loadInstances();
+            } catch (err) {
+                alert(`Could not delete ${fullName}: ${err.message}`);
+            }
+        }
+
+        // Re-labels the form in place for the currently selected media type.
+        // Doesn't touch any entered values — only the labels/placeholders/
+        // hints that describe which service they're for.
+        function onInstanceTypeChange() {
+            const mediaType = document.getElementById('instance-add-type').value;
+            const isRadarr = mediaType === 'radarr';
+            const label = isRadarr ? 'Radarr' : 'Sonarr';
+            const defaultPort = isRadarr ? '7878' : '8989';
+
+            document.getElementById('instance-add-url-label').textContent = `${label} URL`;
+            document.getElementById('instance-add-url').placeholder = `http://${mediaType}:${defaultPort}`;
+            document.getElementById('instance-add-api-key').placeholder = `Found in ${label} → Settings → General`;
+            document.getElementById('instance-add-root-folders').placeholder = `What ${label} sees on its side, comma-separated for more than one`;
+            document.getElementById('instance-add-db-toggle-label').textContent =
+                `Connect directly to ${label}'s database (faster than the API, optional)`;
+            document.getElementById('instance-add-db-path').placeholder =
+                `/${mediaType}-${isRadarr ? '4k' : 'strm'}-data/${mediaType}.db`;
+
+            const pathsLabel = document.getElementById('instance-add-paths-label');
+            const pathsInput = document.getElementById('instance-add-paths');
+            if (isRadarr) {
+                pathsLabel.textContent = 'Movie Paths';
+                pathsInput.placeholder = 'Container paths where movies live, comma-separated (e.g. /data/movies)';
+            } else {
+                pathsLabel.textContent = 'TV Paths';
+                pathsInput.placeholder = 'Container paths where TV shows live, comma-separated (e.g. /data/tv)';
+            }
+        }
+
+        function toggleDbFields() {
+            const enabled = document.getElementById('instance-add-db-enable').checked;
+            document.getElementById('instance-add-db-fields').hidden = !enabled;
+            if (enabled) toggleDbTypeFields();
+        }
+
+        function toggleDbTypeFields() {
+            const isSqlite = document.getElementById('instance-add-db-type').value === 'sqlite';
+            document.getElementById('instance-add-db-path-row').hidden = !isSqlite;
+            document.getElementById('instance-add-db-pg-fields').hidden = isSqlite;
+        }
+
+        // Comma-separated text field -> array of trimmed, non-empty strings.
+        function splitCsv(value) {
+            return (value || '').split(',').map(s => s.trim()).filter(Boolean);
+        }
+
+        // Read every field currently in the form into the shape the wizard
+        // API expects. Shared by the test and save calls so they can never
+        // drift apart on what a field means.
+        function collectWizardPayload() {
+            const field = id => document.getElementById(id).value.trim();
+            const mediaType = document.getElementById('instance-add-type').value;
+            const editMode = document.getElementById('instance-add-form').dataset.editMode === 'true';
+
+            const payload = {
+                media_type: mediaType,
+                name: field('instance-add-name'),
+                url: field('instance-add-url'),
+                api_key: field('instance-add-api-key'),
+                root_folders: splitCsv(field('instance-add-root-folders')),
+                edit_existing: editMode,
+            };
+
+            const paths = splitCsv(field('instance-add-paths'));
+            if (mediaType === 'radarr') {
+                payload.movie_paths = paths;
+            } else {
+                payload.tv_paths = paths;
+            }
+
+            if (document.getElementById('instance-add-db-enable').checked) {
+                payload.db_type = document.getElementById('instance-add-db-type').value;
+                if (payload.db_type === 'sqlite') {
+                    payload.db_path = field('instance-add-db-path');
+                } else {
+                    payload.db_host = field('instance-add-db-host');
+                    const port = field('instance-add-db-port');
+                    if (port) payload.db_port = parseInt(port, 10);
+                    payload.db_name = field('instance-add-db-name');
+                    payload.db_user = field('instance-add-db-user');
+                    payload.db_password = field('instance-add-db-password');
+                }
+            }
+
+            return payload;
+        }
+
+        async function testWizardConnection() {
+            const resultEl = document.getElementById('instance-add-result');
+            const btn = document.getElementById('instance-add-test-btn');
+            const payload = collectWizardPayload();
+
+            if (!payload.url || !payload.api_key) {
+                resultEl.innerHTML = `<div class="result-error">URL and API key are required before testing.</div>`;
+                return;
+            }
+
+            btn.disabled = true;
+            resultEl.innerHTML = `<span class="result-testing">Testing&hellip;</span>`;
+
+            try {
+                const resp = await fetch('/api/wizard/test-connection', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                const data = await resp.json();
+                if (!resp.ok) throw new Error(formatErrorDetail(data.detail) || `HTTP ${resp.status}`);
+
+                const parts = [];
+                if (data.api) {
+                    parts.push(data.api.success
+                        ? `<span class="test-badge">✅ API connection OK</span>`
+                        : `<span class="test-badge">❌ API: ${escHtml(data.api.error)}</span>`);
+
+                    // Radarr/Sonarr already know their own root folders — no
+                    // reason to make someone retype what the API already
+                    // has. Only fills the field if it's still empty, so this
+                    // never overwrites something the user already typed.
+                    if (data.api.success && data.api.root_folders && data.api.root_folders.length) {
+                        const rootFoldersInput = document.getElementById('instance-add-root-folders');
+                        if (rootFoldersInput && !rootFoldersInput.value.trim()) {
+                            rootFoldersInput.value = data.api.root_folders.join(',');
+                            parts.push(`<span class="test-badge">📁 Found ${data.api.root_folders.length} root folder(s), filled in below</span>`);
+                        }
+                    }
+                }
+                if (data.db) {
+                    parts.push(data.db.success
+                        ? `<span class="test-badge">✅ Database connection OK</span>`
+                        : `<span class="test-badge">❌ Database: ${escHtml(data.db.error)}</span>`);
+                }
+                resultEl.innerHTML = parts.length ? parts.join('') : 'Nothing to test yet — fill in a URL/API key or enable the database section.';
+            } catch (err) {
+                resultEl.innerHTML = `<div class="result-error">${escHtml(err.message)}</div>`;
+            } finally {
+                btn.disabled = false;
+            }
+        }
+
+        async function saveWizardInstance() {
+            const resultEl = document.getElementById('instance-add-result');
+            const saveBtn = document.getElementById('instance-add-save-btn');
+            const payload = collectWizardPayload();
+
+            if (!payload.url || !payload.api_key) {
+                resultEl.innerHTML = `<div class="result-error">URL and API key are required.</div>`;
+                return;
+            }
+
+            saveBtn.disabled = true;
+            resultEl.innerHTML = `<span class="result-testing">Saving&hellip;</span>`;
+
+            try {
+                const resp = await fetch('/api/wizard/save-instance', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                const data = await resp.json();
+                if (!resp.ok) throw new Error(formatErrorDetail(data.detail) || `HTTP ${resp.status}`);
+
+                resultEl.innerHTML = `
+                    <div class="result-success">
+                        <strong>Added ${escHtml(data.instance_name)}.</strong>
+                        Webhook path: <code>${escHtml(data.webhook_path)}</code><br>
+                        ${escHtml(data.restart_reason)}
+                    </div>
+                `;
+                // The new instance isn't live until chronarr-core restarts, so
+                // there's nothing more to do here — leave the success message
+                // up rather than collapsing the form, and refresh the instance
+                // list in case a restart already happened in the background.
+                loadInstances();
+            } catch (err) {
+                resultEl.innerHTML = `<div class="result-error">${escHtml(err.message)}</div>`;
+            } finally {
+                saveBtn.disabled = false;
+            }
+        }
+
+        // --- Backup & Restore ---
+
+        function handleRestoreFileChosen(event) {
+            const file = event.target.files[0];
+            // Clear the input now so choosing the same filename again later
+            // still fires this handler — browsers don't fire `change` for
+            // an unchanged value otherwise.
+            event.target.value = '';
+            if (!file) return;
+
+            const resultEl = document.getElementById('restore-result');
+            const reader = new FileReader();
+            reader.onload = () => restoreFromBackupText(reader.result, resultEl);
+            reader.onerror = () => {
+                resultEl.innerHTML = `<div class="result-error">Could not read that file.</div>`;
+            };
+            reader.readAsText(file);
+        }
+
+        async function restoreFromBackupText(text, resultEl) {
+            let backup;
+            try {
+                backup = JSON.parse(text);
+            } catch (err) {
+                resultEl.innerHTML = `<div class="result-error">That doesn't look like a valid backup file — it isn't valid JSON.</div>`;
+                return;
+            }
+
+            if (typeof backup.env !== 'string' || typeof backup.env_secrets !== 'string') {
+                resultEl.innerHTML = `<div class="result-error">That file doesn't look like a Chronarr env backup — missing "env"/"env_secrets" content.</div>`;
+                return;
+            }
+
+            const when = backup.exported_at ? ` from ${backup.exported_at}` : '';
+            const confirmed = confirm(
+                `This will overwrite your current .env and .env.secrets with the backup${when}. ` +
+                `Chronarr auto-snapshots the current files first, so this can be undone by restoring again — ` +
+                `but it does take effect immediately on disk. Continue?`
+            );
+            if (!confirmed) return;
+
+            resultEl.innerHTML = `<span class="result-testing">Restoring&hellip;</span>`;
+
+            try {
+                const resp = await fetch('/api/wizard/env-restore', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(backup),
+                });
+                const data = await resp.json();
+                if (!resp.ok) throw new Error(formatErrorDetail(data.detail) || `HTTP ${resp.status}`);
+
+                resultEl.innerHTML = `
+                    <div class="result-success">
+                        <strong>Restored.</strong> ${escHtml(data.restart_reason)}<br>
+                        Your previous files were saved as <code>${escHtml(data.pre_restore_backup || 'n/a')}</code> first.
+                    </div>
+                `;
+            } catch (err) {
+                resultEl.innerHTML = `<div class="result-error">${escHtml(err.message)}</div>`;
+            }
+        }
     </script>
 </body>
 </html>

--- a/webhooks/webhook_batcher.py
+++ b/webhooks/webhook_batcher.py
@@ -53,8 +53,9 @@ class WebhookBatcher:
                 webhook_data['episodes'] = existing_eps
 
             self.pending[key] = webhook_data
-            _log("INFO", f"Batched {media_type} webhook for {key} ({len(webhook_data.get('episodes', []))} episode(s) pending)")
-            _log("DEBUG", f"Batch added - key: {key}, media_type: {media_type}, timer scheduled for {config.batch_delay}s")
+            instance = webhook_data.get('instance', media_type)
+            _log("INFO", f"[{instance}] Batched {media_type} webhook for {key} ({len(webhook_data.get('episodes', []))} episode(s) pending)")
+            _log("DEBUG", f"[{instance}] Batch added - key: {key}, media_type: {media_type}, timer scheduled for {config.batch_delay}s")
 
             timer = threading.Timer(config.batch_delay, self._process_item, args=[key])
             self.timers[key] = timer
@@ -68,7 +69,8 @@ class WebhookBatcher:
             if key in self.processing:
                 # Previous batch for this key is still running — re-schedule so accumulated
                 # episode data isn't stranded with no timer and no processor to pick it up.
-                _log("DEBUG", f"Batch item {key} still processing, re-scheduling in {config.batch_delay}s")
+                instance = self.pending[key].get('instance', '?')
+                _log("DEBUG", f"[{instance}] Batch item {key} still processing, re-scheduling in {config.batch_delay}s")
                 timer = threading.Timer(config.batch_delay, self._process_item, args=[key])
                 self.timers[key] = timer
                 timer.start()
@@ -89,17 +91,18 @@ class WebhookBatcher:
         try:
             media_type = webhook_data.get('media_type')
             path_str = webhook_data.get('path')
-            
-            _log("DEBUG", f"Processing batch item: key={key}, media_type={media_type}, path={path_str}")
-            
+            instance = webhook_data.get('instance', media_type or '?')
+
+            _log("DEBUG", f"[{instance}] Processing batch item: key={key}, media_type={media_type}, path={path_str}")
+
             if not path_str:
-                _log("ERROR", f"No path found for {media_type} {key}")
+                _log("ERROR", f"[{instance}] No path found for {media_type} {key}")
                 return
-            
+
             path_obj = Path(path_str)
             if not path_obj.exists():
-                _log("ERROR", f"BATCH PROCESSING FAILED: Path does not exist: {path_obj}")
-                _log("ERROR", f"This indicates a path mapping issue - webhook rejected to prevent wrong processing")
+                _log("ERROR", f"[{instance}] BATCH PROCESSING FAILED: Path does not exist: {path_obj}")
+                _log("ERROR", f"[{instance}] This indicates a path mapping issue - webhook rejected to prevent wrong processing")
                 return
             
             # Validate IMDb ID for movies — only reject if a conflicting ID is found.
@@ -112,14 +115,14 @@ class WebhookBatcher:
                 if detected_imdb:
                     # An ID was found — check it matches
                     if detected_imdb == expected_imdb or detected_imdb.replace('tt', '') == expected_imdb.replace('tt', ''):
-                        _log("DEBUG", f"Batch validation passed: IMDb {expected_imdb} confirmed in folder name")
+                        _log("DEBUG", f"[{instance}] Batch validation passed: IMDb {expected_imdb} confirmed in folder name")
                     else:
-                        _log("ERROR", f"BATCH VALIDATION FAILED: folder contains {detected_imdb} but webhook expected {expected_imdb} in {path_str}")
-                        _log("ERROR", f"This prevents processing the wrong movie due to a mismatched batch entry")
+                        _log("ERROR", f"[{instance}] BATCH VALIDATION FAILED: folder contains {detected_imdb} but webhook expected {expected_imdb} in {path_str}")
+                        _log("ERROR", f"[{instance}] This prevents processing the wrong movie due to a mismatched batch entry")
                         return
                 else:
                     # No IMDb ID in folder/file names — standard naming, trust the webhook
-                    _log("DEBUG", f"Batch validation: no IMDb in folder name for {path_str}, trusting webhook ID {expected_imdb}")
+                    _log("DEBUG", f"[{instance}] Batch validation: no IMDb in folder name for {path_str}, trusting webhook ID {expected_imdb}")
 
             # Validate IMDb ID for TV shows — same logic: conflict = reject, absent = proceed.
             if media_type == 'tv':
@@ -128,65 +131,71 @@ class WebhookBatcher:
                 detected_imdb = parse_imdb_from_path(path_obj)
                 if detected_imdb:
                     if detected_imdb == expected_imdb or detected_imdb.replace('tt', '') == expected_imdb.replace('tt', ''):
-                        _log("DEBUG", f"TV batch validation passed: IMDb {expected_imdb} confirmed in folder name")
+                        _log("DEBUG", f"[{instance}] TV batch validation passed: IMDb {expected_imdb} confirmed in folder name")
                     else:
-                        _log("ERROR", f"BATCH VALIDATION FAILED: folder contains {detected_imdb} but webhook expected {expected_imdb} in TV {path_str}")
-                        _log("ERROR", f"This prevents processing the wrong series due to a mismatched batch entry")
+                        _log("ERROR", f"[{instance}] BATCH VALIDATION FAILED: folder contains {detected_imdb} but webhook expected {expected_imdb} in TV {path_str}")
+                        _log("ERROR", f"[{instance}] This prevents processing the wrong series due to a mismatched batch entry")
                         return
                 else:
-                    _log("DEBUG", f"TV batch validation: no IMDb in folder name for {path_str}, trusting webhook ID {expected_imdb}")
-                
+                    _log("DEBUG", f"[{instance}] TV batch validation: no IMDb in folder name for {path_str}, trusting webhook ID {expected_imdb}")
+
                 if not self.tv_processor:
-                    _log("ERROR", "TV processor not available")
+                    _log("ERROR", f"[{instance}] TV processor not available")
                     return
 
-                instance = webhook_data.get('instance', 'sonarr')
                 processing_mode = webhook_data.get('processing_mode', config.tv_webhook_processing_mode)
                 episodes_data = webhook_data.get('episodes', [])
 
                 if processing_mode == 'targeted' and episodes_data:
-                    _log("INFO", f"Using targeted episode processing for {len(episodes_data)} episodes")
+                    _log("INFO", f"[{instance}] Using targeted episode processing for {len(episodes_data)} episodes")
                     if len(episodes_data) > 1 and config.sequential_delay > 0:
-                        _log("INFO", f"Processing {len(episodes_data)} episodes sequentially with {config.sequential_delay}s delay")
-                        self._process_episodes_sequentially(path_obj, episodes_data, instance=instance)
+                        _log("INFO", f"[{instance}] Processing {len(episodes_data)} episodes sequentially with {config.sequential_delay}s delay")
+                        self._process_episodes_sequentially(path_obj, episodes_data, imdb_id=expected_imdb, instance=instance)
                     else:
                         self.tv_processor.process_webhook_episodes(path_obj, episodes_data, imdb_id=expected_imdb, instance=instance)
                 else:
-                    _log("INFO", f"Using series processing mode (fallback or configured)")
+                    _log("INFO", f"[{instance}] Using series processing mode (fallback or configured)")
                     self.tv_processor.process_series(path_obj, imdb_id=expected_imdb, instance=instance)
 
             elif media_type == 'movie':
                 if not self.movie_processor:
-                    _log("ERROR", "Movie processor not available")
+                    _log("ERROR", f"[{instance}] Movie processor not available")
                     return
 
-                instance = webhook_data.get('instance', 'radarr')
                 self.movie_processor.process_movie(path_obj, webhook_mode=True, imdb_id=expected_imdb, instance=instance)
             else:
-                _log("ERROR", f"Unknown media type: {media_type}")
-        
+                _log("ERROR", f"[{instance}] Unknown media type: {media_type}")
+
         except Exception as e:
-            _log("ERROR", f"Error processing {media_type} {key}: {e}")
+            _log("ERROR", f"[{locals().get('instance', '?')}] Error processing {media_type} {key}: {e}")
         finally:
             with self.lock:
                 self.processing.discard(key)
     
-    def _process_episodes_sequentially(self, path_obj: Path, episodes_data: list, instance: str = 'sonarr'):
-        """Process episodes one by one with delays to avoid Sonarr API spam."""
+    def _process_episodes_sequentially(self, path_obj: Path, episodes_data: list, imdb_id: str = None, instance: str = 'sonarr'):
+        """Process episodes one by one with delays to avoid Sonarr API spam.
+
+        imdb_id is the ID the batch already validated (webhook-provided,
+        or confirmed against the folder name) — pass it through rather than
+        letting process_webhook_episodes() re-derive it from the path.
+        That fallback only works for ID-tagged folder names; a normal
+        "Gunsmoke" folder with no embedded IMDb tag has nothing to parse,
+        so every episode in the batch would fail outright without this.
+        """
         total_episodes = len(episodes_data)
         for i, episode in enumerate(episodes_data, 1):
             try:
                 season = episode.get('seasonNumber', '?')
                 episode_num = episode.get('episodeNumber', '?')
-                _log("INFO", f"Processing episode {i}/{total_episodes}: S{season:02d}E{episode_num:02d}")
-                self.tv_processor.process_webhook_episodes(path_obj, [episode], instance=instance)
+                _log("INFO", f"[{instance}] Processing episode {i}/{total_episodes}: S{season:02d}E{episode_num:02d}")
+                self.tv_processor.process_webhook_episodes(path_obj, [episode], imdb_id=imdb_id, instance=instance)
                 if i < total_episodes and config.sequential_delay > 0:
-                    _log("INFO", f"Waiting {config.sequential_delay}s before next episode...")
+                    _log("INFO", f"[{instance}] Waiting {config.sequential_delay}s before next episode...")
                     time.sleep(config.sequential_delay)
             except Exception as e:
-                _log("ERROR", f"Error processing episode {i}/{total_episodes}: {e}")
+                _log("ERROR", f"[{instance}] Error processing episode {i}/{total_episodes}: {e}")
 
-        _log("INFO", f"Completed sequential processing of {total_episodes} episodes")
+        _log("INFO", f"[{instance}] Completed sequential processing of {total_episodes} episodes")
     
     def get_status(self) -> Dict:
         """Get batch queue status"""


### PR DESCRIPTION
…ixes

Setup Wizard (v3 plan Part 5): add, edit, and delete Radarr/Sonarr instances from /setup without hand-editing env files.

- config/env_writer.py writes instance config into .env/.env.secrets, touching only the keys it's given; secrets always land in .env.secrets, never .env. Backup/restore endpoints for both files.
- New wizard endpoints: test-connection, save-instance (add or edit), delete-instance, instance-details, env-backup, env-restore.
- Root Folders auto-fill from Radarr/Sonarr's own API instead of requiring manual entry.
- /setup shows per-instance health (connected/method) instead of one global status, with Edit/Delete on each row.
- Populate Database's instance picker now derives Media Type from the selected instance (Radarr -> movies, Sonarr -> TV) instead of requiring both to be set in sync; the backend treats the instance's own type as authoritative so a mismatched media_type can't silently populate nothing.

Multi-instance webhook processing fixes:

- TVProcessor/MovieProcessor were built once at startup wired only to the default Radarr/Sonarr instance. The `instance` parameter threaded through every method only tagged Chronarr's own DB writes, never selected which server to actually query - so a named instance's webhook silently fell back to air-date/release-date instead of real import history. Both processors now resolve client, using_db, and path_mapper per call from the InstanceRegistry using that parameter. Also fixes the Sonarr webhook route not passing instance through to series-path resolution, which would have used the default instance's root folder mapping even after the processor-level fix.
- Every log line in the webhook receive/batch/process path is now tagged with the instance name it belongs to.
- Multi-episode webhook batches were losing their IMDb ID for series without an ID embedded in the folder name, falling back to a path parse that only works for ID-tagged folders.
- Episode dates read via direct Sonarr DB access were mislabeled as coming from the API.
- .env/.env.secrets are now loaded before the instance-discovery config is built, so a newly added instance is picked up without needing a full container recreate.
- The web container's core-proxy hostname no longer collides with core's own bind-address setting.