### PR TITLE
fix: instance-scoped episodes/delete, orphaned-cleanup, and setup page

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -1651,24 +1651,29 @@ async def cleanup_orphaned_records_hybrid(request: OrphanedCleanupRequest, depen
     from utils.orphaned_cleanup import OrphanedRecordCleaner
 
     db = dependencies["db"]
-    radarr_db_client = dependencies.get("radarr_db_client")
-    sonarr_db_client = dependencies.get("sonarr_db_client")
+    registry = dependencies.get("registry")
 
     try:
-        # Initialize the cleaner with available database clients
+        # Initialize the cleaner — registry lets it resolve the right
+        # Radarr/Sonarr client per row's own instance instead of a single
+        # fixed client (the old radarr_db_client/sonarr_db_client keys were
+        # never actually populated in dependencies, so check_database was
+        # silently inert before this).
         cleaner = OrphanedRecordCleaner(
             chronarr_db=db,
-            radarr_db_client=radarr_db_client,
-            sonarr_db_client=sonarr_db_client
+            registry=registry
         )
 
         # Validate that we can perform the requested checks
         warnings = []
         if request.check_database:
-            if request.check_movies and not radarr_db_client:
-                warnings.append("Radarr database client not configured - movie database validation disabled")
-            if request.check_series and not sonarr_db_client:
-                warnings.append("Sonarr database client not configured - series database validation disabled")
+            if not registry:
+                warnings.append("Instance registry not available - database validation disabled")
+            else:
+                if request.check_movies and not registry.radarr_names:
+                    warnings.append("No Radarr instances configured - movie database validation disabled")
+                if request.check_series and not registry.sonarr_names:
+                    warnings.append("No Sonarr instances configured - series database validation disabled")
 
         _log("INFO", f"Starting hybrid orphaned record cleanup (dry_run={request.dry_run})")
 

--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -389,32 +389,41 @@ async def debug_series_date_distribution(dependencies: dict):
         }
 
 
-async def get_series_episodes(dependencies: dict, imdb_id: str):
-    """Get all episodes for a specific TV series"""
+async def get_series_episodes(dependencies: dict, imdb_id: str, instance: str = 'sonarr'):
+    """Get all episodes for a specific TV series, scoped to one instance.
+
+    A given IMDb ID can exist independently under multiple Sonarr instances
+    (e.g. a full back-catalog under the default `sonarr` and a separate,
+    smaller pickup under a named instance like `sonarr_strm`) — each is its
+    own series/episodes rows, keyed by (imdb_id, instance). Not filtering by
+    instance here pulled every instance's episodes into one merged list, so
+    a series row that's genuinely only 15 episodes under one instance would
+    show all 175 from every instance sharing the IMDb ID.
+    """
     db = dependencies["db"]
-    
+
     with db.get_connection() as conn:
         cursor = conn.cursor()
-        
+
         # Get series info - PostgreSQL
-        cursor.execute("SELECT * FROM series WHERE imdb_id = %s", (imdb_id,))
+        cursor.execute("SELECT * FROM series WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
         series_row = cursor.fetchone()
         if not series_row:
             raise HTTPException(status_code=404, detail="Series not found")
-        
+
         series_info = dict(series_row)
         try:
             series_info['title'] = _clean_folder_title(Path(series_info['path']).name) if series_info['path'] else imdb_id
         except:
             series_info['title'] = imdb_id
-        
+
         # Get episodes - PostgreSQL
         cursor.execute("""
             SELECT season, episode, instance, aired, dateadded, source, has_video_file, last_updated
             FROM episodes
-            WHERE imdb_id = %s
+            WHERE imdb_id = %s AND instance = %s
             ORDER BY season, episode
-        """, (imdb_id,))
+        """, (imdb_id, instance))
         
         episodes = []
         for row in cursor.fetchall():
@@ -1715,8 +1724,8 @@ def register_web_routes(app, dependencies):
         return await get_tv_series_list(dependencies, skip, limit, search, imdb_search, date_filter, source_filter, instance)
     
     @app.get("/api/series/{imdb_id}/episodes")
-    async def api_series_episodes(imdb_id: str):
-        return await get_series_episodes(dependencies, imdb_id)
+    async def api_series_episodes(imdb_id: str, instance: str = 'sonarr'):
+        return await get_series_episodes(dependencies, imdb_id, instance)
     
     @app.get("/api/series/sources")
     async def api_series_sources():
@@ -1811,13 +1820,13 @@ def register_web_routes(app, dependencies):
         return await get_episode_date_options(dependencies, imdb_id, season, episode, instance)
     
     @app.delete("/api/episodes/{imdb_id}/{season}/{episode}")
-    async def api_delete_episode(imdb_id: str, season: int, episode: int):
+    async def api_delete_episode(imdb_id: str, season: int, episode: int, instance: str = 'sonarr'):
         """Delete an episode from the database"""
         db = dependencies["db"]
-        
+
         try:
             # Use the existing database method
-            deleted = db.delete_episode(imdb_id, season, episode)
+            deleted = db.delete_episode(imdb_id, season, episode, instance)
             
             if deleted:
                 return {

--- a/chronarr-web/static/js/app.js
+++ b/chronarr-web/static/js/app.js
@@ -499,7 +499,7 @@ function updateSeriesTable(data) {
                 <td>${series.episodes_with_video}</td>
                 <td>${instanceBadge(series.instance)}</td>
                 <td>
-                    <button class="btn btn-sm btn-primary" onclick="viewSeriesEpisodes('${series.imdb_id}')">
+                    <button class="btn btn-sm btn-primary" onclick="viewSeriesEpisodes('${series.imdb_id}', '${series.instance || 'sonarr'}')">
                         <i class="fas fa-list"></i> Episodes
                     </button>
                     <button class="btn btn-sm btn-danger" onclick="deleteSeries('${series.imdb_id}', '${series.instance || 'sonarr'}', ${JSON.stringify(series.title || series.imdb_id).replace(/"/g, '&quot;')})" style="margin-left: 5px;" title="Delete Series">
@@ -542,9 +542,9 @@ function refreshSeries() {
     loadSeries(isNaN(currentSeriesPage) ? 1 : currentSeriesPage);
 }
 
-async function viewSeriesEpisodes(imdbId) {
+async function viewSeriesEpisodes(imdbId, instance = 'sonarr') {
     try {
-        const data = await apiCall(`/api/series/${imdbId}/episodes`);
+        const data = await apiCall(`/api/series/${imdbId}/episodes?instance=${encodeURIComponent(instance)}`);
         showEpisodesModal(data);
     } catch (error) {
         console.error('Failed to load episodes:', error);
@@ -622,7 +622,7 @@ function showEpisodesModal(data) {
                                         `<td>${dateadded}</td>`;
                                     
                                     return `
-                                        <tr class="${rowClass}" data-has-date="${!missingDate}" data-imdb="${data.series.imdb_id}" data-season="${episode.season}" data-episode="${episode.episode}">
+                                        <tr class="${rowClass}" data-has-date="${!missingDate}" data-imdb="${data.series.imdb_id}" data-season="${episode.season}" data-episode="${episode.episode}" data-instance="${episode.instance || 'sonarr'}">
                                             <td>
                                                 <input type="checkbox" class="episode-checkbox" onchange="updateBulkDeleteButton()">
                                             </td>
@@ -635,7 +635,7 @@ function showEpisodesModal(data) {
                                                 <button class="btn btn-sm btn-primary" onclick="editEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode}, '${dateadded}', '${episode.source || ''}', '${episode.instance || 'sonarr'}')">
                                                     <i class="fas fa-edit"></i> Edit
                                                 </button>
-                                                <button class="btn btn-sm btn-danger" onclick="deleteEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode})" style="margin-left: 5px;">
+                                                <button class="btn btn-sm btn-danger" onclick="deleteEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode}, '${episode.instance || 'sonarr'}')" style="margin-left: 5px;">
                                                     <i class="fas fa-trash"></i> Delete
                                                 </button>
                                             </td>
@@ -1311,7 +1311,7 @@ async function updateEpisodeDate(imdbId, season, episode, dateadded, source, ins
         const episodesModal = document.getElementById('episodes-modal');
         if (episodesModal) {
             closeEpisodesModal();
-            setTimeout(() => viewSeriesEpisodes(imdbId), 100);
+            setTimeout(() => viewSeriesEpisodes(imdbId, instance), 100);
         }
         
     } catch (error) {
@@ -1407,23 +1407,23 @@ Analysis:
 }
 
 // Episode deletion functionality
-async function deleteEpisode(imdbId, season, episode) {
+async function deleteEpisode(imdbId, season, episode, instance = 'sonarr') {
     // Validate parameters
     if (!imdbId || season === undefined || season === null || episode === undefined || episode === null) {
         console.error('deleteEpisode: Invalid parameters:', {imdbId, season, episode});
         showToast('Invalid episode parameters', 'error');
         return;
     }
-    
+
     const episodeStr = `S${season.toString().padStart(2, '0')}E${episode.toString().padStart(2, '0')}`;
-    
+
     // Confirmation dialog
     if (!confirm(`⚠️ Delete Episode ${episodeStr}?\n\nThis will permanently remove the episode from the database.\n\nAre you sure you want to continue?`)) {
         return;
     }
-    
+
     try {
-        const response = await fetch(`/api/episodes/${imdbId}/${season}/${episode}`, {
+        const response = await fetch(`/api/episodes/${imdbId}/${season}/${episode}?instance=${encodeURIComponent(instance)}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'
@@ -1829,9 +1829,10 @@ async function bulkDeleteSelected() {
         const imdbId = row.getAttribute('data-imdb');
         const season = parseInt(row.getAttribute('data-season'));
         const episode = parseInt(row.getAttribute('data-episode'));
-        
+        const instance = row.getAttribute('data-instance') || 'sonarr';
+
         try {
-            const response = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}`, {
+            const response = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}?instance=${encodeURIComponent(instance)}`, {
                 method: 'DELETE'
             });
             

--- a/core/database.py
+++ b/core/database.py
@@ -581,19 +581,29 @@ class ChronarrDatabase:
             return deleted_count
     
     def delete_orphaned_episodes(self) -> List[Dict]:
-        """Delete DB episode rows that have no matching file on disk. Checks filesystem."""
+        """Delete DB episode rows that have no matching file on disk. Checks filesystem.
+
+        Scoped per (imdb_id, instance): the same IMDb ID can have independent
+        series/episode rows under multiple Sonarr instances (e.g. a full
+        back-catalog under the default instance and a separate pickup under
+        a named one). Without filtering the episode SELECT/DELETE by
+        instance too, checking one instance's directory listing would delete
+        another instance's still-present episodes just because they share an
+        IMDb ID.
+        """
         from utils.file_utils import find_episodes_on_disk
         from pathlib import Path
-        
+
         deleted_episodes = []
-        
+
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT DISTINCT imdb_id, path FROM series")
+            cursor.execute("SELECT DISTINCT imdb_id, instance, path FROM series")
             series_list = cursor.fetchall()
 
             for series in series_list:
                 imdb_id = series['imdb_id']
+                instance = series['instance']
                 series_path = Path(series['path'])
                 if not series_path.exists():
                     continue
@@ -602,18 +612,19 @@ class ChronarrDatabase:
                 disk_episode_keys = set(disk_episodes.keys())
 
                 cursor.execute(
-                    "SELECT season, episode, dateadded, source FROM episodes WHERE imdb_id = %s",
-                    (imdb_id,)
+                    "SELECT season, episode, dateadded, source FROM episodes WHERE imdb_id = %s AND instance = %s",
+                    (imdb_id, instance)
                 )
                 for ep in cursor.fetchall():
                     season, episode = ep['season'], ep['episode']
                     if (season, episode) not in disk_episode_keys:
                         cursor.execute(
-                            "DELETE FROM episodes WHERE imdb_id = %s AND season = %s AND episode = %s",
-                            (imdb_id, season, episode)
+                            "DELETE FROM episodes WHERE imdb_id = %s AND instance = %s AND season = %s AND episode = %s",
+                            (imdb_id, instance, season, episode)
                         )
                         deleted_episodes.append({
                             'imdb_id': imdb_id,
+                            'instance': instance,
                             'season': season,
                             'episode': episode,
                             'dateadded': ep['dateadded'],
@@ -787,7 +798,12 @@ class ChronarrDatabase:
             return [dict(r) for r in cursor.fetchall()]
 
     def delete_orphaned_movies(self) -> List[Dict]:
-        """Delete DB movie rows whose directory or video files no longer exist on disk."""
+        """Delete DB movie rows whose directory or video files no longer exist on disk.
+
+        Scoped per (imdb_id, instance) — see delete_orphaned_episodes for why: the same
+        IMDb ID can have independent rows under multiple Radarr instances, and deleting
+        by imdb_id alone would remove another instance's still-valid row too.
+        """
         from pathlib import Path
 
         deleted_movies = []
@@ -795,16 +811,17 @@ class ChronarrDatabase:
 
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT imdb_id, path, dateadded, source FROM movies")
+            cursor.execute("SELECT imdb_id, instance, path, dateadded, source FROM movies")
 
             for movie in cursor.fetchall():
                 imdb_id = movie['imdb_id']
+                instance = movie['instance']
                 movie_path = Path(movie['path'])
 
                 if not movie_path.exists():
-                    cursor.execute("DELETE FROM movies WHERE imdb_id = %s", (imdb_id,))
+                    cursor.execute("DELETE FROM movies WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
                     deleted_movies.append({
-                        'imdb_id': imdb_id, 'reason': 'directory_not_found',
+                        'imdb_id': imdb_id, 'instance': instance, 'reason': 'directory_not_found',
                         'path': str(movie_path), 'dateadded': movie['dateadded'],
                         'source': movie['source']
                     })
@@ -815,9 +832,9 @@ class ChronarrDatabase:
                     for f in movie_path.iterdir() if f.is_file()
                 )
                 if not has_video:
-                    cursor.execute("DELETE FROM movies WHERE imdb_id = %s", (imdb_id,))
+                    cursor.execute("DELETE FROM movies WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
                     deleted_movies.append({
-                        'imdb_id': imdb_id, 'reason': 'no_video_files',
+                        'imdb_id': imdb_id, 'instance': instance, 'reason': 'no_video_files',
                         'path': str(movie_path), 'dateadded': movie['dateadded'],
                         'source': movie['source']
                     })
@@ -825,27 +842,32 @@ class ChronarrDatabase:
             conn.commit()
 
         return deleted_movies
-    
+
     def delete_orphaned_series(self) -> List[Dict]:
-        """Delete DB series (and all their episodes) whose directory no longer exists on disk."""
+        """Delete DB series (and all their episodes) whose directory no longer exists on disk.
+
+        Scoped per (imdb_id, instance) — see delete_orphaned_episodes for why.
+        """
         from pathlib import Path
 
         deleted_series = []
 
         with self.get_connection() as conn:
             cursor = conn.cursor()
-            cursor.execute("SELECT imdb_id, path, last_updated, metadata FROM series")
+            cursor.execute("SELECT imdb_id, instance, path, last_updated, metadata FROM series")
 
             for series in cursor.fetchall():
                 imdb_id = series['imdb_id']
+                instance = series['instance']
                 series_path = Path(series['path'])
 
                 if not series_path.exists():
-                    cursor.execute("DELETE FROM episodes WHERE imdb_id = %s", (imdb_id,))
+                    cursor.execute("DELETE FROM episodes WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
                     episodes_deleted = cursor.rowcount
-                    cursor.execute("DELETE FROM series WHERE imdb_id = %s", (imdb_id,))
+                    cursor.execute("DELETE FROM series WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
                     deleted_series.append({
                         'imdb_id': imdb_id,
+                        'instance': instance,
                         'reason': 'directory_not_found',
                         'path': str(series_path),
                         'last_updated': series['last_updated'],

--- a/scheduler/cleanup_scheduler.py
+++ b/scheduler/cleanup_scheduler.py
@@ -215,14 +215,16 @@ class CleanupScheduler:
             from utils.orphaned_cleanup import OrphanedRecordCleaner
 
             db = self.dependencies.get("db")
-            radarr_db_client = self.dependencies.get("radarr_db_client")
-            sonarr_db_client = self.dependencies.get("sonarr_db_client")
+            registry = self.dependencies.get("registry")
 
-            # Initialize the cleaner
+            # Initialize the cleaner — registry lets it resolve the right
+            # Radarr/Sonarr client per row's own instance instead of a single
+            # fixed client (this dict never actually had radarr_db_client/
+            # sonarr_db_client keys, so check_database was silently inert
+            # before this).
             cleaner = OrphanedRecordCleaner(
                 chronarr_db=db,
-                radarr_db_client=radarr_db_client,
-                sonarr_db_client=sonarr_db_client
+                registry=registry
             )
 
             # Run cleanup with configured options

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -499,7 +499,7 @@ function updateSeriesTable(data) {
                 <td>${series.episodes_with_video}</td>
                 <td>${instanceBadge(series.instance)}</td>
                 <td>
-                    <button class="btn btn-sm btn-primary" onclick="viewSeriesEpisodes('${series.imdb_id}')">
+                    <button class="btn btn-sm btn-primary" onclick="viewSeriesEpisodes('${series.imdb_id}', '${series.instance || 'sonarr'}')">
                         <i class="fas fa-list"></i> Episodes
                     </button>
                     <button class="btn btn-sm btn-danger" onclick="deleteSeries('${series.imdb_id}', '${series.instance || 'sonarr'}', ${JSON.stringify(series.title || series.imdb_id).replace(/"/g, '&quot;')})" style="margin-left: 5px;" title="Delete Series">
@@ -542,9 +542,9 @@ function refreshSeries() {
     loadSeries(isNaN(currentSeriesPage) ? 1 : currentSeriesPage);
 }
 
-async function viewSeriesEpisodes(imdbId) {
+async function viewSeriesEpisodes(imdbId, instance = 'sonarr') {
     try {
-        const data = await apiCall(`/api/series/${imdbId}/episodes`);
+        const data = await apiCall(`/api/series/${imdbId}/episodes?instance=${encodeURIComponent(instance)}`);
         showEpisodesModal(data);
     } catch (error) {
         console.error('Failed to load episodes:', error);
@@ -622,7 +622,7 @@ function showEpisodesModal(data) {
                                         `<td>${dateadded}</td>`;
                                     
                                     return `
-                                        <tr class="${rowClass}" data-has-date="${!missingDate}" data-imdb="${data.series.imdb_id}" data-season="${episode.season}" data-episode="${episode.episode}">
+                                        <tr class="${rowClass}" data-has-date="${!missingDate}" data-imdb="${data.series.imdb_id}" data-season="${episode.season}" data-episode="${episode.episode}" data-instance="${episode.instance || 'sonarr'}">
                                             <td>
                                                 <input type="checkbox" class="episode-checkbox" onchange="updateBulkDeleteButton()">
                                             </td>
@@ -635,7 +635,7 @@ function showEpisodesModal(data) {
                                                 <button class="btn btn-sm btn-primary" onclick="editEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode}, '${dateadded}', '${episode.source || ''}', '${episode.instance || 'sonarr'}')">
                                                     <i class="fas fa-edit"></i> Edit
                                                 </button>
-                                                <button class="btn btn-sm btn-danger" onclick="deleteEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode})" style="margin-left: 5px;">
+                                                <button class="btn btn-sm btn-danger" onclick="deleteEpisode('${data.series.imdb_id}', ${episode.season}, ${episode.episode}, '${episode.instance || 'sonarr'}')" style="margin-left: 5px;">
                                                     <i class="fas fa-trash"></i> Delete
                                                 </button>
                                             </td>
@@ -1311,7 +1311,7 @@ async function updateEpisodeDate(imdbId, season, episode, dateadded, source, ins
         const episodesModal = document.getElementById('episodes-modal');
         if (episodesModal) {
             closeEpisodesModal();
-            setTimeout(() => viewSeriesEpisodes(imdbId), 100);
+            setTimeout(() => viewSeriesEpisodes(imdbId, instance), 100);
         }
         
     } catch (error) {
@@ -1407,23 +1407,23 @@ Analysis:
 }
 
 // Episode deletion functionality
-async function deleteEpisode(imdbId, season, episode) {
+async function deleteEpisode(imdbId, season, episode, instance = 'sonarr') {
     // Validate parameters
     if (!imdbId || season === undefined || season === null || episode === undefined || episode === null) {
         console.error('deleteEpisode: Invalid parameters:', {imdbId, season, episode});
         showToast('Invalid episode parameters', 'error');
         return;
     }
-    
+
     const episodeStr = `S${season.toString().padStart(2, '0')}E${episode.toString().padStart(2, '0')}`;
-    
+
     // Confirmation dialog
     if (!confirm(`⚠️ Delete Episode ${episodeStr}?\n\nThis will permanently remove the episode from the database.\n\nAre you sure you want to continue?`)) {
         return;
     }
-    
+
     try {
-        const response = await fetch(`/api/episodes/${imdbId}/${season}/${episode}`, {
+        const response = await fetch(`/api/episodes/${imdbId}/${season}/${episode}?instance=${encodeURIComponent(instance)}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'
@@ -1829,9 +1829,10 @@ async function bulkDeleteSelected() {
         const imdbId = row.getAttribute('data-imdb');
         const season = parseInt(row.getAttribute('data-season'));
         const episode = parseInt(row.getAttribute('data-episode'));
-        
+        const instance = row.getAttribute('data-instance') || 'sonarr';
+
         try {
-            const response = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}`, {
+            const response = await apiCall(`/api/episodes/${imdbId}/${season}/${episode}?instance=${encodeURIComponent(instance)}`, {
                 method: 'DELETE'
             });
             

--- a/static/setup.html
+++ b/static/setup.html
@@ -408,11 +408,18 @@
                 <div class="base-url-row">
                     <label for="base-url">Base URL:</label>
                     <input type="text" id="base-url" placeholder="http://your-server:8080" />
+                    <button type="button" class="btn-copy" id="base-url-reset" title="Reset to this page's own address">
+                        <i class="fas fa-rotate-left"></i> Reset
+                    </button>
                 </div>
                 <p class="hint-text">
                     This is the address Radarr and Sonarr will use to reach Chronarr's core container.
-                    It should be the hostname (or IP) your media apps can reach, on port
-                    <code>8080</code> by default. Edit it once here and all webhook URLs below update automatically.
+                    Defaults to the address you're viewing this page from, but that's often wrong: if Radarr/Sonarr
+                    run as Docker containers on the <strong>same network</strong> as Chronarr, use the Docker
+                    <strong>container or service name</strong> instead (e.g. <code>http://chronarr-core:8080</code>,
+                    not this page's IP) — container names resolve between containers on a shared network even when
+                    the host IP doesn't. Edit it once here and all webhook URLs below update automatically; your
+                    change is remembered in this browser so it won't reset on the next visit.
                 </p>
             </div>
 
@@ -466,15 +473,48 @@
 
     <script>
         // Infer the likely core URL from the current page's host, swapping port to 8080.
-        // The user can override this in the input.
+        // Only a starting guess — it's the address *this browser* used to reach the
+        // web container, which for a Docker-networked Radarr/Sonarr is frequently not
+        // reachable from inside another container (the container/service name is).
         function defaultCoreUrl() {
             const { protocol, hostname } = window.location;
             return `${protocol}//${hostname}:8080`;
         }
 
+        const BASE_URL_STORAGE_KEY = 'chronarr.setup.baseUrl';
+
+        function readStoredBaseUrl() {
+            try {
+                return localStorage.getItem(BASE_URL_STORAGE_KEY) || '';
+            } catch (e) {
+                return ''; // private browsing / storage blocked — just fall back to the guess
+            }
+        }
+
+        function storeBaseUrl(value) {
+            try {
+                localStorage.setItem(BASE_URL_STORAGE_KEY, value);
+            } catch (e) {
+                // Nothing to do — the field still works for this session, it just
+                // won't survive a reload if storage isn't available.
+            }
+        }
+
         const baseInput = document.getElementById('base-url');
-        baseInput.value = defaultCoreUrl();
-        baseInput.addEventListener('input', rebuildUrls);
+        // A value saved in this browser (e.g. the Docker network name the user
+        // corrected it to) wins over the page-address guess, so it doesn't reset
+        // every time /setup is reopened.
+        baseInput.value = readStoredBaseUrl() || defaultCoreUrl();
+        baseInput.addEventListener('input', () => {
+            storeBaseUrl(baseInput.value);
+            rebuildUrls();
+        });
+
+        document.getElementById('base-url-reset').addEventListener('click', () => {
+            baseInput.value = defaultCoreUrl();
+            storeBaseUrl(baseInput.value);
+            rebuildUrls();
+        });
 
         function buildWebhookUrl(path) {
             const base = (baseInput.value || '').replace(/\/$/, '');

--- a/utils/orphaned_cleanup.py
+++ b/utils/orphaned_cleanup.py
@@ -8,23 +8,68 @@ from typing import Dict, List, Any, Optional, Tuple
 from datetime import datetime
 
 from core.logging import _log
+from clients.radarr_db_client import RadarrDbClient
+from clients.sonarr_db_client import SonarrDbClient
 
 
 class OrphanedRecordCleaner:
-    """Clean up orphaned records from Chronarr database"""
+    """Clean up orphaned records from Chronarr database, per (imdb_id, instance).
 
-    def __init__(self, chronarr_db, radarr_db_client=None, sonarr_db_client=None):
+    The same IMDb ID can have independent rows under multiple Radarr/Sonarr
+    instances (a full back-catalog under the default instance, a separate
+    smaller pickup under a named one). Every check and delete here is scoped
+    to one row's own instance — resolved from the InstanceRegistry — so
+    checking or removing one instance's row never touches another instance's
+    still-valid data sharing the same IMDb ID.
+    """
+
+    def __init__(self, chronarr_db, registry=None, radarr_db_client=None, sonarr_db_client=None):
         """
         Initialize cleanup utility
 
         Args:
             chronarr_db: ChronarrDatabase instance
-            radarr_db_client: Optional RadarrDbClient instance
-            sonarr_db_client: Optional SonarrDbClient instance
+            registry: InstanceRegistry — resolves the right Radarr/Sonarr client
+                per row's own instance. Required for check_database to work
+                correctly across more than the default instance.
+            radarr_db_client, sonarr_db_client: fallback single clients, used only
+                when registry is None or doesn't have a client for a row's instance
+                (legacy/test construction path — same pattern as TVProcessor/MovieProcessor).
         """
         self.chronarr_db = chronarr_db
+        self.registry = registry
         self.radarr_db = radarr_db_client
         self.sonarr_db = sonarr_db_client
+
+    def _resolve_radarr(self, instance: str):
+        """Return a Radarr client for this instance, or the fallback default."""
+        if self.registry:
+            client = self.registry.radarr(instance)
+            if client is not None:
+                return client
+        return self.radarr_db
+
+    def _resolve_sonarr(self, instance: str):
+        """Return a Sonarr client for this instance, or the fallback default."""
+        if self.registry:
+            client = self.registry.sonarr(instance)
+            if client is not None:
+                return client
+        return self.sonarr_db
+
+    @staticmethod
+    def _radarr_movie_by_imdb(client, imdb_id: str) -> Optional[Dict[str, Any]]:
+        """Call whichever lookup method this client type actually has."""
+        if isinstance(client, RadarrDbClient):
+            return client.get_movie_by_imdb(imdb_id)
+        return client.movie_by_imdb(imdb_id)
+
+    @staticmethod
+    def _sonarr_series_by_imdb(client, imdb_id: str) -> Optional[Dict[str, Any]]:
+        """Call whichever lookup method this client type actually has."""
+        if isinstance(client, SonarrDbClient):
+            return client.get_series_by_imdb(imdb_id)
+        return client.series_by_imdb(imdb_id)
 
     def find_orphaned_movies(self, check_filesystem: bool = True, check_database: bool = True) -> List[Dict[str, Any]]:
         """
@@ -43,7 +88,7 @@ class OrphanedRecordCleaner:
         with self.chronarr_db.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
-                SELECT imdb_id, title, path, dateadded
+                SELECT imdb_id, instance, title, path, dateadded
                 FROM movies
                 ORDER BY title
             """)
@@ -53,6 +98,7 @@ class OrphanedRecordCleaner:
 
         for movie in movies:
             imdb_id = movie['imdb_id']
+            instance = movie['instance']
             title = movie['title']
             file_path = movie.get('path')
 
@@ -66,15 +112,19 @@ class OrphanedRecordCleaner:
                     filesystem_missing = True
                     reasons.append(f"File not found: {file_path}")
 
-            # Check 2: Radarr database
-            if check_database and self.radarr_db:
-                try:
-                    radarr_movie = self.radarr_db.get_movie_by_imdb(imdb_id)
-                    if not radarr_movie:
-                        database_missing = True
-                        reasons.append("Not found in Radarr database")
-                except Exception as e:
-                    _log("WARNING", f"Error checking Radarr DB for {imdb_id}: {e}")
+            # Check 2: this row's own Radarr instance's database
+            if check_database:
+                radarr_client = self._resolve_radarr(instance)
+                if radarr_client:
+                    try:
+                        radarr_movie = self._radarr_movie_by_imdb(radarr_client, imdb_id)
+                        if not radarr_movie:
+                            database_missing = True
+                            reasons.append(f"Not found in Radarr database (instance: {instance})")
+                    except Exception as e:
+                        _log("WARNING", f"[{instance}] Error checking Radarr DB for {imdb_id}: {e}")
+                else:
+                    _log("WARNING", f"[{instance}] No Radarr client available to verify {imdb_id} — skipping database check for this row")
 
             # Orphaned if BOTH checks fail (hybrid approach)
             if check_filesystem and check_database:
@@ -89,6 +139,7 @@ class OrphanedRecordCleaner:
             if is_orphaned and reasons:
                 orphaned.append({
                     'imdb_id': imdb_id,
+                    'instance': instance,
                     'title': title,
                     'file_path': file_path,
                     'dateadded': movie.get('dateadded'),
@@ -116,7 +167,7 @@ class OrphanedRecordCleaner:
         with self.chronarr_db.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
-                SELECT imdb_id, path
+                SELECT imdb_id, instance, path
                 FROM series
                 ORDER BY path
             """)
@@ -126,6 +177,7 @@ class OrphanedRecordCleaner:
 
         for series in series_list:
             imdb_id = series['imdb_id']
+            instance = series['instance']
             series_path = series.get('path')
             # Extract title from path for display purposes
             title = Path(series_path).name if series_path else imdb_id
@@ -140,15 +192,19 @@ class OrphanedRecordCleaner:
                     filesystem_missing = True
                     reasons.append(f"Series path not found: {series_path}")
 
-            # Check 2: Sonarr database
-            if check_database and self.sonarr_db:
-                try:
-                    sonarr_series = self.sonarr_db.get_series_by_imdb(imdb_id)
-                    if not sonarr_series:
-                        database_missing = True
-                        reasons.append("Not found in Sonarr database")
-                except Exception as e:
-                    _log("WARNING", f"Error checking Sonarr DB for {imdb_id}: {e}")
+            # Check 2: this row's own Sonarr instance's database
+            if check_database:
+                sonarr_client = self._resolve_sonarr(instance)
+                if sonarr_client:
+                    try:
+                        sonarr_series = self._sonarr_series_by_imdb(sonarr_client, imdb_id)
+                        if not sonarr_series:
+                            database_missing = True
+                            reasons.append(f"Not found in Sonarr database (instance: {instance})")
+                    except Exception as e:
+                        _log("WARNING", f"[{instance}] Error checking Sonarr DB for {imdb_id}: {e}")
+                else:
+                    _log("WARNING", f"[{instance}] No Sonarr client available to verify {imdb_id} — skipping database check for this row")
 
             # Orphaned if BOTH checks fail (hybrid approach)
             if check_filesystem and check_database:
@@ -161,19 +217,20 @@ class OrphanedRecordCleaner:
                 is_orphaned = False
 
             if is_orphaned and reasons:
-                # Count episodes for this series
+                # Count episodes for this series, scoped to the same instance
                 with self.chronarr_db.get_connection() as conn:
                     cursor = conn.cursor()
                     cursor.execute("""
                         SELECT COUNT(*) as episode_count
                         FROM episodes
-                        WHERE imdb_id = %s
-                    """, (imdb_id,))
+                        WHERE imdb_id = %s AND instance = %s
+                    """, (imdb_id, instance))
                     result = cursor.fetchone()
                     episode_count = result['episode_count'] if result else 0
 
                 orphaned.append({
                     'imdb_id': imdb_id,
+                    'instance': instance,
                     'title': title,
                     'series_path': series_path,
                     'episode_count': episode_count,
@@ -200,24 +257,25 @@ class OrphanedRecordCleaner:
 
         for movie in orphaned_movies:
             imdb_id = movie['imdb_id']
+            instance = movie.get('instance', 'radarr')
             title = movie['title']
             reasons = ', '.join(movie['reasons'])
 
             if dry_run:
-                _log("INFO", f"[DRY RUN] Would remove movie: {title} ({imdb_id}) - Reasons: {reasons}")
+                _log("INFO", f"[DRY RUN] Would remove movie: {title} ({imdb_id}, instance: {instance}) - Reasons: {reasons}")
                 removed_titles.append(f"{title} ({imdb_id})")
                 removed_count += 1
             else:
                 try:
                     with self.chronarr_db.get_connection() as conn:
                         cursor = conn.cursor()
-                        cursor.execute("DELETE FROM movies WHERE imdb_id = %s", (imdb_id,))
+                        cursor.execute("DELETE FROM movies WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
 
-                    _log("INFO", f"Removed orphaned movie: {title} ({imdb_id}) - Reasons: {reasons}")
+                    _log("INFO", f"Removed orphaned movie: {title} ({imdb_id}, instance: {instance}) - Reasons: {reasons}")
                     removed_titles.append(f"{title} ({imdb_id})")
                     removed_count += 1
                 except Exception as e:
-                    _log("ERROR", f"Failed to remove movie {imdb_id}: {e}")
+                    _log("ERROR", f"[{instance}] Failed to remove movie {imdb_id}: {e}")
 
         return {
             'removed_count': removed_count,
@@ -242,12 +300,13 @@ class OrphanedRecordCleaner:
 
         for series in orphaned_series:
             imdb_id = series['imdb_id']
+            instance = series.get('instance', 'sonarr')
             title = series['title']
             episode_count = series.get('episode_count', 0)
             reasons = ', '.join(series['reasons'])
 
             if dry_run:
-                _log("INFO", f"[DRY RUN] Would remove series: {title} ({imdb_id}) with {episode_count} episodes - Reasons: {reasons}")
+                _log("INFO", f"[DRY RUN] Would remove series: {title} ({imdb_id}, instance: {instance}) with {episode_count} episodes - Reasons: {reasons}")
                 removed_titles.append(f"{title} ({imdb_id}) - {episode_count} episodes")
                 removed_count += 1
                 removed_episodes += episode_count
@@ -256,16 +315,16 @@ class OrphanedRecordCleaner:
                     with self.chronarr_db.get_connection() as conn:
                         cursor = conn.cursor()
                         # Remove episodes first
-                        cursor.execute("DELETE FROM episodes WHERE imdb_id = %s", (imdb_id,))
+                        cursor.execute("DELETE FROM episodes WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
                         # Then remove series
-                        cursor.execute("DELETE FROM series WHERE imdb_id = %s", (imdb_id,))
+                        cursor.execute("DELETE FROM series WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
 
-                    _log("INFO", f"Removed orphaned series: {title} ({imdb_id}) with {episode_count} episodes - Reasons: {reasons}")
+                    _log("INFO", f"Removed orphaned series: {title} ({imdb_id}, instance: {instance}) with {episode_count} episodes - Reasons: {reasons}")
                     removed_titles.append(f"{title} ({imdb_id}) - {episode_count} episodes")
                     removed_count += 1
                     removed_episodes += episode_count
                 except Exception as e:
-                    _log("ERROR", f"Failed to remove series {imdb_id}: {e}")
+                    _log("ERROR", f"[{instance}] Failed to remove series {imdb_id}: {e}")
 
         return {
             'removed_count': removed_count,


### PR DESCRIPTION
- Setup page Base URL now persists to localStorage instead of resetting to the browser's own address on every reload, with a Reset button and hint text about using the Docker container/service name when Radarr/Sonarr run on the same network as Chronarr.

- Viewing a series' episodes (GET /api/series/{imdb_id}/episodes) queried by imdb_id alone with no instance filter. The same IMDb ID can have independent series/episode rows under multiple Sonarr instances, so a series that's genuinely a handful of episodes under one instance could show every episode from every instance sharing that IMDb ID merged into one list. Same root cause broke single and bulk episode delete. Both endpoints now take an instance param; Edit/Delete/bulk-delete in the UI thread each row's own instance through instead of assuming the default.

- Orphaned-record cleanup could delete another instance's data. core/database.py's delete_orphaned_episodes()/delete_orphaned_movies()/ delete_orphaned_series() deleted by imdb_id alone, so removing one instance's genuinely-orphaned row would delete every instance's row sharing that imdb_id. Fixed to scope both the check and the delete to (imdb_id, instance).

- The class actually wired to the cleanup scheduler and the manual cleanup endpoint (utils/orphaned_cleanup.py's OrphanedRecordCleaner) had the same delete bug, plus was constructed with a single fixed default-instance Radarr/Sonarr client, so its "does this still exist" check looked at the wrong instance for any named-instance row. Now takes the InstanceRegistry and resolves the right client per row's own instance for both the check and the delete.