### PR TITLE
fix: retry on transient filesystem errors during webhook processing

### DIFF
--- a/processors/movie_processor.py
+++ b/processors/movie_processor.py
@@ -15,7 +15,7 @@ from clients.external_clients import ExternalClientManager
 from config.settings import config
 from utils.logging import _log
 from utils.imdb_utils import find_imdb_in_directory  # Phase 3: Replaced NFOManager
-from utils.file_utils import find_media_path_by_imdb_and_title
+from utils.file_utils import find_media_path_by_imdb_and_title, list_video_files_with_retry
 
 
 def _get_local_timezone():
@@ -195,10 +195,11 @@ class MovieProcessor:
         # Update database
         self.db.upsert_movie(imdb_id, str(movie_path), instance=instance)
         
-        # Check for video files
-        video_exts = (".mkv", ".mp4", ".avi", ".mov", ".m4v")
-        has_video = any(f.is_file() and f.suffix.lower() in video_exts for f in movie_path.iterdir())
-        
+        # Check for video files — retries internally on a transient OSError
+        # (e.g. a network/FUSE mount reporting ENOTCONN for a just-created
+        # file) instead of failing the whole webhook on a one-off blip.
+        has_video = len(list_video_files_with_retry(movie_path)) > 0
+
         if not has_video:
             _log("WARNING", f"[{instance}] No video files found in: {movie_path} - skipping database entry")
             return "no_video_files"

--- a/processors/tv_processor.py
+++ b/processors/tv_processor.py
@@ -18,7 +18,8 @@ from utils.imdb_utils import parse_imdb_from_path  # Phase 3: Replaced NFOManage
 from utils.file_utils import (
     find_media_path_by_imdb_and_title,
     find_episodes_on_disk,
-    extract_title_from_directory_name
+    extract_title_from_directory_name,
+    list_video_files_with_retry
 )
 from utils.async_file_utils import (
     async_find_episodes_on_disk,
@@ -738,13 +739,14 @@ class TVProcessor:
                 _log("WARNING", f"[{instance}] Season directory not found: {season_dir}")
                 continue
 
-            # Find matching episode files
+            # Find matching episode files — the listing itself retries internally on
+            # a transient OSError (e.g. a network/FUSE mount reporting ENOTCONN for
+            # a just-created file) instead of failing the whole webhook on a blip.
             episode_files = []
-            for file_path in season_dir.iterdir():
-                if file_path.is_file() and file_path.suffix.lower() in ('.mkv', '.mp4', '.avi', '.mov', '.m4v'):
-                    parsed = self._parse_episode_from_filename(file_path.name)
-                    if parsed and parsed == (season_num, episode_num):
-                        episode_files.append(file_path)
+            for file_path in list_video_files_with_retry(season_dir):
+                parsed = self._parse_episode_from_filename(file_path.name)
+                if parsed and parsed == (season_num, episode_num):
+                    episode_files.append(file_path)
 
             if not episode_files:
                 _log("WARNING", f"[{instance}] No video files found for S{season_num:02d}E{episode_num:02d}")

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,6 +1,7 @@
 """File utilities — path resolution, video file discovery, episode parsing."""
 import glob
 import re
+import time
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple, Union
 
@@ -62,9 +63,9 @@ def clean_title_for_search(title: str) -> str:
 def find_video_files(directory: Path, recursive: bool = True) -> List[Path]:
     if not directory.exists():
         return []
-    
+
     video_files = []
-    
+
     if recursive:
         for item in directory.rglob('*'):
             if item.is_file() and item.suffix.lower() in VIDEO_EXTENSIONS:
@@ -73,8 +74,49 @@ def find_video_files(directory: Path, recursive: bool = True) -> List[Path]:
         for item in directory.iterdir():
             if item.is_file() and item.suffix.lower() in VIDEO_EXTENSIONS:
                 video_files.append(item)
-    
+
     return video_files
+
+
+# Some network/FUSE-backed mounts (e.g. decypharr's DFS backend for debrid/usenet
+# libraries) can report a just-created file as briefly unreadable — ENOTCONN or
+# similar — for a few seconds right after it's symlinked in, while the mount's
+# own backing downloader for that file finishes initializing. That's a timing
+# race in the mount layer, not a real "file is missing" condition, so retrying
+# a few times rides it out instead of failing the whole webhook on a one-off
+# blip. Starting point: 5 attempts, 3s apart (~15s of patience before giving
+# up) — tune these two constants if that's not enough (or is too much) in
+# practice.
+TRANSIENT_FS_RETRIES = 5
+TRANSIENT_FS_RETRY_DELAY = 3.0
+
+
+def list_video_files_with_retry(
+    directory: Path,
+    retries: int = TRANSIENT_FS_RETRIES,
+    delay: float = TRANSIENT_FS_RETRY_DELAY,
+) -> List[Path]:
+    """Return video files directly under `directory` (non-recursive), retrying
+    the whole listing+stat pass on a transient OSError (e.g. ENOTCONN) instead
+    of letting it propagate and fail the caller immediately.
+
+    Re-raises the last OSError once every attempt is exhausted, so a genuinely
+    broken mount still surfaces loudly rather than being silently treated as
+    "no video files found".
+    """
+    last_exc: Optional[OSError] = None
+    for attempt in range(1, retries + 1):
+        try:
+            return [
+                item for item in directory.iterdir()
+                if item.is_file() and item.suffix.lower() in VIDEO_EXTENSIONS
+            ]
+        except OSError as e:
+            last_exc = e
+            if attempt < retries:
+                _log("WARNING", f"Transient error listing {directory} (attempt {attempt}/{retries}): {e} — retrying in {delay}s")
+                time.sleep(delay)
+    raise last_exc
 
 
 def extract_episode_info(filename: str) -> Optional[Tuple[int, int]]:


### PR DESCRIPTION
Network/FUSE-backed mounts (e.g. decypharr's DFS backend for debrid/ usenet libraries) can report a just-created file as briefly unreadable (ENOTCONN) for a few seconds right after it's symlinked in, while the mount's own backing downloader for that file finishes initializing. That's a timing race in the mount layer, not a real missing-file condition, but it was failing the whole webhook outright on the first hit - confirmed live against a real decypharr mount (a movie import failed with [Errno 107] Transport endpoint is not connected seconds after decypharr's own log said the file was ready).

Added list_video_files_with_retry() to utils/file_utils.py: retries the whole directory listing + stat pass on OSError instead of letting it propagate immediately. Starting point: 5 attempts, 3s apart (~15s of patience before giving up, on top of the existing 5s batch delay). Re-raises the last error once retries are exhausted, so a genuinely broken mount still fails loudly rather than being silently treated as "no video files found".

Applied at both places that scan a directory for video files as part of webhook processing: MovieProcessor.process_movie()'s has_video check and TVProcessor.process_webhook_episodes()'s episode-file matching. Verified with a mocked Path.iterdir(): recovers after transient failures within the retry budget, and still raises once persistent failures exhaust it.