### PR TITLE
fix: Emby plugin date lookup and cross-instance path-scan isolation

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -2590,30 +2590,38 @@ async def update_episode_nfo(imdb_id: str, season: int, episode: int, request: R
 # Emby Plugin Lookup Functions
 # ---------------------------
 
-async def lookup_episode(imdb_id: str, season: int, episode: int, dependencies: dict):
+async def lookup_episode(imdb_id: str, season: int, episode: int, dependencies: dict, instance: str = None):
     """
     Lookup episode dateadded from Chronarr database for Emby plugin integration
-    
+
     Returns dateadded information if found, or null if not available.
     Used by Emby plugin to populate missing dateadded elements in NFO files.
+
+    The plugin's request has no concept of instance (it predates multi-instance
+    support) — when instance isn't given, search across every instance sharing
+    this imdb_id/season/episode instead of silently defaulting to 'sonarr' only,
+    which would miss any row that exists solely under a named instance.
     """
     try:
-        _log("DEBUG", f"Episode lookup called for {imdb_id} S{season:02d}E{episode:02d}")
-        
+        _log("DEBUG", f"Episode lookup called for {imdb_id} S{season:02d}E{episode:02d} (instance: {instance or 'any'})")
+
         db = dependencies.get("db")
         if not db:
             print(f"ERROR: Database not available in dependencies")
             raise HTTPException(status_code=500, detail="Database not available")
-        
+
         # Normalize IMDb ID (ensure tt prefix)
         if not imdb_id.startswith('tt'):
             imdb_id = f"tt{imdb_id}"
-        
+
         _log("DEBUG", f"Querying database for episode {imdb_id} S{season:02d}E{episode:02d}")
-        
+
         # Query database for episode
-        result = db.get_episode_date(imdb_id, season, episode)
-        
+        if instance:
+            result = db.get_episode_date(imdb_id, season, episode, instance)
+        else:
+            result = db.get_episode_date_any_instance(imdb_id, season, episode)
+
         _log("DEBUG", f"Database query result: {result}")
         
         if result and result.get('dateadded'):
@@ -2636,6 +2644,7 @@ async def lookup_episode(imdb_id: str, season: int, episode: int, dependencies: 
                 "dateadded": dateadded_str,
                 "source": result.get('source', 'database'),
                 "air_date": result.get('air_date') if result.get('air_date') else None,
+                "instance": result.get('instance'),
                 "auto_fixed": False  # Auto-fix functionality disabled
             }
         else:
@@ -2833,28 +2842,31 @@ async def lookup_movie_by_title(title: str, year: str, dependencies: dict):
         raise HTTPException(status_code=500, detail=f"Movie title lookup failed: {str(e)}")
 
 
-async def lookup_movie(imdb_id: str, dependencies: dict):
+async def lookup_movie(imdb_id: str, dependencies: dict, instance: str = None):
     """
     Lookup movie dateadded from Chronarr database for Emby plugin integration
-    
-    Returns dateadded information if found, or null if not available.  
+
+    Returns dateadded information if found, or null if not available.
     Used by Emby plugin to populate missing dateadded elements in NFO files.
+
+    See lookup_episode() for why instance is optional and how it's resolved
+    when the caller (the plugin, which predates multi-instance) doesn't send one.
     """
     try:
         db = dependencies.get("db")
         if not db:
             raise HTTPException(status_code=500, detail="Database not available")
-        
-        _log("DEBUG", f"Movie lookup called for IMDb ID: {imdb_id}")
-        
+
+        _log("DEBUG", f"Movie lookup called for IMDb ID: {imdb_id} (instance: {instance or 'any'})")
+
         # Normalize IMDb ID (ensure tt prefix)
         if not imdb_id.startswith('tt'):
             imdb_id = f"tt{imdb_id}"
-        
+
         _log("DEBUG", f"Normalized IMDb ID: {imdb_id}")
-        
+
         # Query database for movie
-        result = db.get_movie_dates(imdb_id)
+        result = db.get_movie_dates(imdb_id, instance) if instance else db.get_movie_dates_any_instance(imdb_id)
         _log("DEBUG", f"Movie lookup for {imdb_id}: database result = {result}")
         
         # If not found, let's see what movies we DO have in the database
@@ -2884,6 +2896,7 @@ async def lookup_movie(imdb_id: str, dependencies: dict):
                 "dateadded": dateadded_str,
                 "source": result.get('source', 'database'),
                 "released": result.get('released') if result.get('released') else None,
+                "instance": result.get('instance'),
                 "auto_fixed": False  # Auto-fix functionality disabled
             }
         else:
@@ -3597,12 +3610,12 @@ def register_routes(app, dependencies: dict):
     # ---------------------------
     
     @app.get("/api/lookup/episode/{imdb_id}/{season}/{episode}")
-    async def _lookup_episode(imdb_id: str, season: int, episode: int):
-        return await lookup_episode(imdb_id, season, episode, dependencies)
-    
+    async def _lookup_episode(imdb_id: str, season: int, episode: int, instance: str = None):
+        return await lookup_episode(imdb_id, season, episode, dependencies, instance)
+
     @app.get("/api/lookup/movie/{imdb_id}")
-    async def _lookup_movie(imdb_id: str):
-        return await lookup_movie(imdb_id, dependencies)
+    async def _lookup_movie(imdb_id: str, instance: str = None):
+        return await lookup_movie(imdb_id, dependencies, instance)
     
     @app.get("/api/lookup/movie/title/{title}")
     async def _lookup_movie_by_title(title: str, year: str = None):

--- a/core/database.py
+++ b/core/database.py
@@ -440,10 +440,51 @@ class ChronarrDatabase:
             row = cursor.fetchone()
             return dict(row) if row else None
 
+    def get_episode_date_any_instance(self, imdb_id: str, season: int, episode: int) -> Optional[Dict]:
+        """Look up an episode's date without knowing which instance owns it.
+
+        For callers that only have (imdb_id, season, episode) — no instance —
+        e.g. the Emby/Jellyfin plugin lookup endpoints, which predate
+        multi-instance and have no instance in their URL. The same IMDb ID
+        can have independent rows under multiple Sonarr instances (a full
+        back-catalog under the default instance, a separate pickup under a
+        named one covering different seasons), so defaulting to 'sonarr'
+        alone would silently miss any row that only exists under a named
+        instance. Prefers a row that actually has a dateadded set; among
+        those, picks deterministically (ordered by instance name) rather
+        than arbitrarily, so behavior doesn't flap between calls.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT * FROM episodes
+                WHERE imdb_id = %s AND season = %s AND episode = %s
+                ORDER BY (dateadded IS NULL), instance
+                LIMIT 1
+            """, (imdb_id, season, episode))
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
     def get_movie_dates(self, imdb_id: str, instance: str = 'radarr') -> Optional[Dict]:
         with self.get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("SELECT * FROM movies WHERE imdb_id = %s AND instance = %s", (imdb_id, instance))
+            row = cursor.fetchone()
+            return dict(row) if row else None
+
+    def get_movie_dates_any_instance(self, imdb_id: str) -> Optional[Dict]:
+        """Look up a movie's date without knowing which instance owns it.
+
+        Same reasoning as get_episode_date_any_instance() — see there.
+        """
+        with self.get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT * FROM movies
+                WHERE imdb_id = %s
+                ORDER BY (dateadded IS NULL), instance
+                LIMIT 1
+            """, (imdb_id,))
             row = cursor.fetchone()
             return dict(row) if row else None
     

--- a/processors/movie_processor.py
+++ b/processors/movie_processor.py
@@ -116,10 +116,15 @@ class MovieProcessor:
     def find_movie_path(self, movie_title: str, imdb_id: str, radarr_path: str = None, instance: str = 'radarr') -> Optional[Path]:
         """Find movie directory path using unified file utilities"""
         _, _, path_mapper = self._resolve_radarr(instance)
+        # Scope the fallback directory scan to this instance's own configured
+        # paths, not every instance's (config.movie_paths) — see
+        # TVProcessor.find_series_path for why (an unrelated instance's
+        # unreadable path shouldn't be able to crash this one's lookup).
+        instance_movie_paths = [Path(p) for p in path_mapper.container_paths] if path_mapper.container_paths else config.movie_paths
         return find_media_path_by_imdb_and_title(
             title=movie_title,
             imdb_id=imdb_id,
-            search_paths=config.movie_paths,
+            search_paths=instance_movie_paths,
             webhook_path=radarr_path,
             path_mapper=path_mapper
         )

--- a/processors/tv_processor.py
+++ b/processors/tv_processor.py
@@ -101,10 +101,16 @@ class TVProcessor:
     def find_series_path(self, series_title: str, imdb_id: str, sonarr_path: str = None, instance: str = 'sonarr') -> Optional[Path]:
         """Find series directory path using unified file utilities"""
         _, _, path_mapper = self._resolve_sonarr(instance)
+        # Scope the fallback directory scan to this instance's own configured
+        # paths, not every instance's (config.tv_paths). Otherwise a webhook
+        # for one instance can be crashed by a completely unrelated instance's
+        # path being unreadable (e.g. a stale/disconnected mount) — the scan
+        # would still walk into it while looking for this series.
+        instance_tv_paths = [Path(p) for p in path_mapper.container_paths] if path_mapper.container_paths else config.tv_paths
         return find_media_path_by_imdb_and_title(
             title=series_title,
             imdb_id=imdb_id,
-            search_paths=config.tv_paths,
+            search_paths=instance_tv_paths,
             webhook_path=sonarr_path,
             path_mapper=path_mapper
         )


### PR DESCRIPTION
- The Emby plugin's date lookup API (GET /api/lookup/episode/{imdb_id}/ {season}/{episode}, and the movie equivalent) predates multi-instance support and has no instance in the URL. The handler called db.get_episode_date()/get_movie_dates() with no instance argument, silently defaulting to the sonarr/radarr instance only - so a series whose episodes only exist under a named instance would never have its date reach Emby, even after the underlying data was correct. Added get_episode_date_any_instance()/get_movie_dates_any_instance() to core/database.py: when the caller doesn't know which instance owns a row, search across every instance sharing that imdb_id instead of guessing one, preferring a row that actually has a dateadded set. Both lookup endpoints now also accept an optional instance query param for a future plugin version, falling back to the any-instance search when absent (the plugin's current behavior), so this fixes the real bug with no plugin changes required.

- find_series_path()/find_movie_path()'s fallback directory scan (used when a webhook's path can't be resolved directly) searched the global list of every configured instance's paths, not just the instance the webhook is actually for. A stale/disconnected mount under one instance's path could crash a completely unrelated instance's webhook with a 422, because the scan would still walk into the broken directory while looking for an unrelated series. Both now scope the scan to the resolved instance's own configured paths.