### PR TITLE
fix: movie delete and debug-data lookup ignored instance

### DIFF
--- a/api/web_routes.py
+++ b/api/web_routes.py
@@ -1635,12 +1635,12 @@ def register_web_routes(app, dependencies):
         return await get_movie_date_options(dependencies, imdb_id, instance)
 
     @app.get("/api/debug/movie/{imdb_id}/raw")
-    async def api_debug_movie_raw(imdb_id: str):
+    async def api_debug_movie_raw(imdb_id: str, instance: str = 'radarr'):
         """Get raw database data for a movie for debugging"""
         db = dependencies["db"]
 
         try:
-            movie = db.get_movie_dates(imdb_id)
+            movie = db.get_movie_dates(imdb_id, instance)
 
             if not movie:
                 raise HTTPException(status_code=404, detail="Movie not found")
@@ -1657,13 +1657,13 @@ def register_web_routes(app, dependencies):
             raise HTTPException(status_code=500, detail=f"Failed to get debug data: {str(e)}")
 
     @app.delete("/api/movies/{imdb_id}")
-    async def api_delete_movie(imdb_id: str):
+    async def api_delete_movie(imdb_id: str, instance: str = 'radarr'):
         """Delete a movie from the database"""
         db = dependencies["db"]
-        
+
         try:
             # Use the existing database method
-            deleted = db.delete_movie(imdb_id)
+            deleted = db.delete_movie(imdb_id, instance)
             
             if deleted:
                 return {

--- a/chronarr-web/static/js/app.js
+++ b/chronarr-web/static/js/app.js
@@ -362,10 +362,10 @@ function updateMoviesTable(data) {
                     <button class="btn btn-sm btn-primary" onclick="editMovie('${movie.imdb_id}', '${dateadded}', '${movie.source || ''}', '${movie.instance || 'radarr'}')">
                         <i class="fas fa-edit"></i> Edit
                     </button>
-                    <button class="btn btn-sm btn-secondary" onclick="debugMovie('${movie.imdb_id}')" title="Debug Data">
+                    <button class="btn btn-sm btn-secondary" onclick="debugMovie('${movie.imdb_id}', '${movie.instance || 'radarr'}')" title="Debug Data">
                         <i class="fas fa-bug"></i>
                     </button>
-                    <button class="btn btn-sm btn-danger" onclick="deleteMovie('${movie.imdb_id}')" style="margin-left: 5px;" title="Delete Movie">
+                    <button class="btn btn-sm btn-danger" onclick="deleteMovie('${movie.imdb_id}', '${movie.instance || 'radarr'}')" style="margin-left: 5px;" title="Delete Movie">
                         <i class="fas fa-trash"></i> Delete
                     </button>
                 </td>
@@ -1375,9 +1375,9 @@ function showToast(message, type = 'info') {
 }
 
 // Debug function
-async function debugMovie(imdbId) {
+async function debugMovie(imdbId, instance = 'radarr') {
     try {
-        const data = await apiCall(`/api/debug/movie/${imdbId}/raw`);
+        const data = await apiCall(`/api/debug/movie/${imdbId}/raw?instance=${encodeURIComponent(instance)}`);
         
         const debugInfo = `
 DEBUG INFO for ${imdbId}:
@@ -1459,14 +1459,14 @@ async function deleteEpisode(imdbId, season, episode, instance = 'sonarr') {
 }
 
 // Movie deletion functionality
-async function deleteMovie(imdbId) {
+async function deleteMovie(imdbId, instance = 'radarr') {
     // Confirmation dialog
     if (!confirm(`⚠️ Delete Movie?\n\nThis will permanently remove the movie (${imdbId}) from the database.\n\nAre you sure you want to continue?`)) {
         return;
     }
-    
+
     try {
-        const response = await fetch(`/api/movies/${imdbId}`, {
+        const response = await fetch(`/api/movies/${imdbId}?instance=${encodeURIComponent(instance)}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -362,10 +362,10 @@ function updateMoviesTable(data) {
                     <button class="btn btn-sm btn-primary" onclick="editMovie('${movie.imdb_id}', '${dateadded}', '${movie.source || ''}', '${movie.instance || 'radarr'}')">
                         <i class="fas fa-edit"></i> Edit
                     </button>
-                    <button class="btn btn-sm btn-secondary" onclick="debugMovie('${movie.imdb_id}')" title="Debug Data">
+                    <button class="btn btn-sm btn-secondary" onclick="debugMovie('${movie.imdb_id}', '${movie.instance || 'radarr'}')" title="Debug Data">
                         <i class="fas fa-bug"></i>
                     </button>
-                    <button class="btn btn-sm btn-danger" onclick="deleteMovie('${movie.imdb_id}')" style="margin-left: 5px;" title="Delete Movie">
+                    <button class="btn btn-sm btn-danger" onclick="deleteMovie('${movie.imdb_id}', '${movie.instance || 'radarr'}')" style="margin-left: 5px;" title="Delete Movie">
                         <i class="fas fa-trash"></i> Delete
                     </button>
                 </td>
@@ -1375,9 +1375,9 @@ function showToast(message, type = 'info') {
 }
 
 // Debug function
-async function debugMovie(imdbId) {
+async function debugMovie(imdbId, instance = 'radarr') {
     try {
-        const data = await apiCall(`/api/debug/movie/${imdbId}/raw`);
+        const data = await apiCall(`/api/debug/movie/${imdbId}/raw?instance=${encodeURIComponent(instance)}`);
         
         const debugInfo = `
 DEBUG INFO for ${imdbId}:
@@ -1459,14 +1459,14 @@ async function deleteEpisode(imdbId, season, episode, instance = 'sonarr') {
 }
 
 // Movie deletion functionality
-async function deleteMovie(imdbId) {
+async function deleteMovie(imdbId, instance = 'radarr') {
     // Confirmation dialog
     if (!confirm(`⚠️ Delete Movie?\n\nThis will permanently remove the movie (${imdbId}) from the database.\n\nAre you sure you want to continue?`)) {
         return;
     }
-    
+
     try {
-        const response = await fetch(`/api/movies/${imdbId}`, {
+        const response = await fetch(`/api/movies/${imdbId}?instance=${encodeURIComponent(instance)}`, {
             method: 'DELETE',
             headers: {
                 'Content-Type': 'application/json'


### PR DESCRIPTION
Same root cause as the episode delete fix: DELETE /api/movies/{imdb_id} and GET /api/debug/movie/{imdb_id}/raw called db.delete_movie()/ get_movie_dates() with no instance, silently defaulting to the radarr instance. Deleting or debugging a movie that lives under a named instance (e.g. radarr_strm) 404'd, because the lookup was always scoped to the default instance's row instead.

Both endpoints now take an instance param; the Movies Database table's Delete and Debug Data buttons thread the row's own instance through, matching the Edit button which already did.